### PR TITLE
Reuse Cursor SDK agents within pi sessions

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import type { Context, Message, ToolCall } from "@earendil-works/pi-ai";
 import type { SDKImage } from "@cursor/sdk";
 import { getCursorPiBridgeContractText } from "./cursor-bridge-contract.js";
@@ -185,6 +186,112 @@ export function estimateCursorPromptMessageTokens(message: Message, options: Pic
 
 export function estimateCursorContextTokens(context: Context, options: CursorPromptOptions = {}): number {
 	return estimateCursorPromptTokens(buildCursorPrompt(context, options), options);
+}
+
+interface CursorContextFingerprintPayload {
+	systemHash: string;
+	messageHashes: string[];
+}
+
+function hashCursorContextValue(value: string): string {
+	return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function serializeMessageForFingerprint(message: Message, index: number): string {
+	switch (message.role) {
+		case "user": {
+			const text =
+				typeof message.content === "string"
+					? message.content
+					: JSON.stringify(message.content);
+			return hashCursorContextValue(`user:${message.timestamp ?? index}:${text}`);
+		}
+		case "assistant":
+			return hashCursorContextValue(`assistant:${message.timestamp ?? index}:${JSON.stringify(message.content)}`);
+		case "toolResult":
+			return hashCursorContextValue(
+				`toolResult:${message.timestamp ?? index}:${message.toolCallId}:${message.toolName}:${JSON.stringify(message.content)}:${message.isError === true}`,
+			);
+	}
+}
+
+function parseCursorContextFingerprint(fingerprint: string): CursorContextFingerprintPayload | undefined {
+	try {
+		const parsed = JSON.parse(fingerprint) as CursorContextFingerprintPayload;
+		if (!parsed || typeof parsed.systemHash !== "string" || !Array.isArray(parsed.messageHashes)) return undefined;
+		if (!parsed.messageHashes.every((entry) => typeof entry === "string")) return undefined;
+		return parsed;
+	} catch {
+		return undefined;
+	}
+}
+
+export function computeCursorContextFingerprint(context: Context): string {
+	const payload: CursorContextFingerprintPayload = {
+		systemHash: hashCursorContextValue(context.systemPrompt ?? ""),
+		messageHashes: context.messages.map((message, index) => serializeMessageForFingerprint(message, index)),
+	};
+	return JSON.stringify(payload);
+}
+
+export function shouldBootstrapCursorSend(
+	sendState: { bootstrapped: boolean; contextFingerprint: string },
+	context: Context,
+): boolean {
+	if (!sendState.bootstrapped) return true;
+	const previous = parseCursorContextFingerprint(sendState.contextFingerprint);
+	if (!previous) return true;
+	const current = parseCursorContextFingerprint(computeCursorContextFingerprint(context));
+	if (!current) return true;
+	if (current.systemHash !== previous.systemHash) return true;
+	if (current.messageHashes.length < previous.messageHashes.length) return true;
+	for (let index = 0; index < previous.messageHashes.length; index += 1) {
+		if (current.messageHashes[index] !== previous.messageHashes[index]) return true;
+	}
+	return false;
+}
+
+export function buildCursorIncrementalPrompt(context: Context, options: CursorPromptOptions = {}): CursorPrompt {
+	// Incremental sends omit the full Cursor SDK tool boundary block; the session agent retains prior bootstrap context.
+	const latestUserMessageIndex = getLatestUserMessageIndex(context.messages);
+	const latestUserMessage = latestUserMessageIndex >= 0 ? context.messages[latestUserMessageIndex] : undefined;
+	const latestUserText = latestUserMessage ? formatMessage(latestUserMessage) : undefined;
+	const sections = [
+		"Continue the conversation using Cursor SDK capabilities only. Do not list, promise, or call pi-only tools from earlier context as if they were available.",
+	];
+	if (context.systemPrompt) {
+		sections.push(`System instructions from pi:\n${sanitizeSystemPromptForCursor(context.systemPrompt)}`);
+	}
+	if (latestUserText) sections.push(latestUserText);
+	const images = extractLatestImages(context.messages);
+	const imageTokenReserve = images.length * (options.imageTokenEstimate ?? 0);
+	const budgetOptions =
+		options.maxInputTokens === undefined
+			? options
+			: { ...options, maxInputTokens: Math.max(1, options.maxInputTokens - imageTokenReserve) };
+	const maxInputTokens = budgetOptions.maxInputTokens;
+	if (maxInputTokens !== undefined && Number.isFinite(maxInputTokens) && maxInputTokens > 0) {
+		const charsPerToken = budgetOptions.charsPerToken ?? CURSOR_APPROX_CHARS_PER_TOKEN;
+		const maxChars = Math.max(1, Math.floor(maxInputTokens * charsPerToken));
+		let text = sections.join(SECTION_SEPARATOR);
+		if (text.length > maxChars) {
+			text = `${text.slice(0, Math.max(0, maxChars - 1))}…`;
+		}
+		return { text, images };
+	}
+	return { text: sections.join(SECTION_SEPARATOR), images };
+}
+
+export function buildCursorSendPrompt(
+	context: Context,
+	options: CursorPromptOptions,
+	sendState: { bootstrapped: boolean; contextFingerprint: string },
+): { prompt: CursorPrompt; bootstrap: boolean } {
+	const bootstrap = shouldBootstrapCursorSend(sendState, context);
+	if (bootstrap) {
+		return { prompt: buildCursorPrompt(context, options), bootstrap: true };
+	}
+	return { prompt: buildCursorIncrementalPrompt(context, options), bootstrap: false };
 }
 
 export function buildCursorPrompt(context: Context, options: CursorPromptOptions = {}): CursorPrompt {

--- a/src/cursor-pi-tool-bridge.ts
+++ b/src/cursor-pi-tool-bridge.ts
@@ -149,18 +149,20 @@ export interface CursorPiToolBridgeRun {
 	resolveToolResultsFromContext(context: Context): void;
 	hasPendingPiToolCallId(piToolCallId: string): boolean;
 	isBridgeMcpToolCall(toolCall: unknown): boolean;
+	setOnToolRequest(handler?: (request: CursorPiBridgeToolRequest) => void): void;
 	cancel(reason: string): void;
 	dispose(): Promise<void>;
 }
 
-export interface CursorPiToolBridgeRunOptions {
-	onToolRequest?: (request: CursorPiBridgeToolRequest) => void;
-}
-
 export interface CursorPiToolBridge {
 	isEnabled(): boolean;
+	getToolSurfaceSignature(): string;
 	createRun(options?: CursorPiToolBridgeRunOptions): Promise<CursorPiToolBridgeRun>;
 	disposeAll(reason?: string): Promise<void>;
+}
+
+export interface CursorPiToolBridgeRunOptions {
+	onToolRequest?: (request: CursorPiBridgeToolRequest) => void;
 }
 
 type CursorPiToolBridgeSnapshotApi = Pick<ExtensionAPI, "getActiveTools" | "getAllTools">;
@@ -504,6 +506,25 @@ function isOverlappingCursorNativePiToolName(toolName: string): boolean {
 	return OVERLAPPING_CURSOR_NATIVE_PI_BUILTIN_TOOL_NAMES.has(toolName);
 }
 
+export function buildCursorPiToolBridgeSurfaceSignature(snapshot: CursorPiToolBridgeSnapshot): string {
+	if (snapshot.tools.length === 0) return "bridge:empty";
+	const serializedTools = snapshot.tools
+		.map((tool) =>
+			JSON.stringify({
+				piToolName: tool.piToolName,
+				mcpToolName: tool.mcpToolName,
+				description: tool.description,
+				inputSchema: tool.inputSchema,
+				source: tool.sourceInfo?.source,
+				path: tool.sourceInfo?.path,
+				scope: tool.sourceInfo?.scope,
+			}),
+		)
+		.sort()
+		.join("\0");
+	return `bridge:on:${stableNameHash(serializedTools)}`;
+}
+
 export function buildCursorPiToolBridgeSnapshot(
 	pi: CursorPiToolBridgeSnapshotApi,
 	options: CursorPiToolBridgeSnapshotOptions = {},
@@ -617,7 +638,8 @@ class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 	private readonly pendingByPiToolCallId = new Map<string, PendingBridgeCall>();
 	private readonly pendingByBridgeCallId = new Map<string, PendingBridgeCall>();
 	private readonly pendingByCursorMcpCallId = new Map<string, PendingBridgeCall>();
-	private readonly onToolRequest?: (request: CursorPiBridgeToolRequest) => void;
+	private onToolRequest?: (request: CursorPiBridgeToolRequest) => void;
+	private liveRunHandlerDetached = false;
 	private mcpServer?: McpProtocolServer;
 	private mcpTransport?: StreamableHTTPServerTransport;
 	private toolCallCounter = 0;
@@ -678,6 +700,21 @@ class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 
 	takeQueuedToolRequests(): CursorPiBridgeToolRequest[] {
 		return this.queuedRequests.splice(0);
+	}
+
+	setOnToolRequest(handler?: (request: CursorPiBridgeToolRequest) => void): void {
+		if (!handler) {
+			this.liveRunHandlerDetached = true;
+			this.rejectQueuedToolRequestsWithoutHandler("Cursor pi tool bridge has no active live run");
+		} else {
+			this.liveRunHandlerDetached = false;
+		}
+		this.onToolRequest = handler;
+		if (handler) {
+			for (const request of this.queuedRequests.splice(0)) {
+				handler(request);
+			}
+		}
 	}
 
 	resolveToolResults(toolResults: readonly ToolResultMessage[]): void {
@@ -816,10 +853,26 @@ class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 			this.pendingByBridgeCallId.set(request.bridgeCallId, pending);
 			this.pendingByCursorMcpCallId.set(cursorMcpCallId, pending);
 			this.knownCursorMcpCallIds.add(cursorMcpCallId);
-			if (!this.onToolRequest) this.queuedRequests.push(request);
+			if (!this.onToolRequest) {
+				if (this.liveRunHandlerDetached) {
+					this.rejectPending(pending, new Error("Cursor pi tool bridge has no active live run"), "cancelled");
+					return;
+				}
+				this.queuedRequests.push(request);
+				this.emitRequestQueuedDiagnostic(request);
+				return;
+			}
 			this.emitRequestQueuedDiagnostic(request);
-			this.onToolRequest?.(request);
+			this.onToolRequest(request);
 		});
+	}
+
+	private rejectQueuedToolRequestsWithoutHandler(reason: string): void {
+		while (this.queuedRequests.length > 0) {
+			const request = this.queuedRequests.shift()!;
+			const pending = this.pendingByPiToolCallId.get(request.piToolCallId);
+			if (pending) this.rejectPending(pending, new Error(reason), "cancelled");
+		}
 	}
 
 	private resolvePending(pending: PendingBridgeCall, result: CallToolResult): void {
@@ -907,6 +960,14 @@ class CursorPiToolBridgeRegistry implements CursorPiToolBridge {
 
 	isEnabled(): boolean {
 		return resolveCursorPiToolBridgeEnabled(this.env);
+	}
+
+	getToolSurfaceSignature(): string {
+		if (!this.isEnabled()) return "bridge:off";
+		const snapshot = buildCursorPiToolBridgeSnapshot(this.pi, {
+			exposeOverlappingBuiltins: resolveCursorPiToolBridgeBuiltinsEnabled(this.env),
+		});
+		return buildCursorPiToolBridgeSurfaceSignature(snapshot);
 	}
 
 	async createRun(options: CursorPiToolBridgeRunOptions = {}): Promise<CursorPiToolBridgeRun> {

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -12,9 +12,14 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { Agent, createAgentPlatform } from "@cursor/sdk";
 import type { InteractionUpdate, SDKAgent, SettingSource } from "@cursor/sdk";
 import { installCursorMcpToolTimeoutOverride } from "./cursor-mcp-timeout-override.js";
-import { buildCursorPrompt } from "./context.js";
+import { buildCursorSendPrompt } from "./context.js";
 import {
-	getRegisteredCursorPiToolBridge,
+	acquireSessionCursorAgent,
+	commitSessionAgentSend,
+	disposeAllSessionCursorAgents,
+	resetSessionCursorAgent,
+} from "./cursor-session-agent.js";
+import {
 	type CursorPiBridgeToolRequest,
 	type CursorPiToolBridgeRun,
 } from "./cursor-pi-tool-bridge.js";
@@ -89,10 +94,17 @@ type CursorLiveQueuedEvent =
 	| { type: "tool"; tool: CursorNativeToolDisplayItem }
 	| { type: "bridge-tool"; request: CursorPiBridgeToolRequest };
 
+interface CursorLiveSdkRun {
+	cancel(): Promise<void>;
+}
+
 interface CursorLiveRun {
 	id: string;
 	agent: SDKAgent;
 	bridgeRun?: CursorPiToolBridgeRun;
+	sessionBridgeRun?: CursorPiToolBridgeRun;
+	sessionAgentScopeKey?: string;
+	sdkRun?: CursorLiveSdkRun;
 	accounting: CursorLiveRunAccountingState;
 	pendingEvents: CursorLiveQueuedEvent[];
 	textDeltas: string[];
@@ -447,7 +459,7 @@ function scheduleCursorNativeRunIdleDispose(run: CursorLiveRun): void {
 	if (run.disposed) return;
 	clearCursorNativeRunIdleDispose(run);
 	run.idleDisposeTimer = setTimeout(() => {
-		void disposeCursorNativeRun(run);
+		void releaseCursorLiveRun(run);
 	}, cursorNativeReplayIdleDisposeMs);
 	run.idleDisposeTimer.unref?.();
 }
@@ -700,24 +712,42 @@ function emitCursorBridgeToolUseTurn(
 	scheduleCursorNativeRunIdleDispose(run);
 }
 
-async function disposeCursorNativeRun(run: CursorLiveRun): Promise<void> {
+function isSuccessfulCursorLiveRun(run: CursorLiveRun): boolean {
+	return run.done && !run.cancelled && !run.errorMessage;
+}
+
+async function abandonSessionCursorAgent(scopeKey: string | undefined): Promise<void> {
+	if (!scopeKey) return;
+	await resetSessionCursorAgent(scopeKey);
+}
+
+async function releaseCursorLiveRun(run: CursorLiveRun): Promise<void> {
 	if (run.disposed) return;
+	const abandoned = !isSuccessfulCursorLiveRun(run);
 	run.disposed = true;
 	pendingCursorLiveRuns.delete(run.id);
 	clearCursorNativeRunIdleDispose(run);
-	run.bridgeRun?.cancel("Cursor live run disposed");
+	run.bridgeRun?.cancel("Cursor live run released");
 	for (const toolDisplayId of run.recordedToolDisplayIds) deleteCursorNativeToolDisplay(toolDisplayId);
 	run.recordedToolDisplayIds = [];
 	run.waiters.clear();
-	try {
-		await run.bridgeRun?.dispose();
-	} catch {
-		// bridge disposal failure should not mask the provider result
+	if (run.sessionBridgeRun) {
+		run.sessionBridgeRun.setOnToolRequest(undefined);
 	}
-	try {
-		await run.agent[Symbol.asyncDispose]();
-	} catch {
-		// disposal failure should not mask the provider result
+	if (run.bridgeRun && run.bridgeRun !== run.sessionBridgeRun) {
+		try {
+			await run.bridgeRun.dispose();
+		} catch {
+			// bridge disposal failure should not mask the provider result
+		}
+	}
+	if (abandoned) {
+		try {
+			await run.sdkRun?.cancel();
+		} catch {
+			// cancellation failure should not block session-agent abandonment
+		}
+		await abandonSessionCursorAgent(run.sessionAgentScopeKey);
 	}
 }
 
@@ -764,14 +794,14 @@ async function emitCursorNativeRunNextTurn(
 		if (run.cancelled) {
 			partial.stopReason = "aborted";
 			stream.push({ type: "error", reason: "aborted", error: partial });
-			await disposeCursorNativeRun(run);
+			await releaseCursorLiveRun(run);
 			return;
 		}
 		if (run.errorMessage) {
 			partial.stopReason = "error";
 			partial.errorMessage = run.errorMessage;
 			stream.push({ type: "error", reason: "error", error: partial });
-			await disposeCursorNativeRun(run);
+			await releaseCursorLiveRun(run);
 			return;
 		}
 		if (run.done) {
@@ -783,7 +813,7 @@ async function emitCursorNativeRunNextTurn(
 			applyCursorApproximateUsage(partial, model, context, takeCursorLiveSessionInputTokens(run, toolResultInputTokens));
 			partial.stopReason = "stop";
 			stream.push({ type: "done", reason: "stop", message: partial });
-			await disposeCursorNativeRun(run);
+			await releaseCursorLiveRun(run);
 			return;
 		}
 
@@ -806,7 +836,7 @@ async function replayPendingCursorLiveRun(
 	try {
 		await emitCursorNativeRunNextTurn(stream, partial, model, context, run, consumed.toolResultInputTokens, signal);
 	} catch (error) {
-		if (error instanceof CursorAbortError) await disposeCursorNativeRun(run);
+		if (error instanceof CursorAbortError) await releaseCursorLiveRun(run);
 		throw error;
 	}
 	return true;
@@ -824,10 +854,10 @@ export function streamCursor(
 		let agent: SDKAgent | null = null;
 		let activeLiveRun: CursorLiveRun | undefined;
 		let bridgeRun: CursorPiToolBridgeRun | undefined;
-		let bridgeRunOwnedByLiveRun = false;
 		let liveRunForBridgeQueue: CursorLiveRun | undefined;
 		const queuedBridgeRequestsBeforeLiveRun: CursorPiBridgeToolRequest[] = [];
 		let resolvedApiKey: string | undefined;
+		let sessionAgentScopeKey = "";
 		let abortSignal: AbortSignal | undefined;
 		let abortListener: (() => void) | undefined;
 		let restoreCursorSdkOutputFilter: (() => void) | undefined;
@@ -856,37 +886,40 @@ export function streamCursor(
 			const selection = buildCursorModelSelection(model.id, options?.reasoning ?? "off", fastEnabled);
 			const settingSources = resolveCursorSettingSources();
 
-			const registeredBridge = getRegisteredCursorPiToolBridge();
-			bridgeRun = registeredBridge
-				? await registeredBridge.createRun({
-						onToolRequest: (request) => {
-							if (liveRunForBridgeQueue && !liveRunForBridgeQueue.disposed) {
-								queueCursorNativeEvent(liveRunForBridgeQueue, { type: "bridge-tool", request });
-							} else {
-								queuedBridgeRequestsBeforeLiveRun.push(request);
-							}
-						},
-					})
-				: undefined;
-			if (!bridgeRun?.enabled || !bridgeRun.mcpServers) {
-				await bridgeRun?.dispose();
-				bridgeRun = undefined;
-			}
-
 			installCursorMcpToolTimeoutOverride();
 			restoreCursorSdkOutputFilter = installCursorSdkOutputFilter();
-			agent = await suppressCursorSdkOutput(() =>
-				Agent.create({
-					apiKey,
-					model: selection,
-					local: settingSources ? { cwd, settingSources } : { cwd },
-					...(bridgeRun?.mcpServers ? { mcpServers: bridgeRun.mcpServers } : {}),
-				}),
-			);
+			const sessionAgentAcquireParams = {
+				apiKey,
+				cwd,
+				modelSelection: selection,
+				settingSources,
+				onBridgeToolRequest: (request: CursorPiBridgeToolRequest) => {
+					if (liveRunForBridgeQueue && !liveRunForBridgeQueue.disposed) {
+						queueCursorNativeEvent(liveRunForBridgeQueue, { type: "bridge-tool", request });
+					} else {
+						queuedBridgeRequestsBeforeLiveRun.push(request);
+					}
+				},
+				createAgent: (createOptions: Parameters<typeof Agent.create>[0]) =>
+					suppressCursorSdkOutput(() => Agent.create(createOptions)),
+			};
+			let sessionAgentLease = await acquireSessionCursorAgent(sessionAgentAcquireParams);
+			sessionAgentScopeKey = sessionAgentLease.scopeKey;
+			agent = sessionAgentLease.agent;
+			bridgeRun = sessionAgentLease.bridgeRun;
 			throwIfAborted();
 
 			const promptOptions = getCursorPromptOptions(model);
-			const prompt = buildCursorPrompt(context, promptOptions);
+			let { prompt, bootstrap } = buildCursorSendPrompt(context, promptOptions, sessionAgentLease.sendState);
+			if (sessionAgentLease.sendState.bootstrapped && bootstrap) {
+				await resetSessionCursorAgent(sessionAgentLease.scopeKey);
+				sessionAgentLease = await acquireSessionCursorAgent(sessionAgentAcquireParams);
+				sessionAgentScopeKey = sessionAgentLease.scopeKey;
+				agent = sessionAgentLease.agent;
+				bridgeRun = sessionAgentLease.bridgeRun;
+				({ prompt, bootstrap } = buildCursorSendPrompt(context, promptOptions, sessionAgentLease.sendState));
+			}
+			const sessionBridgeRun = sessionAgentLease.bridgeRun;
 			const promptInputTokens = estimateCursorPromptInputTokens(prompt, promptOptions);
 			let thinkingContentIndex = -1;
 			let activityTraceChars = 0;
@@ -903,6 +936,8 @@ export function streamCursor(
 						id: useNativeToolReplay ? nativeReplayId : bridgeRun!.id,
 						agent,
 						bridgeRun,
+						sessionBridgeRun,
+						sessionAgentScopeKey,
 						accounting: createCursorLiveRunAccountingState(promptInputTokens),
 						pendingEvents: [],
 						textDeltas,
@@ -918,7 +953,6 @@ export function streamCursor(
 				pendingCursorLiveRuns.set(liveRun.id, liveRun);
 				activeLiveRun = liveRun;
 				liveRunForBridgeQueue = liveRun;
-				bridgeRunOwnedByLiveRun = bridgeRun !== undefined;
 				for (const request of queuedBridgeRequestsBeforeLiveRun.splice(0)) {
 					queueCursorNativeEvent(liveRun, { type: "bridge-tool", request });
 				}
@@ -1252,6 +1286,7 @@ export function streamCursor(
 				{ text: prompt.text, images: prompt.images.length > 0 ? prompt.images : undefined },
 				{ onDelta, onStep },
 			);
+			if (liveRun) liveRun.sdkRun = run;
 			if (options?.signal?.aborted) {
 				await run.cancel().catch(() => {});
 				throw new CursorAbortError();
@@ -1265,14 +1300,24 @@ export function streamCursor(
 						discardIncompleteStartedToolCalls();
 						await cacheSdkContextWindow(liveRun.agent.agentId, model.id);
 						if (liveRun.disposed) return;
+						if (result.status === "finished" && !options?.signal?.aborted) {
+							commitSessionAgentSend(sessionAgentScopeKey, context, bootstrap);
+						} else {
+							await abandonSessionCursorAgent(sessionAgentScopeKey);
+						}
 						liveRun.cancelled = result.status === "cancelled";
-						liveRun.finalText = selectCursorFinalText(result.result, liveRun.textDeltas, liveRun.emittedText, cursorPlanTextCandidate);
+						if (result.status === "error") {
+							liveRun.errorMessage = sanitizeError(result.result ?? "Cursor SDK run failed", resolvedApiKey ?? options?.apiKey);
+						} else {
+							liveRun.finalText = selectCursorFinalText(result.result, liveRun.textDeltas, liveRun.emittedText, cursorPlanTextCandidate);
+						}
 						liveRun.done = true;
 						notifyCursorNativeRun(liveRun);
 						scheduleCursorNativeRunIdleDispose(liveRun);
 					})
-					.catch((error: unknown) => {
+					.catch(async (error: unknown) => {
 						if (liveRun.disposed) return;
+						await abandonSessionCursorAgent(sessionAgentScopeKey);
 						liveRun.errorMessage = sanitizeError(error, resolvedApiKey ?? options?.apiKey);
 						notifyCursorNativeRun(liveRun);
 						scheduleCursorNativeRunIdleDispose(liveRun);
@@ -1284,7 +1329,7 @@ export function streamCursor(
 					closeTraceBlock();
 					await emitCursorNativeRunNextTurn(stream, partial, model, context, liveRun, 0, options?.signal);
 				} catch (error) {
-					if (error instanceof CursorAbortError) await disposeCursorNativeRun(liveRun);
+					if (error instanceof CursorAbortError) await releaseCursorLiveRun(liveRun);
 					throw error;
 				}
 				agent = null;
@@ -1300,9 +1345,16 @@ export function streamCursor(
 			closeTraceBlock();
 
 			if (result.status === "cancelled") {
+				await abandonSessionCursorAgent(sessionAgentScopeKey);
 				partial.stopReason = "aborted";
 				stream.push({ type: "error", reason: "aborted", error: partial });
+			} else if (result.status === "error") {
+				await abandonSessionCursorAgent(sessionAgentScopeKey);
+				partial.stopReason = "error";
+				partial.errorMessage = sanitizeError(result.result ?? "Cursor SDK run failed", resolvedApiKey ?? options?.apiKey);
+				stream.push({ type: "error", reason: "error", error: partial });
 			} else {
+				commitSessionAgentSend(sessionAgentScopeKey, context, bootstrap);
 				const finalCursorText = selectCursorFinalText(result.result, textDeltas, textDeltas.join(""), cursorPlanTextCandidate, {
 					allowPartialPrefix: true,
 				});
@@ -1311,7 +1363,8 @@ export function streamCursor(
 				stream.push({ type: "done", reason: "stop", message: partial });
 			}
 		} catch (error) {
-			if (activeLiveRun && !activeLiveRun.disposed) await disposeCursorNativeRun(activeLiveRun);
+			if (activeLiveRun && !activeLiveRun.disposed) await releaseCursorLiveRun(activeLiveRun);
+			else await abandonSessionCursorAgent(sessionAgentScopeKey);
 			if (error instanceof CursorAbortError) {
 				partial.stopReason = "aborted";
 				stream.push({ type: "error", reason: "aborted", error: partial });
@@ -1322,27 +1375,9 @@ export function streamCursor(
 			}
 		} finally {
 			restoreCursorSdkOutputFilter?.();
-			if (activeLiveRun?.disposed) agent = null;
 
 			if (abortSignal && abortListener) {
 				abortSignal.removeEventListener("abort", abortListener);
-			}
-
-			if (bridgeRun && !bridgeRunOwnedByLiveRun) {
-				try {
-					await bridgeRun.dispose();
-				} catch {
-					// bridge disposal failure should not mask original error
-				}
-			}
-
-			if (agent) {
-				try {
-					await agent[Symbol.asyncDispose]();
-				} catch {
-					// disposal failure should not mask original error
-				}
-				agent = null;
 			}
 		}
 
@@ -1361,4 +1396,5 @@ export const __testUtils = {
 	resetCursorNativeReplayIdleDisposeMs: () => {
 		cursorNativeReplayIdleDisposeMs = DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS;
 	},
+	resetSessionCursorAgents: () => disposeAllSessionCursorAgents(),
 };

--- a/src/cursor-session-agent.ts
+++ b/src/cursor-session-agent.ts
@@ -1,0 +1,358 @@
+import type { ExtensionHandler, SessionCompactEvent, SessionShutdownEvent, SessionTreeEvent } from "@earendil-works/pi-coding-agent";
+import { createHash } from "node:crypto";
+import { Agent } from "@cursor/sdk";
+import type { ModelSelection, SDKAgent, SettingSource } from "@cursor/sdk";
+import type { Context } from "@earendil-works/pi-ai";
+import {
+	getRegisteredCursorPiToolBridge,
+	type CursorPiBridgeToolRequest,
+	type CursorPiToolBridgeRun,
+} from "./cursor-pi-tool-bridge.js";
+import { computeCursorContextFingerprint } from "./context.js";
+import { getCursorSessionScopeKey, onCursorSessionScopeKeyChange } from "./cursor-session-scope.js";
+
+export interface SessionCursorAgentSendState {
+	bootstrapped: boolean;
+	contextFingerprint: string;
+}
+
+export interface SessionCursorAgentLease {
+	scopeKey: string;
+	agent: SDKAgent;
+	bridgeRun?: CursorPiToolBridgeRun;
+	sendState: SessionCursorAgentSendState;
+	created: boolean;
+}
+
+interface SessionCursorAgentPoolEntry {
+	poolKey: string;
+	scopeKey: string;
+	agent?: SDKAgent;
+	bridgeRun?: CursorPiToolBridgeRun;
+	sendState: SessionCursorAgentSendState;
+	creating?: Promise<SessionCursorAgentPoolEntry>;
+	creationGeneration?: number;
+}
+
+class SessionCursorAgentCreationSupersededError extends Error {
+	constructor() {
+		super("Cursor session agent creation was superseded");
+		this.name = "SessionCursorAgentCreationSupersededError";
+	}
+}
+
+export class SessionCursorAgentScopeClosedError extends Error {
+	constructor() {
+		super("Cursor session agent scope is closed");
+		this.name = "SessionCursorAgentScopeClosedError";
+	}
+}
+
+function assertScopeAcceptsAcquire(scopeKey: string): void {
+	if (terminalDisposedScopeKeys.has(scopeKey)) {
+		throw new SessionCursorAgentScopeClosedError();
+	}
+}
+
+function rethrowSupersededWhenReplacedByDifferentPoolKey(scopeKey: string, poolKey: string, error: unknown): void {
+	if (!(error instanceof SessionCursorAgentCreationSupersededError)) return;
+	const replacement = sessionAgentsByScope.get(scopeKey);
+	if (replacement && replacement.poolKey !== poolKey) {
+		throw error;
+	}
+}
+
+interface SessionCursorAgentCreateParams {
+	apiKey: string;
+	cwd: string;
+	modelSelection: ModelSelection;
+	settingSources?: SettingSource[];
+	onBridgeToolRequest?: (request: CursorPiBridgeToolRequest) => void;
+	createAgent?: typeof Agent.create;
+}
+
+interface CursorSessionAgentExtensionApi {
+	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
+	on(event: "session_compact", handler: ExtensionHandler<SessionCompactEvent>): void;
+	on(event: "session_tree", handler: ExtensionHandler<SessionTreeEvent>): void;
+	on(event: "model_select", handler: ExtensionHandler<{ model: unknown }>): void;
+}
+
+const sessionAgentsByScope = new Map<string, SessionCursorAgentPoolEntry>();
+const invalidatedScopeKeys = new Set<string>();
+const terminalDisposedScopeKeys = new Set<string>();
+const scopeCreationGenerations = new Map<string, number>();
+
+function getScopeCreationGeneration(scopeKey: string): number {
+	return scopeCreationGenerations.get(scopeKey) ?? 0;
+}
+
+function invalidateScopeCreations(scopeKey: string): void {
+	scopeCreationGenerations.set(scopeKey, getScopeCreationGeneration(scopeKey) + 1);
+}
+
+function buildModelPoolKey(modelSelection: ModelSelection): string {
+	return JSON.stringify(modelSelection);
+}
+
+function buildSettingSourcesPoolKey(settingSources?: SettingSource[]): string {
+	return settingSources?.join(",") ?? "";
+}
+
+function buildApiKeyPoolKeyFingerprint(apiKey: string): string {
+	return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}
+
+function buildBridgePoolKeySuffix(): string {
+	const registeredBridge = getRegisteredCursorPiToolBridge();
+	if (!registeredBridge) return "bridge:absent";
+	return registeredBridge.getToolSurfaceSignature();
+}
+
+function buildSessionAgentPoolKey(scopeKey: string, params: SessionCursorAgentCreateParams): string {
+	return [
+		scopeKey,
+		params.cwd,
+		buildModelPoolKey(params.modelSelection),
+		buildSettingSourcesPoolKey(params.settingSources),
+		buildApiKeyPoolKeyFingerprint(params.apiKey),
+		buildBridgePoolKeySuffix(),
+	].join("\0");
+}
+
+async function disposePoolEntry(entry: SessionCursorAgentPoolEntry): Promise<void> {
+	entry.bridgeRun?.cancel("Cursor session agent disposed");
+	try {
+		await entry.bridgeRun?.dispose();
+	} catch {
+		// disposal failure should not block session replacement
+	}
+	if (!entry.agent) return;
+	try {
+		await entry.agent[Symbol.asyncDispose]();
+	} catch {
+		// disposal failure should not block session replacement
+	}
+}
+
+async function disposePoolEntryForScope(scopeKey: string, options?: { terminal?: boolean }): Promise<void> {
+	invalidateScopeCreations(scopeKey);
+	if (options?.terminal) {
+		terminalDisposedScopeKeys.add(scopeKey);
+	}
+	const entry = sessionAgentsByScope.get(scopeKey);
+	invalidatedScopeKeys.delete(scopeKey);
+	if (!entry) return;
+	sessionAgentsByScope.delete(scopeKey);
+	if (entry.creating || !entry.agent) return;
+	await disposePoolEntry(entry);
+}
+
+function createInitialSendState(): SessionCursorAgentSendState {
+	return { bootstrapped: false, contextFingerprint: "" };
+}
+
+function bindBridgeToolRequest(
+	entry: SessionCursorAgentPoolEntry,
+	onBridgeToolRequest?: (request: CursorPiBridgeToolRequest) => void,
+): void {
+	entry.bridgeRun?.setOnToolRequest(onBridgeToolRequest);
+}
+
+function leaseFromEntry(
+	entry: SessionCursorAgentPoolEntry,
+	scopeKey: string,
+	params: SessionCursorAgentCreateParams,
+	created: boolean,
+): SessionCursorAgentLease {
+	bindBridgeToolRequest(entry, params.onBridgeToolRequest);
+	return {
+		scopeKey,
+		agent: entry.agent!,
+		bridgeRun: entry.bridgeRun,
+		sendState: entry.sendState,
+		created,
+	};
+}
+
+async function createSessionAgentEntry(
+	scopeKey: string,
+	poolKey: string,
+	params: SessionCursorAgentCreateParams,
+): Promise<SessionCursorAgentPoolEntry> {
+	const registeredBridge = getRegisteredCursorPiToolBridge();
+	let bridgeRun: CursorPiToolBridgeRun | undefined;
+	if (registeredBridge) {
+		bridgeRun = await registeredBridge.createRun({
+			onToolRequest: params.onBridgeToolRequest,
+		});
+		if (!bridgeRun.enabled || !bridgeRun.mcpServers) {
+			await bridgeRun.dispose();
+			bridgeRun = undefined;
+		}
+	}
+
+	const resolvedPoolKey = buildSessionAgentPoolKey(scopeKey, params);
+	const createAgent = params.createAgent ?? Agent.create;
+	let agent: SDKAgent;
+	try {
+		agent = await createAgent({
+			apiKey: params.apiKey,
+			model: params.modelSelection,
+			local: params.settingSources ? { cwd: params.cwd, settingSources: params.settingSources } : { cwd: params.cwd },
+			...(bridgeRun?.mcpServers ? { mcpServers: bridgeRun.mcpServers } : {}),
+		});
+	} catch (error) {
+		if (bridgeRun) {
+			bridgeRun.cancel("Cursor session agent create failed");
+			try {
+				await bridgeRun.dispose();
+			} catch {
+				// bridge disposal failure should not mask agent create failure
+			}
+		}
+		throw error;
+	}
+
+	return {
+		poolKey: resolvedPoolKey,
+		scopeKey,
+		agent,
+		bridgeRun,
+		sendState: createInitialSendState(),
+	};
+}
+
+export { shouldBootstrapCursorSend } from "./context.js";
+
+export function commitSessionAgentSend(scopeKey: string, context: Context, bootstrapped: boolean): void {
+	const entry = sessionAgentsByScope.get(scopeKey);
+	if (!entry) return;
+	entry.sendState.bootstrapped = bootstrapped || entry.sendState.bootstrapped;
+	entry.sendState.contextFingerprint = computeCursorContextFingerprint(context);
+}
+
+export function invalidateSessionAgent(scopeKey: string = getCursorSessionScopeKey()): void {
+	invalidatedScopeKeys.add(scopeKey);
+}
+
+export async function acquireSessionCursorAgent(params: SessionCursorAgentCreateParams): Promise<SessionCursorAgentLease> {
+	const scopeKey = getCursorSessionScopeKey();
+	assertScopeAcceptsAcquire(scopeKey);
+	if (invalidatedScopeKeys.has(scopeKey)) {
+		await disposePoolEntryForScope(scopeKey);
+	}
+
+	const poolKey = buildSessionAgentPoolKey(scopeKey, params);
+	const existing = sessionAgentsByScope.get(scopeKey);
+	if (existing?.poolKey === poolKey && !existing.creating) {
+		return leaseFromEntry(existing, scopeKey, params, false);
+	}
+
+	if (existing && existing.poolKey !== poolKey) {
+		await disposePoolEntryForScope(scopeKey);
+	}
+
+	let entry = sessionAgentsByScope.get(scopeKey);
+	if (entry?.creating) {
+		try {
+			await entry.creating;
+		} catch (error) {
+			if (error instanceof SessionCursorAgentCreationSupersededError) {
+				assertScopeAcceptsAcquire(scopeKey);
+				rethrowSupersededWhenReplacedByDifferentPoolKey(scopeKey, poolKey, error);
+			} else {
+				throw error;
+			}
+		}
+		entry = sessionAgentsByScope.get(scopeKey);
+		if (entry && entry.poolKey === poolKey && entry.agent && !entry.creating) {
+			return leaseFromEntry(entry, scopeKey, params, false);
+		}
+	}
+
+	assertScopeAcceptsAcquire(scopeKey);
+	const creationGeneration = getScopeCreationGeneration(scopeKey);
+	const placeholder: SessionCursorAgentPoolEntry = {
+		poolKey,
+		scopeKey,
+		sendState: createInitialSendState(),
+		creationGeneration,
+	};
+	const creating = createSessionAgentEntry(scopeKey, poolKey, params).then(async (createdEntry) => {
+		const stillCurrent =
+			sessionAgentsByScope.get(scopeKey) === placeholder &&
+			getScopeCreationGeneration(scopeKey) === placeholder.creationGeneration;
+		if (!stillCurrent) {
+			await disposePoolEntry(createdEntry);
+			if (sessionAgentsByScope.get(scopeKey) === placeholder) {
+				sessionAgentsByScope.delete(scopeKey);
+			}
+			throw new SessionCursorAgentCreationSupersededError();
+		}
+		sessionAgentsByScope.set(scopeKey, createdEntry);
+		return createdEntry;
+	});
+	placeholder.creating = creating;
+	sessionAgentsByScope.set(scopeKey, placeholder);
+
+	try {
+		const createdEntry = await creating;
+		return leaseFromEntry(createdEntry, scopeKey, params, true);
+	} catch (error) {
+		if (sessionAgentsByScope.get(scopeKey) === placeholder) {
+			sessionAgentsByScope.delete(scopeKey);
+		}
+		if (error instanceof SessionCursorAgentCreationSupersededError) {
+			assertScopeAcceptsAcquire(scopeKey);
+			rethrowSupersededWhenReplacedByDifferentPoolKey(scopeKey, poolKey, error);
+			return acquireSessionCursorAgent(params);
+		}
+		throw error;
+	}
+}
+
+export async function resetSessionCursorAgent(scopeKey: string = getCursorSessionScopeKey()): Promise<void> {
+	await disposePoolEntryForScope(scopeKey);
+}
+
+export async function disposeSessionCursorAgent(scopeKey: string = getCursorSessionScopeKey()): Promise<void> {
+	await disposePoolEntryForScope(scopeKey, { terminal: true });
+}
+
+export async function disposeAllSessionCursorAgents(): Promise<void> {
+	const scopeKeys = [...new Set([...sessionAgentsByScope.keys(), ...terminalDisposedScopeKeys])];
+	await Promise.all(scopeKeys.map((scopeKey) => disposePoolEntryForScope(scopeKey, { terminal: true })));
+	invalidatedScopeKeys.clear();
+	terminalDisposedScopeKeys.clear();
+}
+
+export function registerCursorSessionAgent(_pi: CursorSessionAgentExtensionApi): void {
+	onCursorSessionScopeKeyChange((previousScopeKey) => {
+		void disposePoolEntryForScope(previousScopeKey, { terminal: true });
+	});
+	_pi.on("session_shutdown", async () => {
+		await disposeSessionCursorAgent();
+	});
+	_pi.on("session_compact", () => {
+		invalidateSessionAgent();
+	});
+	_pi.on("session_tree", () => {
+		invalidateSessionAgent();
+	});
+	_pi.on("model_select", () => {
+		invalidateSessionAgent();
+	});
+}
+
+export const __testUtils = {
+	sessionAgentsByScope,
+	invalidateSessionAgent,
+	disposeSessionCursorAgent,
+	resetSessionCursorAgent,
+	disposeAllSessionCursorAgents,
+	buildApiKeyPoolKeyFingerprint,
+	buildSessionAgentPoolKey,
+	SessionCursorAgentCreationSupersededError,
+	SessionCursorAgentScopeClosedError,
+};

--- a/src/cursor-session-cwd.ts
+++ b/src/cursor-session-cwd.ts
@@ -1,12 +1,13 @@
+import {
+	getCursorSessionCwdFromScope,
+	registerCursorSessionScope,
+	__testUtils as cursorSessionScopeTestUtils,
+} from "./cursor-session-scope.js";
 import type { ExtensionHandler, SessionStartEvent } from "@earendil-works/pi-coding-agent";
 
 interface CursorSessionCwdExtensionApi {
 	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
 }
-
-const state = {
-	sessionCwd: process.cwd(),
-};
 
 /**
  * Pi session cwd when known; falls back to process.cwd() before session_start.
@@ -14,24 +15,14 @@ const state = {
  * changes without a new session_start event are not reflected here.
  */
 export function getCursorSessionCwd(): string {
-	return state.sessionCwd;
-}
-
-function setCursorSessionCwd(cwd: string): void {
-	state.sessionCwd = cwd;
-}
-
-function resetCursorSessionCwd(): void {
-	state.sessionCwd = process.cwd();
+	return getCursorSessionCwdFromScope();
 }
 
 export function registerCursorSessionCwd(pi: CursorSessionCwdExtensionApi): void {
-	pi.on("session_start", (_event, ctx) => {
-		setCursorSessionCwd(ctx.cwd);
-	});
+	registerCursorSessionScope(pi);
 }
 
 export const __testUtils = {
-	set: setCursorSessionCwd,
-	reset: resetCursorSessionCwd,
+	set: cursorSessionScopeTestUtils.set,
+	reset: cursorSessionScopeTestUtils.reset,
 };

--- a/src/cursor-session-scope.ts
+++ b/src/cursor-session-scope.ts
@@ -1,0 +1,65 @@
+import type { ExtensionHandler, SessionStartEvent } from "@earendil-works/pi-coding-agent";
+
+interface CursorSessionScopeExtensionApi {
+	on(event: "session_start", handler: ExtensionHandler<SessionStartEvent>): void;
+}
+
+const ANONYMOUS_SESSION_SCOPE_KEY = "__anonymous__";
+
+type CursorSessionScopeChangeHandler = (previousScopeKey: string) => void;
+
+const state = {
+	sessionCwd: process.cwd(),
+	sessionFile: undefined as string | undefined,
+};
+
+let scopeChangeHandler: CursorSessionScopeChangeHandler | undefined;
+
+/**
+ * Pi session file when known; used to scope reused Cursor SDK agents to one pi session.
+ */
+export function getCursorSessionFile(): string | undefined {
+	return state.sessionFile;
+}
+
+/**
+ * Stable scope key for session-agent pooling. Falls back to a process-local anonymous key
+ * before the first session_start (tests and early startup).
+ */
+export function getCursorSessionScopeKey(): string {
+	return state.sessionFile ?? ANONYMOUS_SESSION_SCOPE_KEY;
+}
+
+export function getCursorSessionCwdFromScope(): string {
+	return state.sessionCwd;
+}
+
+function setCursorSessionScope(cwd: string, sessionFile: string | undefined): void {
+	state.sessionCwd = cwd;
+	state.sessionFile = sessionFile;
+}
+
+function resetCursorSessionScope(): void {
+	state.sessionCwd = process.cwd();
+	state.sessionFile = undefined;
+}
+
+export function onCursorSessionScopeKeyChange(handler: CursorSessionScopeChangeHandler): void {
+	scopeChangeHandler = handler;
+}
+
+export function registerCursorSessionScope(pi: CursorSessionScopeExtensionApi): void {
+	pi.on("session_start", (_event, ctx) => {
+		const previousScopeKey = getCursorSessionScopeKey();
+		setCursorSessionScope(ctx.cwd, ctx.sessionManager?.getSessionFile?.() ?? undefined);
+		if (previousScopeKey !== getCursorSessionScopeKey()) {
+			scopeChangeHandler?.(previousScopeKey);
+		}
+	});
+}
+
+export const __testUtils = {
+	ANONYMOUS_SESSION_SCOPE_KEY,
+	set: setCursorSessionScope,
+	reset: resetCursorSessionScope,
+};

--- a/src/cursor-state.ts
+++ b/src/cursor-state.ts
@@ -17,7 +17,9 @@ interface CursorGlobalConfig {
 	fastDefaults?: Record<string, boolean>;
 }
 
-type CursorFastControlsModel = Pick<NonNullable<ExtensionContext["model"]>, "id" | "provider"> | undefined;
+type CursorFastControlsModel =
+	| Pick<NonNullable<ExtensionContext["model"]>, "id" | "provider" | "api">
+	| undefined;
 
 type CursorFastControlsContext = {
 	model: CursorFastControlsModel;
@@ -32,6 +34,7 @@ interface CursorFastControlsExtensionApi extends Pick<ExtensionAPI, "appendEntry
 	}): void;
 	on(event: "session_start", handler: (event: SessionStartEvent, ctx: CursorFastControlsContext) => Promise<void> | void): void;
 	on(event: "model_select", handler: (event: { model: ExtensionContext["model"] }, ctx: CursorFastControlsContext) => Promise<void> | void): void;
+	on(event: "turn_start", handler: (event: unknown, ctx: CursorFastControlsContext) => Promise<void> | void): void;
 }
 
 const sessionFastPreferences = new Map<string, boolean>();
@@ -91,23 +94,27 @@ function getEffectiveFast(baseModelId: string, modelId: string): boolean | undef
 	return sessionFastPreferences.get(baseModelId) ?? globalFastPreferences.get(baseModelId) ?? metadata.defaultFast;
 }
 
+function isCursorModel(model: CursorFastControlsModel): boolean {
+	return model?.provider === CURSOR_PROVIDER || model?.api === "cursor-sdk";
+}
+
 function updateCursorStatus(ctx: { model: CursorFastControlsModel; ui: Pick<ExtensionContext["ui"], "setStatus"> }, model = ctx.model): void {
-	if (model?.provider !== CURSOR_PROVIDER) {
+	if (!model || !isCursorModel(model)) {
 		ctx.ui.setStatus("cursor", undefined);
 		return;
 	}
 	const metadata = getCursorModelMetadata(model.id);
-	if (!metadata) {
+	if (!metadata?.supportsFast) {
 		ctx.ui.setStatus("cursor", undefined);
 		return;
 	}
 	const fast = getEffectiveFast(metadata.baseModelId, model.id);
-	ctx.ui.setStatus("cursor", fast ? "cursor fast" : undefined);
+	ctx.ui.setStatus("cursor", fast === true ? "cursor fast" : undefined);
 }
 
 function getCurrentCursorMetadata(ctx: { model: CursorFastControlsModel }) {
 	const model = ctx.model;
-	if (model?.provider !== CURSOR_PROVIDER) return undefined;
+	if (!model || !isCursorModel(model)) return undefined;
 	return getCursorModelMetadata(model.id);
 }
 
@@ -204,6 +211,10 @@ export function registerCursorFastControls(pi: CursorFastControlsExtensionApi): 
 
 	pi.on("model_select", async (event, ctx) => {
 		updateCursorStatus(ctx, event.model);
+	});
+
+	pi.on("turn_start", async (_event, ctx) => {
+		updateCursorStatus(ctx);
 	});
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { registerCursorNativeToolDisplay } from "./cursor-native-tool-display.js
 import { registerCursorPiToolBridge } from "./cursor-pi-tool-bridge.js";
 import { registerCursorQuestionTool } from "./cursor-question-tool.js";
 import { registerCursorSessionCwd } from "./cursor-session-cwd.js";
+import { registerCursorSessionAgent } from "./cursor-session-agent.js";
 import { streamCursor } from "./cursor-provider.js";
 
 type CursorExtensionApi =
@@ -16,6 +17,7 @@ type CursorExtensionApi =
 		}): void;
 	}
 	& Parameters<typeof registerCursorSessionCwd>[0]
+	& Parameters<typeof registerCursorSessionAgent>[0]
 	& Parameters<typeof registerCursorFastControls>[0]
 	& Parameters<typeof registerCursorNativeToolDisplay>[0]
 	& Parameters<typeof registerCursorQuestionTool>[0]
@@ -39,6 +41,7 @@ function registerCursorProvider(pi: Pick<ExtensionAPI, "registerProvider">, mode
 export default async function (pi: CursorExtensionApi) {
 	// Session cwd must register before other session_start listeners that depend on it.
 	registerCursorSessionCwd(pi);
+	registerCursorSessionAgent(pi);
 	registerCursorFastControls(pi);
 	registerCursorNativeToolDisplay(pi);
 	registerCursorQuestionTool(pi);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
 	buildCursorPrompt,
+	buildCursorSendPrompt,
+	buildCursorIncrementalPrompt,
+	computeCursorContextFingerprint,
+	shouldBootstrapCursorSend,
 	CURSOR_IMAGE_TOKEN_ESTIMATE,
 	estimateCursorContextTokens,
 	estimateCursorPromptMessageTokens,
@@ -471,5 +475,84 @@ describe("buildCursorPrompt", () => {
 		expect(result.text).not.toContain("do not execute every Cursor tool");
 		expect(result.text).toContain("replay is display-only and not a capability to invoke");
 		expect(result.text).toContain("use Cursor web/search/browser/MCP or say web search is not configured");
+	});
+});
+
+describe("buildCursorSendPrompt", () => {
+	it("bootstraps the first send with the full Cursor prompt", () => {
+		const context: Context = {
+			systemPrompt: "Be helpful.",
+			messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+		};
+		const sendState = { bootstrapped: false, contextFingerprint: "" };
+
+		const { prompt, bootstrap } = buildCursorSendPrompt(context, {}, sendState);
+
+		expect(bootstrap).toBe(true);
+		expect(prompt.text).toContain("Cursor SDK tool boundary:");
+		expect(prompt.text).toContain("User: Hello");
+	});
+
+	it("sends an incremental prompt after a bootstrapped session agent send", () => {
+		const priorContext: Context = {
+			systemPrompt: "Be helpful.",
+			messages: [
+				{ role: "user", content: "Hello", timestamp: 1 },
+				{ role: "assistant", content: [{ type: "text", text: "Hi" }], api: "cursor-sdk", provider: "cursor", model: "test", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+			],
+		};
+		const context: Context = {
+			systemPrompt: "Be helpful.",
+			messages: [...priorContext.messages, { role: "user", content: "Follow up", timestamp: 3 }],
+		};
+		const sendState = { bootstrapped: true, contextFingerprint: computeCursorContextFingerprint(priorContext) };
+
+		const { prompt, bootstrap } = buildCursorSendPrompt(context, {}, sendState);
+
+		expect(bootstrap).toBe(false);
+		expect(prompt.text).toContain("Continue the conversation using Cursor SDK capabilities only");
+		expect(prompt.text).toContain("User: Follow up");
+		expect(prompt.text).not.toContain("Cursor SDK tool boundary:");
+		expect(prompt.text).not.toContain("User: Hello");
+	});
+
+	it("rebootstraps after branch shrink using shouldBootstrapCursorSend", () => {
+		const context: Context = {
+			messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+		};
+		const sendState = {
+			bootstrapped: true,
+			contextFingerprint: computeCursorContextFingerprint({
+				messages: [
+					{ role: "user", content: "Hello", timestamp: 1 },
+					{ role: "assistant", content: [{ type: "text", text: "Hi" }], api: "cursor-sdk", provider: "cursor", model: "test", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+				],
+			}),
+		};
+
+		expect(shouldBootstrapCursorSend(sendState, context)).toBe(true);
+		expect(buildCursorSendPrompt(context, {}, sendState).bootstrap).toBe(true);
+	});
+
+	it("rebootstraps when same-length history diverges", () => {
+		const priorContext: Context = {
+			messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+		};
+		const editedContext: Context = {
+			messages: [{ role: "user", content: "Hello edited", timestamp: 1 }],
+		};
+		const sendState = { bootstrapped: true, contextFingerprint: computeCursorContextFingerprint(priorContext) };
+
+		expect(shouldBootstrapCursorSend(sendState, editedContext)).toBe(true);
+		expect(buildCursorSendPrompt(editedContext, {}, sendState).bootstrap).toBe(true);
+	});
+
+	it("omits the full tool boundary block from incremental prompts", () => {
+		const incremental = buildCursorIncrementalPrompt({
+			systemPrompt: "Be helpful.",
+			messages: [{ role: "user", content: "Follow up", timestamp: 3 }],
+		});
+		expect(incremental.text).not.toContain("Cursor SDK tool boundary:");
+		expect(incremental.text).toContain("Continue the conversation using Cursor SDK capabilities only");
 	});
 });

--- a/test/cursor-mcp-timeout-override.test.ts
+++ b/test/cursor-mcp-timeout-override.test.ts
@@ -79,17 +79,17 @@ describe("Cursor MCP timeout override", () => {
 		expect(isCursorSdkMcpToolTimeoutStack(stack.replace(/node_modules\/\@cursor\/sdk/g, "src"))).toBe(false);
 	});
 
-	it("wires the override before Cursor provider Agent.create", () => {
+	it("wires the override before Cursor session agent creation", () => {
 		const providerSource = readFileSync(join(process.cwd(), "src/cursor-provider.ts"), "utf8");
 		const installIndex = providerSource.indexOf("installCursorMcpToolTimeoutOverride();");
-		const createIndex = providerSource.indexOf("Agent.create({");
+		const acquireIndex = providerSource.indexOf("acquireSessionCursorAgent(sessionAgentAcquireParams)");
 
 		expect(providerSource).toContain(
 			'import { installCursorMcpToolTimeoutOverride } from "./cursor-mcp-timeout-override.js";',
 		);
 		expect(installIndex).toBeGreaterThanOrEqual(0);
-		expect(createIndex).toBeGreaterThanOrEqual(0);
-		expect(installIndex).toBeLessThan(createIndex);
+		expect(acquireIndex).toBeGreaterThanOrEqual(0);
+		expect(installIndex).toBeLessThan(acquireIndex);
 	});
 
 	it("extends only the Cursor SDK MCP tool-call default timeout", () => {

--- a/test/cursor-pi-tool-bridge.test.ts
+++ b/test/cursor-pi-tool-bridge.test.ts
@@ -7,6 +7,7 @@ import { Type } from "typebox";
 import {
 	__testUtils,
 	buildCursorPiToolBridgeSnapshot,
+	buildCursorPiToolBridgeSurfaceSignature,
 	registerCursorPiToolBridge,
 	resolveCursorPiToolBridgeBuiltinsEnabled,
 	resolveCursorPiToolBridgeDebugEnabled,
@@ -790,6 +791,26 @@ describe("cursor pi tool bridge loopback MCP lifecycle", () => {
 		}
 	});
 
+	it("rejects MCP calls when no live run handler is bound", async () => {
+		const registry = __testUtils.createRegistry(
+			createMockPi({ active: ["read"], tools: [createToolInfo("read")] }),
+			{ PI_CURSOR_EXPOSE_BUILTIN_TOOLS: "1" },
+		);
+		const run = await registry.createRun({ onToolRequest: () => {} });
+		run.setOnToolRequest(undefined);
+		const { client, transport } = await connectClient(run.mcpServers!.pi_tools.url);
+		try {
+			const callPromise = client.callTool({ name: "pi__read", arguments: { path: "README.md" } });
+			const error = await callPromise.catch((callError: unknown) => callError);
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toMatch(/no active live run|MCP error/i);
+		} finally {
+			await client.close().catch(() => undefined);
+			await transport.close().catch(() => undefined);
+			await run.dispose();
+		}
+	});
+
 	it("rejects pending MCP waits on abort/dispose", async () => {
 		const registry = __testUtils.createRegistry(
 			createMockPi({ active: ["read"], tools: [createToolInfo("read")] }),
@@ -812,5 +833,14 @@ describe("cursor pi tool bridge loopback MCP lifecycle", () => {
 			await transport.close().catch(() => undefined);
 			await run.dispose();
 		}
+	});
+
+	it("changes the bridge surface signature when tool schema changes but the MCP name stays the same", () => {
+		const schema = Type.Object({ target: Type.String() });
+		const schemaV2 = Type.Object({ target: Type.String(), force: Type.Optional(Type.Boolean()) });
+		const snapshotA = buildCursorPiToolBridgeSnapshot(createMockPi({ active: ["sem_reindex"], tools: [createToolInfo("sem_reindex", "Reindex", schema)] }));
+		const snapshotB = buildCursorPiToolBridgeSnapshot(createMockPi({ active: ["sem_reindex"], tools: [createToolInfo("sem_reindex", "Reindex", schemaV2)] }));
+
+		expect(buildCursorPiToolBridgeSurfaceSignature(snapshotA)).not.toBe(buildCursorPiToolBridgeSurfaceSignature(snapshotB));
 	});
 });

--- a/test/cursor-provider.test.ts
+++ b/test/cursor-provider.test.ts
@@ -325,6 +325,7 @@ describe("streamCursor", () => {
 		delete process.env.PI_CURSOR_EXPOSE_BUILTIN_TOOLS;
 		expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(0);
 		cursorProviderTestUtils.resetCursorNativeReplayIdleDisposeMs();
+		await cursorProviderTestUtils.resetSessionCursorAgents();
 		cursorSessionCwdTestUtils.reset();
 		nativeToolDisplayTestUtils.reset();
 		modelDiscoveryTestUtils.registerModelItems(cursorModelItems);
@@ -1970,7 +1971,7 @@ describe("streamCursor", () => {
 		}
 	});
 
-	it("disposes abandoned native replay runs after the idle timeout", async () => {
+	it("disposes abandoned native replay runs after the idle timeout and abandons the session agent", async () => {
 		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
 		cursorProviderTestUtils.setCursorNativeReplayIdleDisposeMs(1);
 		const registeredTools: RegisteredTool[] = [];
@@ -2019,7 +2020,7 @@ describe("streamCursor", () => {
 		expect(mockDispose).toHaveBeenCalledTimes(1);
 	});
 
-	it("cleans up pending native replay runs when replay aborts mid-flight", async () => {
+	it("cleans up pending native replay runs when replay aborts mid-flight and abandons the session agent", async () => {
 		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
 		const registeredTools: RegisteredTool[] = [];
 		await registerNativeToolDisplayForTest(registeredTools);
@@ -3149,7 +3150,7 @@ describe("streamCursor", () => {
 		expect(message).not.toContain("super-secret-key-12345");
 	});
 
-	it("disposes agent on success", async () => {
+	it("keeps the session agent alive after a successful text-only turn", async () => {
 		const mockDispose = vi.fn().mockResolvedValue(undefined);
 		const mockSend = vi.fn().mockResolvedValue({
 			id: "run-1",
@@ -3168,10 +3169,10 @@ describe("streamCursor", () => {
 		const stream = streamCursor(makeModel(), makeContext(), { apiKey: "test-key" });
 		await collectEvents(stream);
 
-		expect(mockDispose).toHaveBeenCalledTimes(1);
+		expect(mockDispose).not.toHaveBeenCalled();
 	});
 
-	it("disposes agent on error", async () => {
+	it("disposes the session agent after a send error", async () => {
 		const mockDispose = vi.fn().mockResolvedValue(undefined);
 		const mockSend = vi.fn().mockRejectedValue(new Error("boom"));
 		mockedCreate.mockResolvedValue({
@@ -3183,6 +3184,341 @@ describe("streamCursor", () => {
 		await collectEvents(stream);
 
 		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("recreates the session agent on the next turn after a send error", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		let sendCallCount = 0;
+		const mockSend = vi.fn().mockImplementation(async () => {
+			sendCallCount += 1;
+			if (sendCallCount === 1) {
+				throw new Error("boom");
+			}
+			return {
+				id: "run-2",
+				agentId: "agent-2",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-2", status: "finished", result: "Recovered" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockImplementation(async () => ({
+			agentId: `agent-${mockedCreate.mock.calls.length + 1}`,
+			send: mockSend,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		const errorEvents = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		expect(getErrorEvent(errorEvents).reason).toBe("error");
+
+		const recoveryEvents = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		expect(getDoneEvent(recoveryEvents).reason).toBe("stop");
+		expect(mockedCreate).toHaveBeenCalledTimes(2);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("reuses the session agent and sends an incremental prompt on follow-up turns", async () => {
+		const mockSend = vi.fn().mockImplementation(async (message: { text?: string }) => {
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: message.text ?? "" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const firstContext = makeContext();
+		await collectEvents(streamCursor(makeModel(), firstContext, { apiKey: "test-key" }));
+
+		const followUpContext = makeContext();
+		followUpContext.messages = [
+			...firstContext.messages,
+			{ role: "assistant", content: [{ type: "text", text: "Hi there." }], api: "cursor-sdk", provider: "cursor", model: "test-model", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+			{ role: "user", content: "Follow up", timestamp: 3 },
+		];
+		await collectEvents(streamCursor(makeModel(), followUpContext, { apiKey: "test-key" }));
+
+		expect(mockedCreate).toHaveBeenCalledTimes(1);
+		expect(mockSend).toHaveBeenCalledTimes(2);
+		const firstPrompt = mockSend.mock.calls[0]?.[0] as { text?: string };
+		const secondPrompt = mockSend.mock.calls[1]?.[0] as { text?: string };
+		expect(firstPrompt.text).toContain("Cursor SDK tool boundary:");
+		expect(firstPrompt.text).toContain("User: Hello");
+		expect(secondPrompt.text).toContain("User: Follow up");
+		expect(secondPrompt.text).not.toContain("User: Hello");
+	});
+
+	it("recreates the session agent when context diverges and sends a full bootstrap prompt", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const mockSend = vi.fn().mockImplementation(async () => ({
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "ok" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		}));
+		mockedCreate.mockImplementation(async () => ({
+			agentId: `agent-${mockedCreate.mock.calls.length + 1}`,
+			send: mockSend,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+
+		const divergentContext = makeContext();
+		divergentContext.messages = [{ role: "user", content: "Hello edited", timestamp: 1 }];
+		await collectEvents(streamCursor(makeModel(), divergentContext, { apiKey: "test-key" }));
+
+		expect(mockedCreate).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+		const secondPrompt = mockSend.mock.calls[1]?.[0] as { text?: string };
+		expect(secondPrompt.text).toContain("Cursor SDK tool boundary:");
+		expect(secondPrompt.text).toContain("User: Hello edited");
+	});
+
+	it("recreates the session agent when branch-shrunk context diverges", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const mockSend = vi.fn().mockImplementation(async () => ({
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "ok" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		}));
+		mockedCreate.mockImplementation(async () => ({
+			agentId: `agent-${mockedCreate.mock.calls.length + 1}`,
+			send: mockSend,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		const firstContext = makeContext();
+		await collectEvents(streamCursor(makeModel(), firstContext, { apiKey: "test-key" }));
+
+		const followUpContext = makeContext();
+		followUpContext.messages = [
+			...firstContext.messages,
+			{
+				role: "assistant",
+				content: [{ type: "text", text: "Hi there." }],
+				api: "cursor-sdk",
+				provider: "cursor",
+				model: "test-model",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+				stopReason: "stop",
+				timestamp: 2,
+			},
+			{ role: "user", content: "Follow up", timestamp: 3 },
+		];
+		await collectEvents(streamCursor(makeModel(), followUpContext, { apiKey: "test-key" }));
+
+		const shrunkContext = makeContext();
+		await collectEvents(streamCursor(makeModel(), shrunkContext, { apiKey: "test-key" }));
+
+		expect(mockedCreate).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+		const thirdPrompt = mockSend.mock.calls[2]?.[0] as { text?: string };
+		expect(thirdPrompt.text).toContain("Cursor SDK tool boundary:");
+		expect(thirdPrompt.text).toContain("User: Hello");
+	});
+
+	it("recreates the session agent when the API key changes between turns", async () => {
+		const mockSend = vi.fn().mockResolvedValue({
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "key-a" }));
+		await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "key-b" }));
+
+		expect(mockedCreate).toHaveBeenCalledTimes(2);
+	});
+
+	it("rebinds bridge onToolRequest when reusing the session agent on a follow-up turn", async () => {
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		process.env.PI_CURSOR_EXPOSE_BUILTIN_TOOLS = "1";
+		registerBridgeForProviderTest({
+			active: ["read"],
+			tools: [createBuiltinToolInfo("read", Type.Object({ path: Type.String() }), "Read files")],
+		});
+
+		let turn2OnDelta: CursorDeltaHandler | undefined;
+		let resolveTurn2Run: (result: { id: string; status: "finished"; result: string }) => void = () => {};
+		let sendCallCount = 0;
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler; onStep: CursorStepHandler }) => {
+			sendCallCount += 1;
+			if (sendCallCount === 1) {
+				opts.onDelta({ update: { type: "text-delta", text: "Hello" } });
+				return {
+					id: "run-1",
+					agentId: "agent-1",
+					status: "finished",
+					wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "Hello" }),
+					cancel: vi.fn(),
+					supports: () => true,
+					unsupportedReason: () => undefined,
+				};
+			}
+
+			turn2OnDelta = opts.onDelta;
+			return {
+				id: "run-2",
+				agentId: "agent-1",
+				status: "running",
+				wait: vi.fn(
+					() =>
+						new Promise<{ id: string; status: "finished"; result: string }>((resolve) => {
+							resolveTurn2Run = resolve;
+						}),
+				),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const firstContext = makeContext();
+		await collectEvents(streamCursor(makeModel("composer-2"), firstContext, { apiKey: "test-key" }));
+
+		const followUpContext = makeContext();
+		followUpContext.messages = [
+			...firstContext.messages,
+			{ role: "assistant", content: [{ type: "text", text: "Hello" }], api: "cursor-sdk", provider: "cursor", model: "test-model", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+			{ role: "user", content: "Read README", timestamp: 3 },
+		];
+
+		const secondEventsPromise = collectEvents(streamCursor(makeModel("composer-2"), followUpContext, { apiKey: "test-key" }));
+		await vi.waitFor(() => expect(mockSend).toHaveBeenCalledTimes(2));
+
+		const createOptions = getCreatedAgentOptions();
+		const { client, transport } = await connectMcpClient(createOptions.mcpServers.pi_tools.url);
+		try {
+			const readCallPromise = client.callTool({ name: "pi__read", arguments: { path: "README.md" } });
+			turn2OnDelta?.({ update: { type: "tool-call-started", callId: "mcp-read", toolCall: { name: "mcp", args: { toolName: "pi__read" } } } });
+
+			const secondEvents = await secondEventsPromise;
+			const secondDone = getDoneEvent(secondEvents);
+			const toolCalls = secondDone.message.content.filter(isToolCallBlock);
+
+			expect(mockedCreate).toHaveBeenCalledTimes(1);
+			expect(secondDone.reason).toBe("toolUse");
+			expect(toolCalls).toHaveLength(1);
+			expect(toolCalls[0]?.name).toBe("read");
+			expect(toolCalls[0]?.arguments).toEqual({ path: "README.md" });
+
+			const readToolResultMessage = {
+				role: "toolResult" as const,
+				toolCallId: toolCalls[0]!.id,
+				toolName: "read",
+				content: [{ type: "text" as const, text: "file contents" }],
+				isError: false,
+				timestamp: 4,
+			};
+			const replayContext = makeContext();
+			replayContext.messages = [...followUpContext.messages, secondDone.message, readToolResultMessage];
+			const replayEventsPromise = collectEvents(streamCursor(makeModel("composer-2"), replayContext, { apiKey: "test-key" }));
+			await expect(readCallPromise).resolves.toMatchObject({ content: [{ type: "text", text: "file contents" }] });
+			resolveTurn2Run({ id: "run-2", status: "finished", result: "Done reading." });
+			const replayEvents = await replayEventsPromise;
+
+			expect(getDoneEvent(replayEvents).reason).toBe("stop");
+		} finally {
+			await client.close().catch(() => undefined);
+			await transport.close().catch(() => undefined);
+		}
+	});
+
+	it("surfaces live-run wait error status as a provider error", async () => {
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+			opts.onDelta({ update: { type: "text-delta", text: "partial" } });
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "error",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "error", result: "Cursor SDK run failed" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const events = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		const error = getErrorEvent(events);
+
+		expect(error.reason).toBe("error");
+		expect(error.error.errorMessage).toContain("Cursor SDK run failed");
+		expect(hasEventType(events, "done")).toBe(false);
+	});
+
+	it("rejects late bridge MCP calls after a successful live run is released", async () => {
+		process.env.PI_CURSOR_EXPOSE_BUILTIN_TOOLS = "1";
+		registerBridgeForProviderTest({
+			active: ["read"],
+			tools: [createBuiltinToolInfo("read", Type.Object({ path: Type.String() }), "Read files")],
+		});
+
+		const mockSend = vi.fn().mockResolvedValue({
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "Hello" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		await collectEvents(streamCursor(makeModel("composer-2"), makeContext(), { apiKey: "test-key" }));
+
+		const createOptions = getCreatedAgentOptions();
+		const { client, transport } = await connectMcpClient(createOptions.mcpServers!.pi_tools.url);
+		try {
+			const callPromise = client.callTool({ name: "pi__read", arguments: { path: "README.md" } });
+			const error = await callPromise.catch((callError: unknown) => callError);
+			expect(error).toBeInstanceOf(Error);
+			expect((error as Error).message).toMatch(/no active live run|MCP error/i);
+		} finally {
+			await client.close().catch(() => undefined);
+			await transport.close().catch(() => undefined);
+		}
 	});
 
 	it("redacts common secret-bearing fields in Cursor SDK error messages", async () => {
@@ -3462,6 +3798,7 @@ describe("streamCursor", () => {
 		expect(getCreatedAgentOptions().mcpServers).toBeUndefined();
 
 		await cursorPiToolBridgeTestUtils.resetRegisteredBridgeForTests();
+		await cursorProviderTestUtils.resetSessionCursorAgents();
 		vi.clearAllMocks();
 		process.env.PI_CURSOR_EXPOSE_BUILTIN_TOOLS = "1";
 		registerBridgeForProviderTest({
@@ -3506,6 +3843,7 @@ describe("streamCursor", () => {
 		expect(getCreatedAgentOptions().mcpServers).toBeUndefined();
 
 		await cursorPiToolBridgeTestUtils.resetRegisteredBridgeForTests();
+		await cursorProviderTestUtils.resetSessionCursorAgents();
 		delete process.env.PI_CURSOR_PI_TOOL_BRIDGE;
 		delete process.env.PI_CURSOR_EXPOSE_BUILTIN_TOOLS;
 		vi.clearAllMocks();
@@ -3777,7 +4115,7 @@ describe("streamCursor", () => {
 		expect(hasEventType(events, "toolcall_start")).toBe(false);
 	});
 
-	it("rejects pending bridge MCP waits and clears live runs on idle disposal", async () => {
+	it("rejects pending bridge MCP waits, clears live runs on idle disposal, and abandons the session agent", async () => {
 		process.env.PI_CURSOR_EXPOSE_BUILTIN_TOOLS = "1";
 		cursorProviderTestUtils.setCursorNativeReplayIdleDisposeMs(1);
 		registerBridgeForProviderTest({
@@ -3816,7 +4154,7 @@ describe("streamCursor", () => {
 			await vi.waitFor(() => expect(cursorProviderTestUtils.pendingCursorNativeRunCount()).toBe(0));
 			const error = await callErrorPromise;
 			expect(error).toBeInstanceOf(Error);
-			expect((error as Error).message).toMatch(/disposed|MCP error/i);
+			expect((error as Error).message).toMatch(/disposed|cancelled|MCP error/i);
 			expect(mockDispose).toHaveBeenCalledTimes(1);
 		} finally {
 			await client.close().catch(() => undefined);

--- a/test/cursor-session-agent.test.ts
+++ b/test/cursor-session-agent.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "@earendil-works/pi-ai";
+import { shouldBootstrapCursorSend, computeCursorContextFingerprint } from "../src/context.js";
+import { __testUtils as cursorSessionScopeTestUtils, registerCursorSessionScope } from "../src/cursor-session-scope.js";
+import {
+	acquireSessionCursorAgent,
+	registerCursorSessionAgent,
+	__testUtils as sessionAgentTestUtils,
+} from "../src/cursor-session-agent.js";
+
+function makeContext(messages: Context["messages"]): Context {
+	return {
+		systemPrompt: "Be helpful.",
+		messages,
+	};
+}
+
+describe("cursor-session-agent", () => {
+	beforeEach(async () => {
+		cursorSessionScopeTestUtils.reset();
+		await sessionAgentTestUtils.disposeAllSessionCursorAgents();
+		vi.clearAllMocks();
+	});
+
+	it("reuses the same SDK agent for the same pi session scope", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockResolvedValue({
+			agentId: "agent-1",
+			[Symbol.asyncDispose]: mockDispose,
+		});
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const first = await acquireSessionCursorAgent(params);
+		const second = await acquireSessionCursorAgent(params);
+
+		expect(first.created).toBe(true);
+		expect(second.created).toBe(false);
+		expect(first.agent).toBe(second.agent);
+		expect(createAgent).toHaveBeenCalledTimes(1);
+		expect(mockDispose).not.toHaveBeenCalled();
+	});
+
+	it("invalidates and recreates the session agent after compaction", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockImplementation(async () => ({
+			agentId: `agent-${createAgent.mock.calls.length + 1}`,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const first = await acquireSessionCursorAgent(params);
+		sessionAgentTestUtils.invalidateSessionAgent("/tmp/sessions/test.jsonl");
+		const second = await acquireSessionCursorAgent(params);
+
+		expect(first.agent).not.toBe(second.agent);
+		expect(createAgent).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("disposes in-flight Agent.create results after session disposal without recreating", async () => {
+		const mockDisposeLate = vi.fn().mockResolvedValue(undefined);
+		let resolveLateCreate: (agent: unknown) => void = () => {};
+		const createAgent = vi.fn().mockImplementation(
+			() =>
+				new Promise((resolve) => {
+					resolveLateCreate = resolve;
+				}),
+		);
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const acquirePromise = acquireSessionCursorAgent(params);
+		await vi.waitFor(() => expect(createAgent).toHaveBeenCalledTimes(1));
+		await sessionAgentTestUtils.disposeSessionCursorAgent("/tmp/sessions/test.jsonl");
+		resolveLateCreate({
+			agentId: "agent-late",
+			[Symbol.asyncDispose]: mockDisposeLate,
+		});
+
+		await expect(acquirePromise).rejects.toBeInstanceOf(sessionAgentTestUtils.SessionCursorAgentScopeClosedError);
+		expect(mockDisposeLate).toHaveBeenCalledTimes(1);
+		expect(createAgent).toHaveBeenCalledTimes(1);
+		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/test.jsonl")).toBe(false);
+		await expect(acquireSessionCursorAgent(params)).rejects.toBeInstanceOf(sessionAgentTestUtils.SessionCursorAgentScopeClosedError);
+	});
+
+	it("does not retry a superseded in-flight acquire when replaced by a different pool key", async () => {
+		const mockDisposeLate = vi.fn().mockResolvedValue(undefined);
+		const mockDisposeReplacement = vi.fn().mockResolvedValue(undefined);
+		let resolveLateCreate: (agent: unknown) => void = () => {};
+		let createCount = 0;
+		const createAgent = vi.fn().mockImplementation(async () => {
+			createCount += 1;
+			if (createCount === 1) {
+				return new Promise((resolve) => {
+					resolveLateCreate = resolve;
+				});
+			}
+			return {
+				agentId: "agent-replacement",
+				[Symbol.asyncDispose]: mockDisposeReplacement,
+			};
+		});
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const baseParams = {
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const firstAcquirePromise = acquireSessionCursorAgent({ ...baseParams, apiKey: "key-a" });
+		await vi.waitFor(() => expect(createAgent).toHaveBeenCalledTimes(1));
+		const secondAcquirePromise = acquireSessionCursorAgent({ ...baseParams, apiKey: "key-b" });
+		await vi.waitFor(() => expect(createAgent).toHaveBeenCalledTimes(2));
+		resolveLateCreate({
+			agentId: "agent-late",
+			[Symbol.asyncDispose]: mockDisposeLate,
+		});
+
+		await expect(firstAcquirePromise).rejects.toBeInstanceOf(sessionAgentTestUtils.SessionCursorAgentCreationSupersededError);
+		const secondLease = await secondAcquirePromise;
+
+		expect(mockDisposeLate).toHaveBeenCalledTimes(1);
+		expect(mockDisposeReplacement).not.toHaveBeenCalled();
+		expect(secondLease.agent).toMatchObject({ agentId: "agent-replacement" });
+		expect(createAgent).toHaveBeenCalledTimes(2);
+	});
+
+	it("clears invalidation before the first agent is created", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockResolvedValue({
+			agentId: "agent-1",
+			[Symbol.asyncDispose]: mockDispose,
+		});
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		sessionAgentTestUtils.invalidateSessionAgent("/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const first = await acquireSessionCursorAgent(params);
+		const second = await acquireSessionCursorAgent(params);
+
+		expect(first.created).toBe(true);
+		expect(second.created).toBe(false);
+		expect(first.agent).toBe(second.agent);
+		expect(createAgent).toHaveBeenCalledTimes(1);
+		expect(mockDispose).not.toHaveBeenCalled();
+	});
+
+	it("detects when a follow-up send should bootstrap after branch shrink", () => {
+		const sendState = {
+			bootstrapped: true,
+			contextFingerprint: computeCursorContextFingerprint({
+				messages: [
+					{ role: "user", content: "Hello", timestamp: 1 },
+					{ role: "assistant", content: [{ type: "text", text: "Hi" }], api: "cursor-sdk", provider: "cursor", model: "test", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+					{ role: "user", content: "More", timestamp: 3 },
+					{ role: "assistant", content: [{ type: "text", text: "Ok" }], api: "cursor-sdk", provider: "cursor", model: "test", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 4 },
+				],
+			}),
+		};
+		const context = makeContext([
+			{ role: "user", content: "Hello", timestamp: 1 },
+			{ role: "assistant", content: [{ type: "text", text: "Hi" }], api: "cursor-sdk", provider: "cursor", model: "test", usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } }, stopReason: "stop", timestamp: 2 },
+		]);
+
+		expect(shouldBootstrapCursorSend(sendState, context)).toBe(true);
+	});
+
+	it("recreates the session agent when the API key identity changes", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockImplementation(async () => ({
+			agentId: `agent-${createAgent.mock.calls.length + 1}`,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const baseParams = {
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		await acquireSessionCursorAgent({ ...baseParams, apiKey: "key-a" });
+		await acquireSessionCursorAgent({ ...baseParams, apiKey: "key-b" });
+
+		expect(createAgent).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("disposes the scoped session agent on session_shutdown", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockResolvedValue({
+			agentId: "agent-1",
+			[Symbol.asyncDispose]: mockDispose,
+		});
+		const sessionShutdownHandlers: Array<() => Promise<void> | void> = [];
+		const pi = {
+			on: vi.fn((event: string, handler: () => Promise<void> | void) => {
+				if (event === "session_shutdown") sessionShutdownHandlers.push(handler);
+			}),
+		};
+
+		registerCursorSessionAgent(pi);
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		await acquireSessionCursorAgent({
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		});
+
+		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/test.jsonl")).toBe(true);
+		await sessionShutdownHandlers[0]?.();
+		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/test.jsonl")).toBe(false);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("disposes the previous scope agent when the session file changes", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockResolvedValue({
+			agentId: "agent-1",
+			[Symbol.asyncDispose]: mockDispose,
+		});
+		const sessionStartHandlers: Array<(event: unknown, ctx: { cwd: string; sessionManager?: { getSessionFile?: () => string } }) => Promise<void> | void> = [];
+		const pi = {
+			on: vi.fn((event: string, handler: (event: unknown, ctx: { cwd: string; sessionManager?: { getSessionFile?: () => string } }) => Promise<void> | void) => {
+				if (event === "session_start") sessionStartHandlers.push(handler);
+			}),
+		};
+
+		registerCursorSessionScope(pi);
+		registerCursorSessionAgent(pi);
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/session-a.jsonl");
+		await acquireSessionCursorAgent({
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		});
+
+		for (const handler of sessionStartHandlers) {
+			await handler({}, { cwd: "/tmp/project", sessionManager: { getSessionFile: () => "/tmp/sessions/session-b.jsonl" } });
+		}
+
+		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/session-a.jsonl")).toBe(false);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/cursor-state.test.ts
+++ b/test/cursor-state.test.ts
@@ -47,7 +47,7 @@ const modelItems: ModelListItem[] = [
 	},
 ];
 
-type CursorFastTestModel = Pick<NonNullable<ExtensionContext["model"]>, "id" | "provider">;
+type CursorFastTestModel = Pick<NonNullable<ExtensionContext["model"]>, "id" | "provider" | "api">;
 type CursorFastTestContext = {
 	model: CursorFastTestModel | undefined;
 	ui: {
@@ -86,6 +86,7 @@ function createHarness(options: { modelId?: string; provider?: string; branch?: 
 			? {
 					provider: options.provider ?? "cursor",
 					id: options.modelId,
+					api: "cursor-sdk",
 				}
 			: undefined,
 		ui: {
@@ -330,5 +331,28 @@ describe("Cursor fast state", () => {
 		await handlers.get("session_start")({}, ctx);
 
 		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", undefined);
+	});
+
+	it("refreshes Cursor fast status on turn_start after session_start without a model", async () => {
+		const { ctx, handlers } = createHarness();
+		await handlers.get("session_start")({}, ctx);
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", undefined);
+
+		ctx.model = { provider: "cursor", id: "composer-2", api: "cursor-sdk" };
+		await handlers.get("turn_start")({}, ctx);
+
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", "cursor fast");
+	});
+
+	it("recognizes cursor-sdk api models when updating footer status", async () => {
+		const { ctx, handlers } = createHarness({
+			modelId: "composer-2",
+			provider: "other-provider",
+		});
+		ctx.model = { provider: "other-provider", id: "composer-2", api: "cursor-sdk" };
+
+		await handlers.get("turn_start")({}, ctx);
+
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", "cursor fast");
 	});
 });


### PR DESCRIPTION
## Summary
- Reuse a Cursor SDK `Agent` and pi bridge run within a pi session when model, cwd, fast mode, setting sources, API key identity, and bridge tool surface match.
- Add session-scoped agent lifecycle handling for shutdown, model/context divergence, tool-surface changes, errors, aborts, and in-flight creation races.
- Send incremental prompts on append-only follow-up turns, while recreating the Cursor agent for divergent branches before a full bootstrap prompt.
- Refresh Cursor fast footer status when the selected model becomes available at turn start and when models identify as `api: cursor-sdk`.

## Validation
- `npm run typecheck`
- `npm test`
- `git diff --check`
- `npm pack --dry-run`
- Live smoke: `PI_CURSOR_SETTING_SOURCES=none pi --no-extensions -e . --model cursor/composer-2.5 --thinking off --no-session -p 'test. say OK'`
- Live smoke: two-turn JSON mode with `PI_CURSOR_SETTING_SOURCES=none`
- Live smoke: two-turn JSON mode with default `PI_CURSOR_SETTING_SOURCES=all`

## Notes
- Release version/changelog updates are intentionally deferred until after this PR merges to `main`.
