### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,16 @@ For multi-step or tool-heavy work, give short progress updates after meaningful 
 ## Updating this file
 
 Keep this file concise and repo-specific. Update it when commands, package layout, safety constraints, or validation expectations change. Put specialized subdirectory rules in a nested `AGENTS.md` only when that subtree has materially different commands or constraints.
+
+## Cursor Cloud specific instructions
+
+This is a pure TypeScript/ESM library with no build step, no Docker, no databases, and no external services required for automated validation. The VM update script runs `npm install`; after that, the environment is ready.
+
+**Validation commands** (see "Setup and commands" above for the full list):
+- `npm test` — runs all 110 Vitest tests (all mocked, no API key needed).
+- `npm run typecheck` — runs `tsc --noEmit`.
+- There is no lint or format script at this time.
+
+**Live smoke tests** (`pi -e . --model cursor/composer-2`, `pi --list-models cursor`) require a `CURSOR_API_KEY` and the `pi` CLI. These are optional and should only be run when explicitly needed. Do not treat their absence as a setup failure.
+
+**Dev watch mode**: `npm run test:watch` starts Vitest in watch mode for interactive development.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future Cloud Agents start with the right context about this repository's development environment.

### What changed

- **`AGENTS.md`**: Added cloud-specific section documenting:
  - The environment is a pure TypeScript/ESM library with no external services needed for automated validation.
  - Validation commands (`npm test`, `npm run typecheck`) and their behavior (all tests mocked, no API key needed).
  - Live smoke tests are optional and require `CURSOR_API_KEY`.
  - Dev watch mode via `npm run test:watch`.

### Verification

All automated validation passes on the Cloud Agent VM:

- `npm run typecheck` — clean (0 errors)
- `npm test` — 110/110 tests pass across 6 test files
- `npm run test:watch` — starts and runs correctly

Test output:
[test_output.log](https://cursor.com/artifacts/c/art-f94aa9af-c3ae-4670-8f54-e4faa4e44ccb)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a85920ff-800e-40f5-a79e-123fcf1c0655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a85920ff-800e-40f5-a79e-123fcf1c0655"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

