### PR TITLE
Fix Cursor session agent behavior for pi /tree navigation

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import type { Context, Message, ToolCall } from "@earendil-works/pi-ai";
+import { convertToLlm } from "@earendil-works/pi-coding-agent";
 import type { SDKImage } from "@cursor/sdk";
 import { getCursorPiBridgeContractText } from "./cursor-bridge-contract.js";
 import { getCursorReplayPromptLabel } from "./cursor-tool-names.js";
@@ -18,6 +19,10 @@ export interface CursorPromptOptions {
 export const CURSOR_APPROX_CHARS_PER_TOKEN = 4;
 export const CURSOR_IMAGE_TOKEN_ESTIMATE = 1200;
 const SECTION_SEPARATOR = "\n\n";
+
+function normalizePiContextMessages(messages: Context["messages"]): Message[] {
+	return convertToLlm(messages as Parameters<typeof convertToLlm>[0]);
+}
 
 function isTextBlock(block: { type: string }): block is { type: "text"; text: string } {
 	return block.type === "text";
@@ -215,6 +220,48 @@ function serializeMessageForFingerprint(message: Message, index: number): string
 	}
 }
 
+function serializeRawPiMessageForFingerprint(message: Context["messages"][number], index: number): string {
+	const role = (message as { role?: string }).role;
+	switch (role) {
+		case "branchSummary": {
+			const entry = message as { summary?: string; fromId?: string; timestamp?: number };
+			return hashCursorContextValue(
+				`branchSummary:${entry.timestamp ?? index}:${entry.fromId ?? ""}:${entry.summary ?? ""}`,
+			);
+		}
+		case "compactionSummary": {
+			const entry = message as { summary?: string; tokensBefore?: number; timestamp?: number };
+			return hashCursorContextValue(
+				`compactionSummary:${entry.timestamp ?? index}:${entry.tokensBefore ?? ""}:${entry.summary ?? ""}`,
+			);
+		}
+		case "custom": {
+			const entry = message as { customType?: string; content?: unknown; timestamp?: number };
+			return hashCursorContextValue(
+				`custom:${entry.timestamp ?? index}:${entry.customType ?? ""}:${JSON.stringify(entry.content)}`,
+			);
+		}
+		case "bashExecution": {
+			const entry = message as {
+				command?: string;
+				output?: string;
+				exitCode?: number | null;
+				cancelled?: boolean;
+				excludeFromContext?: boolean;
+				timestamp?: number;
+			};
+			if (entry.excludeFromContext) {
+				return hashCursorContextValue(`bashExecution:excluded:${entry.timestamp ?? index}`);
+			}
+			return hashCursorContextValue(
+				`bashExecution:${entry.timestamp ?? index}:${entry.command ?? ""}:${entry.output ?? ""}:${entry.exitCode ?? ""}:${entry.cancelled === true}`,
+			);
+		}
+		default:
+			return serializeMessageForFingerprint(message as Message, index);
+	}
+}
+
 function parseCursorContextFingerprint(fingerprint: string): CursorContextFingerprintPayload | undefined {
 	try {
 		const parsed = JSON.parse(fingerprint) as CursorContextFingerprintPayload;
@@ -229,7 +276,7 @@ function parseCursorContextFingerprint(fingerprint: string): CursorContextFinger
 export function computeCursorContextFingerprint(context: Context): string {
 	const payload: CursorContextFingerprintPayload = {
 		systemHash: hashCursorContextValue(context.systemPrompt ?? ""),
-		messageHashes: context.messages.map((message, index) => serializeMessageForFingerprint(message, index)),
+		messageHashes: context.messages.map((message, index) => serializeRawPiMessageForFingerprint(message, index)),
 	};
 	return JSON.stringify(payload);
 }
@@ -245,6 +292,12 @@ export function shouldBootstrapCursorSend(
 	if (!current) return true;
 	if (current.systemHash !== previous.systemHash) return true;
 	if (current.messageHashes.length < previous.messageHashes.length) return true;
+	if (current.messageHashes.length > previous.messageHashes.length) {
+		for (let index = previous.messageHashes.length; index < context.messages.length; index += 1) {
+			const role = (context.messages[index] as { role?: string }).role;
+			if (role === "branchSummary" || role === "compactionSummary") return true;
+		}
+	}
 	for (let index = 0; index < previous.messageHashes.length; index += 1) {
 		if (current.messageHashes[index] !== previous.messageHashes[index]) return true;
 	}
@@ -253,8 +306,9 @@ export function shouldBootstrapCursorSend(
 
 export function buildCursorIncrementalPrompt(context: Context, options: CursorPromptOptions = {}): CursorPrompt {
 	// Incremental sends omit the full Cursor SDK tool boundary block; the session agent retains prior bootstrap context.
-	const latestUserMessageIndex = getLatestUserMessageIndex(context.messages);
-	const latestUserMessage = latestUserMessageIndex >= 0 ? context.messages[latestUserMessageIndex] : undefined;
+	const messages = normalizePiContextMessages(context.messages);
+	const latestUserMessageIndex = getLatestUserMessageIndex(messages);
+	const latestUserMessage = latestUserMessageIndex >= 0 ? messages[latestUserMessageIndex] : undefined;
 	const latestUserText = latestUserMessage ? formatMessage(latestUserMessage) : undefined;
 	const sections = [
 		"Continue the conversation using Cursor SDK capabilities only. Do not list, promise, or call pi-only tools from earlier context as if they were available.",
@@ -263,7 +317,7 @@ export function buildCursorIncrementalPrompt(context: Context, options: CursorPr
 		sections.push(`System instructions from pi:\n${sanitizeSystemPromptForCursor(context.systemPrompt)}`);
 	}
 	if (latestUserText) sections.push(latestUserText);
-	const images = extractLatestImages(context.messages);
+	const images = extractLatestImages(messages);
 	const imageTokenReserve = images.length * (options.imageTokenEstimate ?? 0);
 	const budgetOptions =
 		options.maxInputTokens === undefined
@@ -312,7 +366,8 @@ export function buildCursorPrompt(context: Context, options: CursorPromptOptions
 		sectionsBeforeMessages.push(`System instructions from pi:\n${sanitizeSystemPromptForCursor(context.systemPrompt)}`);
 	}
 
-	const messageSections = context.messages
+	const messages = normalizePiContextMessages(context.messages);
+	const messageSections = messages
 		.map((msg, index) => {
 			const text = formatMessage(msg);
 			return text ? { index, text } : undefined;
@@ -324,7 +379,7 @@ export function buildCursorPrompt(context: Context, options: CursorPromptOptions
 			"If web research is requested, do not claim it unless a Cursor web/search/browser/MCP tool ran.",
 		].join("\n"),
 	];
-	const images = extractLatestImages(context.messages);
+	const images = extractLatestImages(messages);
 	const imageTokenReserve = images.length * (options.imageTokenEstimate ?? 0);
 	const budgetOptions =
 		options.maxInputTokens === undefined
@@ -334,7 +389,7 @@ export function buildCursorPrompt(context: Context, options: CursorPromptOptions
 		sectionsBeforeMessages,
 		messageSections,
 		sectionsAfterMessages,
-		getLatestUserMessageIndex(context.messages),
+		getLatestUserMessageIndex(messages),
 		budgetOptions,
 	);
 	const text = parts.join(SECTION_SEPARATOR);

--- a/src/cursor-session-agent.ts
+++ b/src/cursor-session-agent.ts
@@ -1,4 +1,10 @@
-import type { ExtensionHandler, SessionCompactEvent, SessionShutdownEvent, SessionTreeEvent } from "@earendil-works/pi-coding-agent";
+import type {
+	ExtensionHandler,
+	SessionBeforeTreeEvent,
+	SessionCompactEvent,
+	SessionShutdownEvent,
+	SessionTreeEvent,
+} from "@earendil-works/pi-coding-agent";
 import { createHash } from "node:crypto";
 import { Agent } from "@cursor/sdk";
 import type { ModelSelection, SDKAgent, SettingSource } from "@cursor/sdk";
@@ -74,6 +80,7 @@ interface SessionCursorAgentCreateParams {
 interface CursorSessionAgentExtensionApi {
 	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
 	on(event: "session_compact", handler: ExtensionHandler<SessionCompactEvent>): void;
+	on(event: "session_before_tree", handler: ExtensionHandler<SessionBeforeTreeEvent>): void;
 	on(event: "session_tree", handler: ExtensionHandler<SessionTreeEvent>): void;
 	on(event: "model_select", handler: ExtensionHandler<{ model: unknown }>): void;
 }
@@ -337,8 +344,11 @@ export function registerCursorSessionAgent(_pi: CursorSessionAgentExtensionApi):
 	_pi.on("session_compact", () => {
 		invalidateSessionAgent();
 	});
-	_pi.on("session_tree", () => {
+	_pi.on("session_before_tree", () => {
 		invalidateSessionAgent();
+	});
+	_pi.on("session_tree", async () => {
+		await resetSessionCursorAgent();
 	});
 	_pi.on("model_select", () => {
 		invalidateSessionAgent();

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -555,4 +555,65 @@ describe("buildCursorSendPrompt", () => {
 		expect(incremental.text).not.toContain("Cursor SDK tool boundary:");
 		expect(incremental.text).toContain("Continue the conversation using Cursor SDK capabilities only");
 	});
+
+	it("includes branch summaries from /tree navigation in bootstrap prompts", () => {
+		const context: Context = {
+			messages: [
+				{ role: "user", content: "Hello", timestamp: 1 },
+				{
+					role: "branchSummary",
+					summary: "We explored approach A and decided against it.",
+					fromId: "entry-a",
+					timestamp: 2,
+				} as Context["messages"][number],
+				{ role: "user", content: "Continue on approach B", timestamp: 3 },
+			],
+		};
+
+		const prompt = buildCursorPrompt(context);
+
+		expect(prompt.text).toContain("summary of a branch that this conversation came back from");
+		expect(prompt.text).toContain("We explored approach A and decided against it.");
+		expect(prompt.text).toContain("User: Continue on approach B");
+	});
+
+	it("rebootstraps when /tree adds a branch summary to the active context", () => {
+		const priorContext: Context = {
+			messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+		};
+		const treeContext: Context = {
+			messages: [
+				{ role: "user", content: "Hello", timestamp: 1 },
+				{
+					role: "branchSummary",
+					summary: "Abandoned branch details",
+					fromId: "entry-a",
+					timestamp: 2,
+				} as Context["messages"][number],
+			],
+		};
+		const sendState = { bootstrapped: true, contextFingerprint: computeCursorContextFingerprint(priorContext) };
+
+		expect(shouldBootstrapCursorSend(sendState, treeContext)).toBe(true);
+		expect(buildCursorSendPrompt(treeContext, {}, sendState).bootstrap).toBe(true);
+	});
+
+	it("includes compaction summaries in bootstrap prompts", () => {
+		const context: Context = {
+			messages: [
+				{
+					role: "compactionSummary",
+					summary: "Earlier work covered auth setup.",
+					tokensBefore: 12000,
+					timestamp: 1,
+				} as Context["messages"][number],
+				{ role: "user", content: "Continue", timestamp: 2 },
+			],
+		};
+
+		const prompt = buildCursorPrompt(context);
+
+		expect(prompt.text).toContain("conversation history before this point was compacted");
+		expect(prompt.text).toContain("Earlier work covered auth setup.");
+	});
 });

--- a/test/cursor-provider.test.ts
+++ b/test/cursor-provider.test.ts
@@ -35,6 +35,7 @@ vi.mock("@cursor/sdk", () => {
 
 import { Agent, createAgentPlatform } from "@cursor/sdk";
 import { __testUtils as cursorSessionCwdTestUtils } from "../src/cursor-session-cwd.js";
+import { __testUtils as sessionAgentTestUtils } from "../src/cursor-session-agent.js";
 import { streamCursor, __testUtils as cursorProviderTestUtils } from "../src/cursor-provider.js";
 import { estimateCursorPromptMessageTokens } from "../src/context.js";
 import { registerCursorPiToolBridge, __testUtils as cursorPiToolBridgeTestUtils } from "../src/cursor-pi-tool-bridge.js";
@@ -3257,6 +3258,66 @@ describe("streamCursor", () => {
 		expect(firstPrompt.text).toContain("User: Hello");
 		expect(secondPrompt.text).toContain("User: Follow up");
 		expect(secondPrompt.text).not.toContain("User: Hello");
+	});
+
+	it("recreates the session agent after session-tree invalidation", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const mockSend = vi.fn().mockResolvedValue({
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "ok" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		});
+		mockedCreate.mockImplementation(async () => ({
+			agentId: `agent-${mockedCreate.mock.calls.length + 1}`,
+			send: mockSend,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		sessionAgentTestUtils.invalidateSessionAgent();
+		await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+
+		expect(mockedCreate).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("bootstraps with branch summary context after /tree navigation", async () => {
+		const mockSend = vi.fn().mockImplementation(async (message: { text?: string }) => ({
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: message.text ?? "" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		}));
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const treeContext = makeContext();
+		treeContext.messages = [
+			{ role: "user", content: "Hello", timestamp: 1 },
+			{
+				role: "branchSummary",
+				summary: "We explored approach A and rejected it.",
+				fromId: "entry-a",
+				timestamp: 2,
+			} as Context["messages"][number],
+			{ role: "user", content: "Continue on approach B", timestamp: 3 },
+		];
+
+		await collectEvents(streamCursor(makeModel(), treeContext, { apiKey: "test-key" }));
+
+		const prompt = mockSend.mock.calls[0]?.[0] as { text?: string };
+		expect(prompt.text).toContain("We explored approach A and rejected it.");
+		expect(prompt.text).toContain("User: Continue on approach B");
 	});
 
 	it("recreates the session agent when context diverges and sends a full bootstrap prompt", async () => {

--- a/test/cursor-session-agent.test.ts
+++ b/test/cursor-session-agent.test.ts
@@ -272,4 +272,87 @@ describe("cursor-session-agent", () => {
 		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/session-a.jsonl")).toBe(false);
 		expect(mockDispose).toHaveBeenCalledTimes(1);
 	});
+
+	it("invalidates and recreates the session agent after session_tree-style invalidation", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockImplementation(async () => ({
+			agentId: `agent-${createAgent.mock.calls.length + 1}`,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const first = await acquireSessionCursorAgent(params);
+		sessionAgentTestUtils.invalidateSessionAgent("/tmp/sessions/test.jsonl");
+		const second = await acquireSessionCursorAgent(params);
+
+		expect(first.agent).not.toBe(second.agent);
+		expect(createAgent).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("resets the scoped session agent when session_tree fires", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockResolvedValue({
+			agentId: "agent-1",
+			[Symbol.asyncDispose]: mockDispose,
+		});
+		const sessionTreeHandlers: Array<() => Promise<void> | void> = [];
+		const pi = {
+			on: vi.fn((event: string, handler: () => Promise<void> | void) => {
+				if (event === "session_tree") sessionTreeHandlers.push(handler);
+			}),
+		};
+
+		registerCursorSessionAgent(pi);
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		await acquireSessionCursorAgent({
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		});
+
+		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/test.jsonl")).toBe(true);
+		await sessionTreeHandlers[0]?.();
+		expect(sessionAgentTestUtils.sessionAgentsByScope.has("/tmp/sessions/test.jsonl")).toBe(false);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it("invalidates before branch summary when session_before_tree fires", async () => {
+		const mockDispose = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockImplementation(async () => ({
+			agentId: `agent-${createAgent.mock.calls.length + 1}`,
+			[Symbol.asyncDispose]: mockDispose,
+		}));
+		const sessionBeforeTreeHandlers: Array<() => void> = [];
+		const pi = {
+			on: vi.fn((event: string, handler: () => void) => {
+				if (event === "session_before_tree") sessionBeforeTreeHandlers.push(handler);
+			}),
+		};
+
+		registerCursorSessionAgent(pi);
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const first = await acquireSessionCursorAgent(params);
+		sessionBeforeTreeHandlers[0]?.();
+		const second = await acquireSessionCursorAgent(params);
+
+		expect(first.agent).not.toBe(second.agent);
+		expect(createAgent).toHaveBeenCalledTimes(2);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
 });


### PR DESCRIPTION
## Summary
- Normalize pi `/tree` and compaction messages (`branchSummary`, `compactionSummary`, etc.) into Cursor bootstrap prompts via `convertToLlm`.
- Fingerprint raw pi message roles so branch/compaction boundaries trigger rebootstrapping instead of incremental sends.
- Invalidate the session agent on `session_before_tree` (before branch-summary LLM) and reset it on `session_tree` (after navigation).

## Test plan
- [x] `npm run typecheck`
- [x] `npm test` (268/268)
- [ ] Live smoke: `/tree` without summary → continue on branch, agent reuses correctly after bootstrap
- [ ] Live smoke: `/tree` with branch summary → next turn includes summary text in Cursor context