### PR TITLE
Fix Cursor lifecycle and discovery edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.9 - 2026-05-14
+
+### Fixed
+
+- Clean up recorded native Cursor tool replay outputs when abandoned replay runs are disposed, avoiding retained file or command output in process memory.
+- Restore `/cursor-fast` state when session persistence fails during command handling.
+- Preserve distinct same-payload Cursor tool completions while deduplicating duplicate SDK completion surfaces.
+- Respect exact `model@context` context-window cache overrides before falling back to parsed base-model context values.
+- Emit native replay text block endings with saved content indexes instead of searching by object identity.
+- Redact discovery failure details with the same secret patterns used for stream errors.
+
+### Changed
+
+- Update fallback Sonnet 4.6 context variants from `300k` to the current `200k` catalog variant.
+- Skip ambiguous Cursor SDK aliases shared by multiple base models or colliding with base model IDs, preventing misleading pi model rows.
+- Reduce context-window cache reloads during model catalog registration.
+- Document image carry-forward as a product decision rather than silently changing current latest-user-message image forwarding behavior.
+
 ## 0.1.8 - 2026-05-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ How to read model IDs:
 - `cursor/...` is the Cursor provider registered by this extension
 - `@1m`, `@272k`, and `@300k` are context-window variants
 - `:medium`, `:high`, and `:xhigh` are pi thinking-level suffixes for models where the Cursor SDK exposes a pi-controllable thinking parameter
-- latest-style Cursor aliases returned by `Cursor.models.list()` are registered too, using the same context suffixes when the target model has context variants
+- unambiguous latest-style Cursor aliases returned by `Cursor.models.list()` are registered too, using the same context suffixes when the target model has context variants; aliases shared by multiple base models or colliding with a base model ID are skipped because their SDK resolution and displayed metadata can diverge
 
 Examples with pi thinking controls:
 
@@ -203,7 +203,7 @@ If no key is available from `/login`, `CURSOR_API_KEY`, or `--api-key`, model di
 
 - `composer-2`
 - `gpt-5.5@1m`, `gpt-5.5@272k`
-- `claude-sonnet-4-6@1m`, `claude-sonnet-4-6@300k`
+- `claude-sonnet-4-6@1m`, `claude-sonnet-4-6@200k`
 - `claude-opus-4-7@1m`, `claude-opus-4-7@300k`
 
 Fallback models are a conservative startup model list. Actual Cursor runs still need a key from `/login`, `CURSOR_API_KEY`, or `--api-key`. If you add auth after startup, run `/reload` or restart pi to refresh the full live Cursor model catalog.

--- a/docs/cursor-model-ux-spec.md
+++ b/docs/cursor-model-ux-spec.md
@@ -13,6 +13,7 @@ Current implementation notes:
 - Cursor `fast` is extension state, not model identity.
 - Cursor fast status uses `ctx.ui.setStatus()`; the default pi footer remains intact.
 - Installed `@cursor/sdk` user messages accept images, and Cursor models are treated as image-capable; registered input metadata is `text` plus `image`.
+- Product decision pending: image payload forwarding currently sends images only from the latest user message. If the latest user turn is plain text after an earlier image turn, the transcript keeps an `[image omitted from transcript]` placeholder but no image bytes are sent to Cursor. Changing this to carry images forward across turns requires a deliberate product decision about token cost, privacy, stale visual context, and expected multimodal follow-up behavior.
 - `@cursor/sdk` is a package dependency of this extension; users should not need a global SDK install.
 - Cursor auth uses pi-native API-key resolution for provider `cursor`: CLI `--api-key`, stored `~/.pi/agent/auth.json` API key from `/login`, then `CURSOR_API_KEY`. The extension config file stores only non-secret Cursor-only state such as fast defaults.
 - Local agents do not pass `settingSources` by default because the current Cursor SDK writes setting/rule loading INFO logs directly to terminal output, which corrupts pi's TUI.
@@ -21,7 +22,7 @@ Current implementation notes:
 - Cursor SDK usage events report cumulative internal agent/tool/cache work, not the replayable pi prompt context. The extension reports approximate prompt/output usage for pi context display and compaction decisions instead of copying raw Cursor SDK usage. When native replay splits one Cursor SDK run into multiple pi turns, prompt input is counted once for the run; later synthetic replay turns report `input: 0` and only their own output estimate.
 - For models without a catalog `context` parameter, context windows are not hardcoded. The extension ships a bundled SDK-derived default/non-Max cache generated from `createAgentPlatform().checkpointStore.loadLatest(agentId).tokenDetails.maxTokens`. Successful runs can update a local override cache, but model discovery does not probe models at startup.
 - Max Mode context windows are distinct from default/non-Max context windows. `@cursor/sdk` 1.0.13 documentation says the SDK may enable Max Mode automatically when a selected model requires it, but the public local-agent `ModelSelection` path still does not expose a manual Max Mode selector. Do not advertise Max Mode context windows unless the SDK catalog exposes an exact parameter/variant or the SDK public API adds a Max Mode selector that the extension actually sends.
-- `@cursor/sdk` 1.0.13 adds latest-style `ModelListItem.aliases`. The extension registers those aliases as pi model IDs (with the same context suffixes when applicable) and sends the alias back in `ModelSelection.id`, while sharing Cursor-only state such as fast defaults with the underlying catalog `id`.
+- `@cursor/sdk` 1.0.13 adds latest-style `ModelListItem.aliases`. The extension registers only unambiguous aliases as pi model IDs (with the same context suffixes when applicable) and sends the alias back in `ModelSelection.id`, while sharing Cursor-only state such as fast defaults with the underlying catalog `id`. Aliases shared by multiple base models, such as generic family aliases, are skipped because the pi row metadata would otherwise imply one base model while Cursor may resolve the alias to another.
 
 ## Goal
 
@@ -137,8 +138,9 @@ Register a `cursor` provider with `pi.registerProvider()`.
 
 Rules:
 
-- Register one pi model for each Cursor base model and SDK alias when there is no Cursor `context` parameter.
-- Register one pi model per Cursor `context` value for each Cursor base model and SDK alias when the model exposes a `context` parameter.
+- Register one pi model for each Cursor base model and each unambiguous SDK alias when there is no Cursor `context` parameter.
+- Register one pi model per Cursor `context` value for each Cursor base model and each unambiguous SDK alias when the model exposes a `context` parameter.
+- Skip SDK aliases that collide with another base model ID or are shared by multiple base models; those aliases can resolve differently from the pi row metadata.
 - Do not encode `reasoning`, `effort`, `thinking`, or `fast` into pi model IDs.
 - Prefer stable, readable `@<context>` suffixes that do not conflict with pi's final `:<thinking>` suffix parser.
 - Sort Cursor models by base ID, then context value in Cursor SDK order before calling `pi.registerProvider()`. Registration order matters for `/model` display and model cycling; `--list-models` sorts output separately.
@@ -486,42 +488,22 @@ Fast flag example:
 pi --model cursor/gpt-5.5@1m --cursor-fast -p "Say ok only"
 ```
 
-## Current Discovered Model Capability Examples
+## Discovered Model Capability Examples
 
-Current live Cursor data says:
+These examples document the capability shapes the extension handles, not an exhaustive live catalog. The exact Cursor catalog changes over time; use `pi -e . --list-models cursor` or `Cursor.models.list()` for the current model surface. When the SDK reports aliases, only unambiguous aliases are registered; shared generic aliases are skipped.
 
-| Model | Cursor controls | Pi representation |
+| Example model shape | Cursor controls | Pi representation |
 |---|---|---|
-| `default` | none | plain model |
-| `composer-2` | fast | plain model + fast extension state |
-| `composer-1.5` | none | plain model |
-| `gpt-5.5` | context, reasoning, fast | context variants + native thinking + fast state |
-| `gpt-5.4` | context, reasoning, fast | context variants + native thinking + fast state |
-| `gpt-5.4-mini` | reasoning | plain model + native thinking |
-| `gpt-5.4-nano` | reasoning | plain model + native thinking |
-| `gpt-5.3-codex` | reasoning, fast | plain model + native thinking + fast state |
-| `gpt-5.3-codex-spark` | reasoning | plain model + native thinking |
-| `gpt-5.2` | reasoning, fast | plain model + native thinking + fast state |
-| `gpt-5.2-codex` | reasoning, fast | plain model + native thinking + fast state |
-| `gpt-5.1-codex-max` | reasoning, fast | plain model + native thinking + fast state |
-| `gpt-5.1-codex-mini` | reasoning | plain model + native thinking |
-| `gpt-5.1` | reasoning | plain model + native thinking |
-| `claude-opus-4-7` | thinking, context, effort | context variants + native thinking |
-| `claude-opus-4-6` | thinking, context, effort, fast | context variants + native thinking + fast state |
-| `claude-opus-4-5` | thinking | plain model + native thinking |
-| `claude-sonnet-4-6` | thinking, context, effort | context variants + native thinking |
-| `claude-sonnet-4-5` | thinking, context | context-qualified model + native thinking |
-| `claude-sonnet-4` | thinking, context | context-qualified model + native thinking |
-| `claude-haiku-4-5` | thinking | plain model + native thinking |
-| `grok-4.3` | context | context variants |
-| `grok-4-20` | thinking | plain model + native thinking |
-| `gemini-3.1-pro` | none | plain model |
-| `gemini-3-flash` | none | plain model |
-| `gemini-2.5-flash` | none | plain model |
-| `gpt-5-mini` | none | plain model |
-| `kimi-k2.5` | none | plain model |
+| plain model, such as `default` or models with no exposed controls | none | plain model |
+| `composer-2`-style model | fast | plain model + fast extension state |
+| GPT-style reasoning model with context variants | context, reasoning, fast when exposed | context variants + native thinking + optional fast state |
+| Claude-style thinking model with context variants | thinking, context, effort when exposed | context variants + native thinking + optional fast state |
+| Claude-style thinking model without context variants | thinking and/or effort | plain model + native thinking |
+| context-only model | context | context variants |
+| unique latest alias for any shape | aliases | same pi rows as the base model shape, using the alias as `ModelSelection.id` |
+| shared generic alias across multiple base models | aliases | skipped to avoid misleading pi rows |
 
-If Cursor later adds `fast`, `context`, `reasoning`, or `effort` to a model, the extension picks it up dynamically.
+If Cursor later adds `fast`, `context`, `reasoning`, `effort`, or aliases to a model, the extension picks up unambiguous capability changes dynamically.
 
 ## Detailed Examples
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-cursor-sdk",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-cursor-sdk",
-			"version": "0.1.8",
+			"version": "0.1.9",
 			"license": "MIT",
 			"dependencies": {
 				"@cursor/sdk": "^1.0.13"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-cursor-sdk",
-	"version": "0.1.8",
+	"version": "0.1.9",
 	"description": "pi provider extension backed by @cursor/sdk local agents",
 	"author": "Mitch Fultz (https://github.com/fitchmultz)",
 	"license": "MIT",

--- a/src/context-window-cache.ts
+++ b/src/context-window-cache.ts
@@ -4,6 +4,7 @@ import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { BUNDLED_CONTEXT_WINDOWS } from "./bundled-context-windows.js";
 
 const CONTEXT_WINDOW_CACHE_FILE = "cursor-sdk-context-windows.json";
+let userContextWindowOverrideLoadCount = 0;
 
 interface ContextWindowCacheFile {
 	contextWindows?: Record<string, number>;
@@ -18,6 +19,7 @@ function isPositiveInteger(value: unknown): value is number {
 }
 
 function loadUserContextWindowOverrides(): Map<string, number> {
+	userContextWindowOverrideLoadCount += 1;
 	const path = getCachePath();
 	const overrides = new Map<string, number>();
 	if (!existsSync(path)) return overrides;
@@ -80,4 +82,8 @@ export function saveCachedContextWindow(modelId: string, contextWindow: number):
 
 export const __testUtils = {
 	getCachePath,
+	getUserContextWindowOverrideLoadCount: () => userContextWindowOverrideLoadCount,
+	resetUserContextWindowOverrideLoadCount: () => {
+		userContextWindowOverrideLoadCount = 0;
+	},
 };

--- a/src/cursor-native-tool-display.ts
+++ b/src/cursor-native-tool-display.ts
@@ -56,9 +56,14 @@ export function canRenderCursorToolNatively(toolName: string): boolean {
 	return isNativeCursorToolName(toolName) && registeredNativeToolNames.has(toolName);
 }
 
-export function recordCursorNativeToolDisplay(item: CursorNativeToolDisplayItem): void {
-	if (!canRenderCursorToolNatively(item.toolName)) return;
+export function recordCursorNativeToolDisplay(item: CursorNativeToolDisplayItem): boolean {
+	if (!canRenderCursorToolNatively(item.toolName)) return false;
 	nativeToolResults.set(item.id, item);
+	return true;
+}
+
+export function deleteCursorNativeToolDisplay(id: string): void {
+	nativeToolResults.delete(id);
 }
 
 function consumeCursorNativeToolDisplay(id: string): CursorNativeToolDisplayItem | undefined {
@@ -68,6 +73,7 @@ function consumeCursorNativeToolDisplay(id: string): CursorNativeToolDisplayItem
 }
 
 export const __testUtils = {
+	nativeToolResultCount: () => nativeToolResults.size,
 	reset(): void {
 		registeredNativeToolNames.clear();
 		nativeToolResults.clear();

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -17,6 +17,7 @@ import { buildCursorPiToolDisplay, formatCursorToolTranscript, mergeCursorToolCa
 import {
 	canRenderCursorToolNatively,
 	isCursorNativeToolDisplayRuntimeEnabled,
+	deleteCursorNativeToolDisplay,
 	recordCursorNativeToolDisplay,
 	type CursorNativeToolDisplayItem,
 } from "./cursor-native-tool-display.js";
@@ -58,6 +59,7 @@ const AUTH_CURSOR_SDK_ERROR_MESSAGE =
 const APPROX_CHARS_PER_TOKEN = 4;
 const IMAGE_TOKEN_ESTIMATE = 1200;
 const CURSOR_ACTIVITY_TRACE_MAX_CHARS = 50000;
+const DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS = 5 * 60 * 1000;
 const CURSOR_NATIVE_REPLAY_TOOL_ID_PATTERN = /^(cursor-replay-\d+-\d+)-tool-\d+$/;
 
 type CursorNativeQueuedEvent =
@@ -73,10 +75,13 @@ interface CursorNativeLiveRun {
 	promptInputTokensReported: boolean;
 	pendingEvents: CursorNativeQueuedEvent[];
 	textDeltas: string[];
+	recordedToolDisplayIds: string[];
 	finalText?: string;
 	done: boolean;
 	cancelled: boolean;
+	disposed: boolean;
 	errorMessage?: string;
+	idleDisposeTimer?: ReturnType<typeof setTimeout>;
 	waiters: Set<() => void>;
 }
 
@@ -88,6 +93,7 @@ interface CursorNativeTurnState {
 }
 
 let cursorNativeReplayCounter = 0;
+let cursorNativeReplayIdleDisposeMs = DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS;
 const pendingCursorNativeRuns = new Map<string, CursorNativeLiveRun>();
 
 function escapeRegExp(value: string): string {
@@ -264,6 +270,21 @@ function queueCursorNativeEvent(run: CursorNativeLiveRun, event: CursorNativeQue
 	notifyCursorNativeRun(run);
 }
 
+function clearCursorNativeRunIdleDispose(run: CursorNativeLiveRun): void {
+	if (!run.idleDisposeTimer) return;
+	clearTimeout(run.idleDisposeTimer);
+	run.idleDisposeTimer = undefined;
+}
+
+function scheduleCursorNativeRunIdleDispose(run: CursorNativeLiveRun): void {
+	if (run.disposed) return;
+	clearCursorNativeRunIdleDispose(run);
+	run.idleDisposeTimer = setTimeout(() => {
+		void disposeCursorNativeRun(run);
+	}, cursorNativeReplayIdleDisposeMs);
+	run.idleDisposeTimer.unref?.();
+}
+
 function isCursorNativeRunReady(run: CursorNativeLiveRun): boolean {
 	return run.pendingEvents.length > 0 || run.done || run.cancelled || run.errorMessage !== undefined;
 }
@@ -310,12 +331,13 @@ function closeCursorNativeThinkingBlock(turn: CursorNativeTurnState): void {
 
 function closeCursorNativeTextBlock(turn: CursorNativeTurnState): string {
 	if (turn.textContentIndex < 0) return "";
-	const block = turn.partial.content[turn.textContentIndex];
+	const contentIndex = turn.textContentIndex;
+	const block = turn.partial.content[contentIndex];
 	turn.textContentIndex = -1;
 	if (block.type !== "text") return "";
 	turn.stream.push({
 		type: "text_end",
-		contentIndex: turn.partial.content.indexOf(block),
+		contentIndex,
 		content: block.text,
 		partial: turn.partial,
 	});
@@ -402,15 +424,24 @@ function emitCursorNativeToolUseTurn(
 		stream.push({ type: "toolcall_delta", contentIndex, delta: JSON.stringify(tool.args), partial });
 		const block = partial.content[contentIndex];
 		if (block.type === "toolCall") stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial });
-		recordCursorNativeToolDisplay({ ...tool, terminate: shouldTerminate });
+		if (recordCursorNativeToolDisplay({ ...tool, terminate: shouldTerminate })) {
+			run.recordedToolDisplayIds.push(tool.id);
+		}
 	}
 	setApproximateUsage(partial, takeCursorNativePromptInputTokens(run), outputText);
 	partial.stopReason = "toolUse";
 	stream.push({ type: "done", reason: "toolUse", message: partial });
+	scheduleCursorNativeRunIdleDispose(run);
 }
 
 async function disposeCursorNativeRun(run: CursorNativeLiveRun): Promise<void> {
+	if (run.disposed) return;
+	run.disposed = true;
 	pendingCursorNativeRuns.delete(run.id);
+	clearCursorNativeRunIdleDispose(run);
+	for (const toolDisplayId of run.recordedToolDisplayIds) deleteCursorNativeToolDisplay(toolDisplayId);
+	run.recordedToolDisplayIds = [];
+	run.waiters.clear();
 	try {
 		await run.agent[Symbol.asyncDispose]();
 	} catch {
@@ -484,7 +515,13 @@ async function replayPendingCursorNativeRun(
 	if (!replayId) return false;
 	const run = pendingCursorNativeRuns.get(replayId);
 	if (!run) return false;
-	await emitCursorNativeRunNextTurn(stream, partial, run, signal);
+	clearCursorNativeRunIdleDispose(run);
+	try {
+		await emitCursorNativeRunNextTurn(stream, partial, run, signal);
+	} catch (error) {
+		if (error instanceof CursorAbortError) await disposeCursorNativeRun(run);
+		throw error;
+	}
 	return true;
 }
 
@@ -498,6 +535,7 @@ export function streamCursor(
 	(async () => {
 		const partial = makeInitialMessage(model);
 		let agent: SDKAgent | null = null;
+		let activeNativeRun: CursorNativeLiveRun | undefined;
 		let resolvedApiKey: string | undefined;
 		let abortSignal: AbortSignal | undefined;
 		let abortListener: (() => void) | undefined;
@@ -551,14 +589,21 @@ export function streamCursor(
 						promptInputTokensReported: false,
 						pendingEvents: [],
 						textDeltas,
+						recordedToolDisplayIds: [],
 						done: false,
 						cancelled: false,
+						disposed: false,
 						waiters: new Set(),
 					}
 				: undefined;
-			if (liveRun) pendingCursorNativeRuns.set(liveRun.id, liveRun);
+			if (liveRun) {
+				pendingCursorNativeRuns.set(liveRun.id, liveRun);
+				activeNativeRun = liveRun;
+			}
 			const startedToolCalls = new Map<string, unknown>();
-			const completedToolFingerprints = new Set<string>();
+			const completedToolIdentities = new Set<string>();
+			const completedStartedToolFingerprints = new Set<string>();
+			const completedFallbackToolFingerprints = new Set<string>();
 
 			const appendLiveTextDelta = (text: string): void => {
 				if (textContentIndex < 0) {
@@ -652,12 +697,25 @@ export function streamCursor(
 				}
 			};
 
-			const handleCompletedToolCall = (toolCall: unknown): void => {
+			const handleCompletedToolCall = (
+				toolCall: unknown,
+				options: { identity?: string; source?: "started" | "fallback" } = {},
+			): void => {
 				const transcript = scrubSensitiveText(formatCursorToolTranscript(toolCall, { cwd }), resolvedApiKey);
 				const display = buildCursorPiToolDisplay(toolCall, { cwd });
 				const fingerprint = getToolFingerprint({ toolName: display.toolName, args: display.args, result: display.result });
-				if (completedToolFingerprints.has(fingerprint)) return;
-				completedToolFingerprints.add(fingerprint);
+				if (options.identity && completedToolIdentities.has(options.identity)) return;
+				if (options.source === "started") {
+					if (completedFallbackToolFingerprints.has(fingerprint)) return;
+				} else if (completedStartedToolFingerprints.has(fingerprint) || completedFallbackToolFingerprints.has(fingerprint)) {
+					return;
+				}
+				if (options.identity) completedToolIdentities.add(options.identity);
+				if (options.source === "started") {
+					completedStartedToolFingerprints.add(fingerprint);
+				} else {
+					completedFallbackToolFingerprints.add(fingerprint);
+				}
 
 				if (useNativeToolReplay && canRenderCursorToolNatively(display.toolName) && liveRun) {
 					nativeToolReplayStarted = true;
@@ -704,7 +762,11 @@ export function streamCursor(
 				} else if (update.type === "tool-call-completed") {
 					const mergedToolCall = mergeCursorToolCalls(startedToolCalls.get(update.callId), update.toolCall);
 					startedToolCalls.delete(update.callId);
-					handleCompletedToolCall(mergedToolCall);
+					const identity = typeof update.callId === "string" ? `cursor-tool:${update.callId}` : undefined;
+					handleCompletedToolCall(mergedToolCall, {
+						identity,
+						source: identity ? "started" : "fallback",
+					});
 				} else if (update.type === "summary") {
 					const summary = `Cursor summary: ${truncateSingleLine(update.summary)}\n`;
 					if (liveRun && nativeToolReplayStarted) {
@@ -723,7 +785,12 @@ export function streamCursor(
 				const step = getObjectField(args.step, "message") ? args.step : undefined;
 				if (getObjectField(args.step, "type") !== "toolCall") return;
 				const toolCall = getObjectField(step, "message");
-				if (toolCall) handleCompletedToolCall(toolCall);
+				const stepId = getObjectField(args.step, "id") ?? getObjectField(toolCall, "id") ?? getObjectField(toolCall, "callId");
+				if (toolCall) {
+					handleCompletedToolCall(toolCall, {
+						identity: typeof stepId === "string" ? `cursor-tool:${stepId}` : undefined,
+					});
+				}
 			};
 
 			// Handle abort signal
@@ -750,21 +817,31 @@ export function streamCursor(
 				void run
 					.wait()
 					.then(async (result) => {
+						if (liveRun.disposed) return;
 						await cacheSdkContextWindow(liveRun.agent.agentId, model.id);
+						if (liveRun.disposed) return;
 						liveRun.cancelled = result.status === "cancelled";
 						liveRun.finalText = hasUsableText(result.result) ? result.result : liveRun.textDeltas.join("");
 						liveRun.done = true;
 						notifyCursorNativeRun(liveRun);
+						scheduleCursorNativeRunIdleDispose(liveRun);
 					})
 					.catch((error: unknown) => {
+						if (liveRun.disposed) return;
 						liveRun.errorMessage = sanitizeError(error, resolvedApiKey ?? options?.apiKey);
 						notifyCursorNativeRun(liveRun);
+						scheduleCursorNativeRunIdleDispose(liveRun);
 					});
 
-				await waitForCursorNativeRunProgress(liveRun, options?.signal);
-				await settleCursorNativeToolBatch(liveRun);
-				closeTraceBlock();
-				await emitCursorNativeRunNextTurn(stream, partial, liveRun, options?.signal);
+				try {
+					await waitForCursorNativeRunProgress(liveRun, options?.signal);
+					await settleCursorNativeToolBatch(liveRun);
+					closeTraceBlock();
+					await emitCursorNativeRunNextTurn(stream, partial, liveRun, options?.signal);
+				} catch (error) {
+					if (error instanceof CursorAbortError) await disposeCursorNativeRun(liveRun);
+					throw error;
+				}
 				agent = null;
 				return;
 			}
@@ -794,6 +871,8 @@ export function streamCursor(
 				stream.push({ type: "error", reason: "error", error: partial });
 			}
 		} finally {
+			if (activeNativeRun?.disposed) agent = null;
+
 			if (abortSignal && abortListener) {
 				abortSignal.removeEventListener("abort", abortListener);
 			}
@@ -813,3 +892,14 @@ export function streamCursor(
 
 	return stream;
 }
+
+export const __testUtils = {
+	DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS,
+	pendingCursorNativeRunCount: () => pendingCursorNativeRuns.size,
+	setCursorNativeReplayIdleDisposeMs: (value: number) => {
+		cursorNativeReplayIdleDisposeMs = value;
+	},
+	resetCursorNativeReplayIdleDisposeMs: () => {
+		cursorNativeReplayIdleDisposeMs = DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS;
+	},
+};

--- a/src/cursor-state.ts
+++ b/src/cursor-state.ts
@@ -105,16 +105,25 @@ function restoreMapValue(map: Map<string, boolean>, key: string, previous: boole
 function persistFastPreference(pi: ExtensionAPI, baseModelId: string, fast: boolean): void {
 	const previousSession = sessionFastPreferences.get(baseModelId);
 	const previousGlobal = globalFastPreferences.get(baseModelId);
+	let savedGlobal = false;
 	sessionFastPreferences.set(baseModelId, fast);
 	globalFastPreferences.set(baseModelId, fast);
 	try {
 		saveGlobalFastPreferences();
+		savedGlobal = true;
+		pi.appendEntry<CursorFastEntryData>(FAST_ENTRY_TYPE, { baseModelId, fast });
 	} catch (error) {
 		restoreMapValue(sessionFastPreferences, baseModelId, previousSession);
 		restoreMapValue(globalFastPreferences, baseModelId, previousGlobal);
+		if (savedGlobal) {
+			try {
+				saveGlobalFastPreferences();
+			} catch {
+				// Preserve the original append failure reported to the user.
+			}
+		}
 		throw error;
 	}
-	pi.appendEntry<CursorFastEntryData>(FAST_ENTRY_TYPE, { baseModelId, fast });
 }
 
 export function getEffectiveFastForModelId(modelId: string): boolean | undefined {

--- a/src/cursor-tool-transcript.ts
+++ b/src/cursor-tool-transcript.ts
@@ -281,15 +281,18 @@ function renderTreeNode(node: unknown, depth = 0, lines: string[] = []): string[
 	return lines;
 }
 
-function formatLs(args: Record<string, unknown>, result: NormalizedResult, options: TranscriptOptions): string {
-	const path = formatPathArg(args, options) ?? ".";
-	if (result.status === "error") return joinSections(`ls ${path}`, formatError(result.error));
-
+function getLsBody(result: NormalizedResult, options: TranscriptOptions): string {
 	const value = asRecord(result.value);
 	const root = value?.directoryTreeRoot ?? result.value;
 	const treeLines = renderTreeNode(root);
 	const body = treeLines.length > 0 ? treeLines.join("\n") : stringifyUnknown(result.value);
-	return joinSections(`ls ${path}`, limitText(body, options));
+	return limitText(body, options);
+}
+
+function formatLs(args: Record<string, unknown>, result: NormalizedResult, options: TranscriptOptions): string {
+	const path = formatPathArg(args, options) ?? ".";
+	if (result.status === "error") return joinSections(`ls ${path}`, formatError(result.error));
+	return joinSections(`ls ${path}`, getLsBody(result, options));
 }
 
 function formatGlob(args: Record<string, unknown>, result: NormalizedResult, options: TranscriptOptions): string {
@@ -528,7 +531,7 @@ export function buildCursorPiToolDisplay(toolCall: unknown, options: TranscriptO
 		return {
 			toolName: "ls",
 			args,
-			result: textToolResult(result.status === "error" ? formatError(result.error) : formatLs(args, result, options).split("\n\n").slice(1).join("\n\n").trim()),
+			result: textToolResult(result.status === "error" ? formatError(result.error) : getLsBody(result, options).trim()),
 			isError: result.status === "error",
 		};
 	}

--- a/src/model-discovery.ts
+++ b/src/model-discovery.ts
@@ -7,7 +7,7 @@ import type {
 } from "@cursor/sdk";
 import { AuthStorage, type ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type { ModelThinkingLevel, ThinkingLevelMap } from "@earendil-works/pi-ai";
-import { getCachedContextWindow, getCachedContextWindowExact } from "./context-window-cache.js";
+import { loadContextWindowCache } from "./context-window-cache.js";
 
 const CURSOR_PROVIDER_ID = "cursor";
 const CURSOR_API_KEY_ENV_VAR = "CURSOR_API_KEY";
@@ -88,7 +88,7 @@ const FALLBACK_MODEL_ITEMS: ModelListItem[] = [
 			{
 				id: "context",
 				displayName: "Context",
-				values: [{ value: "1m" }, { value: "300k" }],
+				values: [{ value: "1m" }, { value: "200k" }],
 			},
 			{
 				id: "effort",
@@ -165,6 +165,7 @@ export type CursorModelFallbackReason = "missing-api-key" | "discovery-failed" |
 export interface CursorModelFallbackIssue {
 	reason: CursorModelFallbackReason;
 	message: string;
+	errorMessage?: string;
 }
 
 export interface DiscoverModelsOptions {
@@ -351,9 +352,14 @@ function getModelName(item: ModelListItem, context?: string, alias?: string): st
 	return context ? `${baseName} @ ${context}` : baseName;
 }
 
-function getContextWindow(piModelId: string, context?: string, baseModelId?: string): number {
-	if (context) return parseContextWindow(context) ?? FALLBACK_CONTEXT_WINDOW;
-	return getCachedContextWindowExact(piModelId) ?? (baseModelId ? getCachedContextWindow(baseModelId) : undefined) ?? FALLBACK_CONTEXT_WINDOW;
+function getContextWindow(contextWindowCache: Map<string, number>, piModelId: string, context?: string, baseModelId?: string): number {
+	return (
+		contextWindowCache.get(piModelId) ??
+		(context ? parseContextWindow(context) : undefined) ??
+		(baseModelId ? contextWindowCache.get(baseModelId) : undefined) ??
+		contextWindowCache.get("default") ??
+		FALLBACK_CONTEXT_WINDOW
+	);
 }
 
 function toMetadata(
@@ -362,6 +368,7 @@ function toMetadata(
 	selectionModelId: string,
 	defaultParams: ModelParameterValue[],
 	context: string | undefined,
+	contextWindowCache: Map<string, number>,
 ): CursorModelMetadata {
 	const thinkingLevelMap = getThinkingLevelMap(item);
 	const fastValue = getParamValue(defaultParams, "fast")?.toLowerCase();
@@ -372,7 +379,7 @@ function toMetadata(
 		displayName: item.displayName || item.id,
 		defaultParams: cloneParams(defaultParams),
 		...(context ? { context } : {}),
-		contextWindow: getContextWindow(piModelId, context, item.id),
+		contextWindow: getContextWindow(contextWindowCache, piModelId, context, item.id),
 		supportsFast: getParameter(item, "fast") !== undefined,
 		defaultFast: fastValue === "true",
 		supportsReasoning: thinkingLevelMap !== undefined,
@@ -404,11 +411,25 @@ function getContextValues(item: ModelListItem): string[] {
 	return getParameter(item, "context")?.values.map((value) => value.value) ?? [];
 }
 
-function getModelIds(item: ModelListItem, reservedBaseModelIds: Set<string>): string[] {
+function getAmbiguousAliases(items: ModelListItem[]): Set<string> {
+	const aliasOwners = new Map<string, Set<string>>();
+	for (const item of items) {
+		for (const rawAlias of item.aliases ?? []) {
+			const alias = rawAlias.trim();
+			if (!alias || alias === item.id) continue;
+			const owners = aliasOwners.get(alias) ?? new Set<string>();
+			owners.add(item.id);
+			aliasOwners.set(alias, owners);
+		}
+	}
+	return new Set([...aliasOwners.entries()].filter(([, owners]) => owners.size > 1).map(([alias]) => alias));
+}
+
+function getModelIds(item: ModelListItem, reservedBaseModelIds: Set<string>, ambiguousAliases: Set<string>): string[] {
 	const ids = [item.id];
 	for (const rawAlias of item.aliases ?? []) {
 		const alias = rawAlias.trim();
-		if (!alias || alias === item.id || ids.includes(alias) || reservedBaseModelIds.has(alias)) continue;
+		if (!alias || alias === item.id || ids.includes(alias) || reservedBaseModelIds.has(alias) || ambiguousAliases.has(alias)) continue;
 		ids.push(alias);
 	}
 	return ids;
@@ -418,20 +439,22 @@ function toModelConfigs(
 	item: ModelListItem,
 	usedPiModelIds: Set<string>,
 	reservedBaseModelIds: Set<string>,
+	ambiguousAliases: Set<string>,
+	contextWindowCache: Map<string, number>,
 ): ProviderModelConfig[] {
 	const defaultParams = getDefaultParams(item);
 	const contextValues = getContextValues(item);
 	const contexts = contextValues.length > 0 ? contextValues : [undefined];
 	const configs: ProviderModelConfig[] = [];
 
-	for (const selectionModelId of getModelIds(item, reservedBaseModelIds)) {
+	for (const selectionModelId of getModelIds(item, reservedBaseModelIds, ambiguousAliases)) {
 		const alias = selectionModelId === item.id ? undefined : selectionModelId;
 		for (const context of contexts) {
 			const params = context ? replaceParam(defaultParams, "context", context) : defaultParams;
 			const piModelId = encodePiModelId(selectionModelId, context);
 			if (usedPiModelIds.has(piModelId)) continue;
 			usedPiModelIds.add(piModelId);
-			const metadata = toMetadata(item, piModelId, selectionModelId, params, context);
+			const metadata = toMetadata(item, piModelId, selectionModelId, params, context, contextWindowCache);
 			metadataByPiModelId.set(piModelId, metadata);
 			configs.push(toModelConfig(metadata, getModelName(item, context, alias)));
 		}
@@ -448,7 +471,9 @@ function registerModelItems(items: ModelListItem[]): ProviderModelConfig[] {
 	metadataByPiModelId.clear();
 	const usedPiModelIds = new Set<string>();
 	const reservedBaseModelIds = new Set(items.map((item) => item.id));
-	return sortModelsByBaseId(items).flatMap((item) => toModelConfigs(item, usedPiModelIds, reservedBaseModelIds));
+	const ambiguousAliases = getAmbiguousAliases(items);
+	const contextWindowCache = loadContextWindowCache();
+	return sortModelsByBaseId(items).flatMap((item) => toModelConfigs(item, usedPiModelIds, reservedBaseModelIds, ambiguousAliases, contextWindowCache));
 }
 
 export function getCursorModelMetadata(modelId: string): CursorModelMetadata | undefined {
@@ -532,6 +557,24 @@ export function buildCursorModelSelection(
 	return params.length > 0 ? { id: metadata.selectionModelId, params } : { id: metadata.selectionModelId };
 }
 
+function scrubDiscoveryErrorText(text: string, apiKey: string): string {
+	let scrubbed = text.replace(new RegExp(apiKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"), "[redacted]");
+	return scrubbed
+		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+		.replace(/((?:^|[\s,{])cookie["']?\s*[:=]\s*["']?)[^\n]+/gi, "$1[redacted]")
+		.replace(
+			/((?:authorization|api[_-]?key|apiKey|token|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)[^"'\s,;}]+/gi,
+			"$1[redacted]",
+		)
+		.trim();
+}
+
+function sanitizeDiscoveryError(error: unknown, apiKey: string): string | undefined {
+	const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+	const scrubbed = scrubDiscoveryErrorText(message, apiKey);
+	return scrubbed || undefined;
+}
+
 function useFallbackModels(options: DiscoverModelsOptions, issue: CursorModelFallbackIssue): ProviderModelConfig[] {
 	options.onFallback?.(issue);
 	return registerModelItems(FALLBACK_MODEL_ITEMS);
@@ -555,10 +598,12 @@ export async function discoverModels(options: DiscoverModelsOptions = {}): Promi
 			reason: "empty-model-list",
 			message: `Cursor model discovery returned no models. Using fallback Cursor models; verify ${AUTH_SETUP_HINT}. ${CATALOG_REFRESH_HINT}`,
 		});
-	} catch {
+	} catch (error) {
+		const errorMessage = sanitizeDiscoveryError(error, apiKey);
 		return useFallbackModels(options, {
 			reason: "discovery-failed",
-			message: `Cursor model discovery failed. Using fallback Cursor models; verify ${AUTH_SETUP_HINT}. ${CATALOG_REFRESH_HINT}`,
+			message: `Cursor model discovery failed${errorMessage ? `: ${errorMessage}` : ""}. Using fallback Cursor models; verify ${AUTH_SETUP_HINT}. ${CATALOG_REFRESH_HINT}`,
+			...(errorMessage ? { errorMessage } : {}),
 		});
 	}
 }

--- a/test/cursor-provider.test.ts
+++ b/test/cursor-provider.test.ts
@@ -32,7 +32,7 @@ vi.mock("@cursor/sdk", () => {
 });
 
 import { Agent, createAgentPlatform } from "@cursor/sdk";
-import { streamCursor } from "../src/cursor-provider.js";
+import { streamCursor, __testUtils as cursorProviderTestUtils } from "../src/cursor-provider.js";
 import { __testUtils as modelDiscoveryTestUtils } from "../src/model-discovery.js";
 import { __testUtils as contextWindowCacheTestUtils } from "../src/context-window-cache.js";
 import { __testUtils as nativeToolDisplayTestUtils, registerCursorNativeToolDisplay } from "../src/cursor-native-tool-display.js";
@@ -197,6 +197,8 @@ describe("streamCursor", () => {
 		vi.clearAllMocks();
 		delete process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY;
 		delete process.env.PI_CURSOR_REGISTER_NATIVE_TOOLS;
+		expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(0);
+		cursorProviderTestUtils.resetCursorNativeReplayIdleDisposeMs();
 		nativeToolDisplayTestUtils.reset();
 		modelDiscoveryTestUtils.registerModelItems(cursorModelItems);
 		// Re-setup default mock return after clearing
@@ -383,6 +385,52 @@ describe("streamCursor", () => {
 		expect(trace).toContain("# pi-cursor-sdk");
 	});
 
+	it("dedupes a completed tool call reported through both delta and step callbacks", async () => {
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: (a: unknown) => void; onStep: (a: unknown) => void }) => {
+			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "read", args: { path: "README.md" } }, callId: "c1" } });
+			opts.onStep({
+				step: {
+					type: "toolCall",
+					message: {
+						type: "read",
+						args: { path: "README.md" },
+						result: { status: "success", value: { content: "# pi-cursor-sdk" } },
+					},
+				},
+			});
+			opts.onDelta({
+				update: {
+					type: "tool-call-completed",
+					toolCall: {
+						name: "read",
+						result: { status: "success", value: { content: "# pi-cursor-sdk" } },
+					},
+					callId: "c1",
+				},
+			});
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "done" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const stream = streamCursor(makeModel(), makeContext(), { apiKey: "test-key" });
+		const events = await collectEvents(stream);
+		const trace = events.filter((e: any) => e.type === "thinking_delta").map((e: any) => e.delta).join("");
+
+		expect(trace.match(/read README\.md/g)).toHaveLength(1);
+		expect(trace.match(/# pi-cursor-sdk/g)).toHaveLength(1);
+	});
+
 	it("replays native Cursor tools as a toolUse turn before final text", async () => {
 		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
 		const registeredTools: RegisteredTool[] = [];
@@ -470,6 +518,140 @@ describe("streamCursor", () => {
 		expect(replayText).toBe("Final answer only.");
 		expect(replayDone.reason).toBe("stop");
 		expect(replayDone.message.content).toEqual([{ type: "text", text: "Final answer only." }]);
+	});
+
+	it("disposes abandoned native replay runs after the idle timeout", async () => {
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		cursorProviderTestUtils.setCursorNativeReplayIdleDisposeMs(1);
+		const registeredTools: RegisteredTool[] = [];
+		await registerNativeToolDisplayForTest(registeredTools);
+
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const runWait = vi.fn(() => new Promise<{ id: string; status: "finished"; result: string }>(() => {}));
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: (a: unknown) => void }) => {
+			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "read", args: { path: "README.md" } }, callId: "c1" } });
+			opts.onDelta({
+				update: {
+					type: "tool-call-completed",
+					toolCall: {
+						name: "read",
+						result: { status: "success", value: { content: "# pi-cursor-sdk" } },
+					},
+					callId: "c1",
+				},
+			});
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "running",
+				wait: runWait,
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: mockDispose,
+		});
+
+		const events = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		const done = events.find((e: any) => e.type === "done") as any;
+
+		expect(done.reason).toBe("toolUse");
+		expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(1);
+		expect(nativeToolDisplayTestUtils.nativeToolResultCount()).toBe(1);
+		expect(mockDispose).not.toHaveBeenCalled();
+
+		await vi.waitFor(() => expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(0));
+		expect(nativeToolDisplayTestUtils.nativeToolResultCount()).toBe(0);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("cleans up pending native replay runs when replay aborts mid-flight", async () => {
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		const registeredTools: RegisteredTool[] = [];
+		await registerNativeToolDisplayForTest(registeredTools);
+
+		const controller = new AbortController();
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		let resolveRun: (result: { id: string; status: "finished"; result: string }) => void = () => {};
+		const runWait = vi.fn(
+			() =>
+				new Promise<{ id: string; status: "finished"; result: string }>((resolve) => {
+					resolveRun = resolve;
+				}),
+		);
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: (a: unknown) => void }) => {
+			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "read", args: { path: "README.md" } }, callId: "c1" } });
+			opts.onDelta({
+				update: {
+					type: "tool-call-completed",
+					toolCall: {
+						name: "read",
+						result: { status: "success", value: { content: "# pi-cursor-sdk" } },
+					},
+					callId: "c1",
+				},
+			});
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "running",
+				wait: runWait,
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: mockDispose,
+		});
+
+		const firstEvents = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		const firstDone = firstEvents.find((e: any) => e.type === "done") as any;
+		const toolCall = firstDone.message.content.find((block: any) => block.type === "toolCall");
+		const readTool = registeredTools.find((tool) => tool.name === "read");
+		const toolResult = await readTool.execute(toolCall.id, toolCall.arguments, undefined, undefined, {});
+
+		expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(1);
+		expect(mockDispose).not.toHaveBeenCalled();
+
+		const replayContext = makeContext();
+		replayContext.messages = [
+			...replayContext.messages,
+			firstDone.message,
+			{
+				role: "toolResult",
+				toolCallId: toolCall.id,
+				toolName: "read",
+				content: toolResult.content,
+				details: toolResult.details,
+				isError: false,
+				timestamp: 2,
+			},
+		];
+
+		const replayEventsPromise = collectEvents(streamCursor(makeModel(), replayContext, { apiKey: "test-key", signal: controller.signal }));
+		await Promise.resolve();
+		controller.abort();
+		const replayEvents = await replayEventsPromise;
+		const error = replayEvents.find((e: any) => e.type === "error") as any;
+
+		expect(error.reason).toBe("aborted");
+		expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(0);
+		expect(nativeToolDisplayTestUtils.nativeToolResultCount()).toBe(0);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+
+		resolveRun({ id: "run-1", status: "finished", result: "late result" });
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(0);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
 	});
 
 	it("streams post-tool Cursor thinking and text while a native replay run is still active", async () => {
@@ -569,6 +751,7 @@ describe("streamCursor", () => {
 		expect(replayText).toBe("Final answer.");
 		expect(finalDone.reason).toBe("stop");
 		expect(finalDone.message.content.map((block: any) => block.type)).toEqual(["thinking", "text"]);
+		expect(replayEvents.find((event: any) => event.type === "text_end")?.contentIndex).toBe(1);
 	});
 
 	it("queues post-tool thinking and text that arrive before the native tool-use turn closes", async () => {
@@ -665,6 +848,7 @@ describe("streamCursor", () => {
 		expect(replayThinking).toBe("Post-tool thought.");
 		expect(replayText).toBe("Final answer.");
 		expect(finalDone.message.content.map((block: any) => block.type)).toEqual(["thinking", "text"]);
+		expect(replayEvents.find((event: any) => event.type === "text_end")?.contentIndex).toBe(1);
 	});
 
 	it("does not duplicate final result after an earlier post-tool text turn", async () => {
@@ -842,6 +1026,82 @@ describe("streamCursor", () => {
 		expect(trace).toContain("Took 0.0s");
 		expect(trace).not.toContain("call_abc");
 		expect(trace).not.toContain("fc_secret");
+	});
+
+	it("keeps distinct completed tool calls with identical display payloads", async () => {
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: (a: unknown) => void }) => {
+			for (const callId of ["c1", "c2"]) {
+				opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "shell", args: { command: "date" } }, callId } });
+				opts.onDelta({
+					update: {
+						type: "tool-call-completed",
+						toolCall: {
+							name: "shell",
+							result: { status: "success", value: { stdout: "Thu May 14\n", stderr: "", exitCode: 0 } },
+						},
+						callId,
+					},
+				});
+			}
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "done" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const stream = streamCursor(makeModel(), makeContext(), { apiKey: "test-key" });
+		const events = await collectEvents(stream);
+		const trace = events.filter((e: any) => e.type === "thinking_delta").map((e: any) => e.delta).join("");
+
+		expect(trace.match(/\$ date/g)).toHaveLength(2);
+		expect(trace.match(/Thu May 14/g)).toHaveLength(2);
+	});
+
+	it("keeps distinct completed tool calls with identical payloads even without started events", async () => {
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: (a: unknown) => void }) => {
+			for (const callId of ["c1", "c2"]) {
+				opts.onDelta({
+					update: {
+						type: "tool-call-completed",
+						toolCall: {
+							name: "shell",
+							args: { command: "date" },
+							result: { status: "success", value: { stdout: "Thu May 14\n", stderr: "", exitCode: 0 } },
+						},
+						callId,
+					},
+				});
+			}
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "done" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const stream = streamCursor(makeModel(), makeContext(), { apiKey: "test-key" });
+		const events = await collectEvents(stream);
+		const trace = events.filter((e: any) => e.type === "thinking_delta").map((e: any) => e.delta).join("");
+
+		expect(trace.match(/\$ date/g)).toHaveLength(2);
+		expect(trace.match(/Thu May 14/g)).toHaveLength(2);
 	});
 
 	it("scrubs secrets from cursor tool transcript output", async () => {

--- a/test/cursor-state.test.ts
+++ b/test/cursor-state.test.ts
@@ -134,6 +134,24 @@ describe("Cursor fast state", () => {
 		expect(pi.appendEntry).not.toHaveBeenCalled();
 	});
 
+	it("rolls fast state back when the session journal append fails", async () => {
+		writeFileSync(__testUtils.getConfigPath(), JSON.stringify({ fastDefaults: { "composer-2": true } }));
+		const { pi, ctx, commands, handlers } = createHarness({ modelId: "composer-2" });
+		pi.appendEntry.mockImplementationOnce(() => {
+			throw new Error("journal unavailable");
+		});
+		await handlers.get("session_start")({}, ctx);
+
+		await commands.get("cursor-fast").handler("", ctx);
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Failed to save Cursor fast preference"), "error");
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", "cursor fast");
+		expect(getEffectiveFastForModelId("composer-2")).toBe(true);
+		expect(JSON.parse(readFileSync(__testUtils.getConfigPath(), "utf-8"))).toEqual({
+			fastDefaults: { "composer-2": true },
+		});
+	});
+
 	it("restores fast state from the active session branch", async () => {
 		const { ctx, handlers } = createHarness({
 			modelId: "composer-2",

--- a/test/cursor-tool-transcript.test.ts
+++ b/test/cursor-tool-transcript.test.ts
@@ -100,6 +100,30 @@ describe("formatCursorToolTranscript", () => {
 		expect(transcript).toContain("Took 0.0s");
 	});
 
+	it("builds native pi display data for Cursor ls calls without parsing formatted transcript headers", () => {
+		const display = buildCursorPiToolDisplay({
+			name: "ls",
+			args: { path: "." },
+			result: {
+				status: "success",
+				value: {
+					directoryTreeRoot: {
+						name: "root",
+						children: [{ name: "src" }, { name: "test" }],
+					},
+				},
+			},
+		});
+
+		expect(display).toMatchObject({
+			toolName: "ls",
+			args: { path: "." },
+			result: { content: [{ type: "text", text: "root\n  src\n  test" }] },
+			isError: false,
+		});
+		expect(display.result.content[0].text).not.toContain("ls .");
+	});
+
 	it("builds native pi display data for Cursor read and shell calls", () => {
 		const readDisplay = buildCursorPiToolDisplay({
 			name: "read",

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -10,7 +10,7 @@ import {
 	__testUtils,
 	type CursorModelFallbackIssue,
 } from "../src/model-discovery.js";
-import { saveCachedContextWindow } from "../src/context-window-cache.js";
+import { saveCachedContextWindow, __testUtils as contextWindowCacheTestUtils } from "../src/context-window-cache.js";
 
 vi.mock("@cursor/sdk", () => ({
 	Cursor: {
@@ -64,7 +64,7 @@ describe("discoverModels", () => {
 			"claude-opus-4-7@1m",
 			"claude-opus-4-7@300k",
 			"claude-sonnet-4-6@1m",
-			"claude-sonnet-4-6@300k",
+			"claude-sonnet-4-6@200k",
 			"composer-2",
 			"gpt-5.5@1m",
 			"gpt-5.5@272k",
@@ -276,6 +276,29 @@ describe("discoverModels", () => {
 		});
 	});
 
+	it("skips aliases that multiple Cursor base models share", async () => {
+		process.env.CURSOR_API_KEY = "test-key-123";
+		mockedList.mockResolvedValueOnce([
+			{
+				id: "model-a",
+				displayName: "Model A",
+				aliases: ["model-latest", "model-shared"],
+				variants: [{ params: [], displayName: "Model A", isDefault: true }],
+			},
+			{
+				id: "model-b",
+				displayName: "Model B",
+				aliases: ["model-stable", "model-shared"],
+				variants: [{ params: [], displayName: "Model B", isDefault: true }],
+			},
+		]);
+
+		const models = await discoverModels();
+
+		expect(models.map((model) => model.id)).toEqual(["model-a", "model-latest", "model-b", "model-stable"]);
+		expect(getCursorModelMetadata("model-shared")).toBeUndefined();
+	});
+
 	it("skips aliases that collide with another Cursor base model id", async () => {
 		process.env.CURSOR_API_KEY = "test-key-123";
 		mockedList.mockResolvedValueOnce([
@@ -419,6 +442,54 @@ describe("discoverModels", () => {
 			expect(models.map((model) => [model.id, model.contextWindow])).toEqual([
 				["composer-2", 200000],
 				["new-sdk-model", 200000],
+			]);
+		} finally {
+			rmSync(tmpAgentDir, { recursive: true, force: true });
+		}
+	});
+
+	it("loads the context-window cache once while registering a model catalog", async () => {
+		const tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-context-window-count-"));
+		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+		try {
+			contextWindowCacheTestUtils.resetUserContextWindowOverrideLoadCount();
+			process.env.CURSOR_API_KEY = "test-key-123";
+			mockedList.mockResolvedValueOnce(
+				Array.from({ length: 25 }, (_, index) => ({
+					id: `synthetic-model-${index}`,
+					displayName: `Synthetic Model ${index}`,
+					variants: [{ params: [], displayName: `Synthetic Model ${index}`, isDefault: true }],
+				})),
+			);
+
+			await discoverModels();
+
+			expect(contextWindowCacheTestUtils.getUserContextWindowOverrideLoadCount()).toBe(1);
+		} finally {
+			rmSync(tmpAgentDir, { recursive: true, force: true });
+		}
+	});
+
+	it("lets user cache override context-qualified model IDs", async () => {
+		const tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-context-window-qualified-"));
+		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+		try {
+			saveCachedContextWindow("gpt-5.5@1m", 950000);
+			process.env.CURSOR_API_KEY = "test-key-123";
+			mockedList.mockResolvedValueOnce([
+				{
+					id: "gpt-5.5",
+					displayName: "GPT-5.5",
+					parameters: [{ id: "context", displayName: "Context", values: [{ value: "1m" }, { value: "272k" }] }],
+					variants: [{ params: [{ id: "context", value: "1m" }], displayName: "GPT-5.5", isDefault: true }],
+				},
+			]);
+
+			const models = await discoverModels();
+
+			expect(models.map((model) => [model.id, model.contextWindow])).toEqual([
+				["gpt-5.5@1m", 950000],
+				["gpt-5.5@272k", 272000],
 			]);
 		} finally {
 			rmSync(tmpAgentDir, { recursive: true, force: true });
@@ -688,7 +759,7 @@ describe("discoverModels", () => {
 			"claude-opus-4-7@1m",
 			"claude-opus-4-7@300k",
 			"claude-sonnet-4-6@1m",
-			"claude-sonnet-4-6@300k",
+			"claude-sonnet-4-6@200k",
 			"composer-2",
 			"gpt-5.5@1m",
 			"gpt-5.5@272k",
@@ -707,8 +778,35 @@ describe("discoverModels", () => {
 				message: expect.stringContaining("Cursor model discovery failed"),
 			}),
 		]);
+		expect(issues[0].message).toContain("network error");
+		expect(issues[0].errorMessage).toBe("network error");
 		expect(issues[0].message).toContain("/login");
 		expect(issues[0].message).not.toContain("test-key-123");
+	});
+
+	it("redacts sensitive values from fallback failure details", async () => {
+		process.env.CURSOR_API_KEY = "test-key-123";
+		const issues: CursorModelFallbackIssue[] = [];
+		mockedList.mockRejectedValueOnce(
+			new Error(
+				'Unauthorized Bearer test-key-123 {"apiKey":"test-key-123","token":"token-value","session_id":"session-value"} cookie: foo=bar; baz=qux',
+			),
+		);
+
+		await discoverModels({ onFallback: (issue) => issues.push(issue) });
+
+		expect(issues[0].reason).toBe("discovery-failed");
+		expect(issues[0].message).toContain("Bearer [redacted]");
+		expect(issues[0].message).toContain('"apiKey":"[redacted]"');
+		expect(issues[0].message).toContain('"token":"[redacted]"');
+		expect(issues[0].message).toContain('"session_id":"[redacted]"');
+		expect(issues[0].message).toContain("cookie: [redacted]");
+		expect(issues[0].errorMessage).toContain("Bearer [redacted]");
+		expect(issues[0].message).not.toContain("test-key-123");
+		expect(issues[0].message).not.toContain("token-value");
+		expect(issues[0].message).not.toContain("session-value");
+		expect(issues[0].message).not.toContain("foo=bar");
+		expect(issues[0].message).not.toContain("baz=qux");
 	});
 
 	it("falls back and reports empty model list when Cursor.models.list returns empty", async () => {


### PR DESCRIPTION
## Summary
- make native Cursor replay disposal idempotent and clean up pending runs on abort
- roll back /cursor-fast memory and disk state when session journal append fails
- dedupe tool completions by shared SDK identity while preserving distinct same-payload calls
- load context-window cache once per model catalog registration
- surface sanitized Cursor discovery failure details in fallback issues

## Verification
- npm test
- npm run typecheck
- subagent reviewer approved changes before commit
