### PR TITLE
Bump pi dev dependency baseline to 0.75.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+- Bump pi dev dependency baseline to `0.75.5` for read-tool collapsed-card rendering, package update fixes, and other upstream pi changes. Cursor edit replay remains display-only via `diffString`; pi's new SDK `details.patch` field is not required because Cursor agents do not execute pi's edit tool.
+
 ### Added
 
 - Add packaged smoke-script entrypoints for the partial live smoke helper, steering RPC smoke, and smoke JSONL validator.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
 				"@modelcontextprotocol/sdk": "^1.29.0"
 			},
 			"devDependencies": {
-				"@earendil-works/pi-ai": "^0.75.3",
-				"@earendil-works/pi-coding-agent": "^0.75.3",
-				"@earendil-works/pi-tui": "^0.75.3",
+				"@earendil-works/pi-ai": "^0.75.5",
+				"@earendil-works/pi-coding-agent": "^0.75.5",
+				"@earendil-works/pi-tui": "^0.75.5",
 				"typebox": "^1.1.38",
 				"typescript": "^6.0.3",
 				"vitest": "^4.1.6"
@@ -82,47 +82,6 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@aws-crypto/sha256-js": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
@@ -160,100 +119,26 @@
 				"tslib": "^2.6.2"
 			}
 		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/is-array-buffer": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^2.2.0",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
 		"node_modules/@aws-sdk/client-bedrock-runtime": {
-			"version": "3.1041.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1041.0.tgz",
-			"integrity": "sha512-1QehYO3jhdvNQ5mOKtwIiNV04y4aywaNZw9HzCp7SSYCX4yy+AGXc2hhYjCiMDUvQPIELuvbR8MXw81NGAj8ZQ==",
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/credential-provider-node": "^3.972.39",
-				"@aws-sdk/eventstream-handler-node": "^3.972.14",
-				"@aws-sdk/middleware-eventstream": "^3.972.10",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.38",
-				"@aws-sdk/middleware-websocket": "^3.972.16",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/token-providers": "3.1041.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
 				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.24",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.17",
-				"@smithy/eventstream-serde-browser": "^4.2.14",
-				"@smithy/eventstream-serde-config-resolver": "^4.3.14",
-				"@smithy/eventstream-serde-node": "^4.2.14",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.7",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
 				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.49",
-				"@smithy/util-defaults-mode-node": "^4.2.54",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -261,25 +146,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.974.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
-			"integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+			"version": "3.974.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.13.tgz",
+			"integrity": "sha512-+Y5/4tHki0uYgyx8eun146DegRVQBpdKGK5RbV0FTKJPpaKTchvqVxrrRFK6Wk0JksO4iAZKw3eqxGEIwtO98w==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/xml-builder": "^3.972.22",
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/types": "^3.973.9",
+				"@aws-sdk/xml-builder": "^3.972.25",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.3",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.2",
+				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -287,16 +166,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
-			"integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.39.tgz",
+			"integrity": "sha512-29wX9zpAvEt1vcj0psha+y6ygBHy2V/S72mp6e7q0KARLWXq+pwE/lR6qGkwknQvruh52lXvlqZIga8Hdxkucw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -304,21 +183,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.972.36",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
-			"integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.41.tgz",
+			"integrity": "sha512-IA3CQTjtJkb6u1H4mE4936c8OPBMa9Jggtwe8U2Mqw/vvb/tZ5Ebd0mcZcX0uKWQhOyYo/+qNIwkV5Xh+FeJJA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/fetch-http-handler": "^5.4.3",
+				"@smithy/node-http-handler": "^4.7.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -326,25 +202,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
-			"integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.43.tgz",
+			"integrity": "sha512-4mzII+3mZEVXXE1xzrLQrCJL7/r62A63bA6SVzZoNL5rqCJghpf+xgGltVrIBBs0n+mOZBKrQl2tRREtvZ5l6A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/credential-provider-env": "^3.972.34",
-				"@aws-sdk/credential-provider-http": "^3.972.36",
-				"@aws-sdk/credential-provider-login": "^3.972.38",
-				"@aws-sdk/credential-provider-process": "^3.972.34",
-				"@aws-sdk/credential-provider-sso": "^3.972.38",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/credential-provider-env": "^3.972.39",
+				"@aws-sdk/credential-provider-http": "^3.972.41",
+				"@aws-sdk/credential-provider-login": "^3.972.43",
+				"@aws-sdk/credential-provider-process": "^3.972.39",
+				"@aws-sdk/credential-provider-sso": "^3.972.43",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.43",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -352,19 +227,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
-			"integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.43.tgz",
+			"integrity": "sha512-HG7kQCwXtbv3oBV61Ins0oNX8KKyvrMqqRkb6ZiAfQHbMuHaiNaEb2KnpKLPkNpqImSBK82UkVE/kaY6IfWikA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -372,23 +245,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.972.39",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
-			"integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+			"version": "3.972.44",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.44.tgz",
+			"integrity": "sha512-sDaBIT0yrNNIPfvlsiTCmANm07zKju+ipWODjEXgZlsjMeIJR3LVp7RDyAOzUoAsTbDfYKDWp+i5WrFiQP6rmQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "^3.972.34",
-				"@aws-sdk/credential-provider-http": "^3.972.36",
-				"@aws-sdk/credential-provider-ini": "^3.972.38",
-				"@aws-sdk/credential-provider-process": "^3.972.34",
-				"@aws-sdk/credential-provider-sso": "^3.972.38",
-				"@aws-sdk/credential-provider-web-identity": "^3.972.38",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/credential-provider-env": "^3.972.39",
+				"@aws-sdk/credential-provider-http": "^3.972.41",
+				"@aws-sdk/credential-provider-ini": "^3.972.43",
+				"@aws-sdk/credential-provider-process": "^3.972.39",
+				"@aws-sdk/credential-provider-sso": "^3.972.43",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.43",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -396,17 +268,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.972.34",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
-			"integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.39.tgz",
+			"integrity": "sha512-2k/amBifLd75eXNwgvPw/2lKYSQ3NhvHQgkVKVjfUq13/eJ3JRtHmznuFenn74OK3sSfp4SMy1YB2w+UVXoKqA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -414,19 +285,36 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
-			"integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.43.tgz",
+			"integrity": "sha512-LPc3+Y4vhH1T4x6CMqwCM6hk5+SRf/Lwmgm8INm95wxTtIRHcMwQUVkDzWu4Iw/RSncxYM2BC01OrYbxOPZvyg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/token-providers": "3.1041.0",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/token-providers": "3.1052.0",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1052.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1052.0.tgz",
+			"integrity": "sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -434,18 +322,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
-			"integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+			"version": "3.972.43",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.43.tgz",
+			"integrity": "sha512-wQtL34lUD/09VXjwAUo2T+I3aEXRDxMB3DKmTJL/Zj0Gi6sLDTrVhae1XVt01yzkquOWajI/sZW72JGDZ1ciTw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/nested-clients": "^3.997.11",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -453,15 +340,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/eventstream-handler-node": {
-			"version": "3.972.14",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.14.tgz",
-			"integrity": "sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==",
+			"version": "3.972.17",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.17.tgz",
+			"integrity": "sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -469,109 +356,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-eventstream": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.10.tgz",
-			"integrity": "sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==",
+			"version": "3.972.13",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.13.tgz",
+			"integrity": "sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
-			"integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
-			"integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
-			"integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws/lambda-invoke-store": "^0.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.972.37",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
-			"integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-arn-parser": "^3.972.3",
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.972.38",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
-			"integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-retry": "^4.3.6",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -579,23 +372,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-websocket": {
-			"version": "3.972.16",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.16.tgz",
-			"integrity": "sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==",
+			"version": "3.972.21",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.21.tgz",
+			"integrity": "sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-format-url": "^3.972.10",
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/eventstream-serde-browser": "^4.2.14",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/fetch-http-handler": "^5.4.3",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -603,67 +391,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.997.6",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
-			"integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+			"version": "3.997.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.11.tgz",
+			"integrity": "sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/middleware-host-header": "^3.972.10",
-				"@aws-sdk/middleware-logger": "^3.972.10",
-				"@aws-sdk/middleware-recursion-detection": "^3.972.11",
-				"@aws-sdk/middleware-user-agent": "^3.972.38",
-				"@aws-sdk/region-config-resolver": "^3.972.13",
-				"@aws-sdk/signature-v4-multi-region": "^3.996.25",
-				"@aws-sdk/types": "^3.973.8",
-				"@aws-sdk/util-endpoints": "^3.996.8",
-				"@aws-sdk/util-user-agent-browser": "^3.972.10",
-				"@aws-sdk/util-user-agent-node": "^3.973.24",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/core": "^3.23.17",
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/hash-node": "^4.2.14",
-				"@smithy/invalid-dependency": "^4.2.14",
-				"@smithy/middleware-content-length": "^4.2.14",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-retry": "^4.5.7",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-body-length-node": "^4.2.3",
-				"@smithy/util-defaults-mode-browser": "^4.3.49",
-				"@smithy/util-defaults-mode-node": "^4.2.54",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/region-config-resolver": {
-			"version": "3.972.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
-			"integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/core": "^3.974.13",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.28",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/fetch-http-handler": "^5.4.3",
+				"@smithy/node-http-handler": "^4.7.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -671,17 +413,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.996.25",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
-			"integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+			"version": "3.996.28",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.28.tgz",
+			"integrity": "sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "^3.972.37",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/signature-v4": "^5.3.14",
-				"@smithy/types": "^4.14.1",
+				"@aws-sdk/types": "^3.973.9",
+				"@smithy/core": "^3.24.3",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -689,17 +430,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.1041.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
-			"integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "^3.974.8",
-				"@aws-sdk/nested-clients": "^3.997.6",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
 				"@aws-sdk/types": "^3.973.8",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
+				"@smithy/core": "^3.24.2",
 				"@smithy/types": "^4.14.1",
 				"tslib": "^2.6.2"
 			},
@@ -708,59 +448,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.973.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"version": "3.973.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
+			"integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-arn-parser": {
-			"version": "3.972.3",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
-			"integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.996.8",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
-			"integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-endpoints": "^3.4.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			}
-		},
-		"node_modules/@aws-sdk/util-format-url": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
-			"integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -780,55 +474,16 @@
 				"node": ">=20.0.0"
 			}
 		},
-		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.972.10",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
-			"integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/types": "^4.14.1",
-				"bowser": "^2.11.0",
-				"tslib": "^2.6.2"
-			}
-		},
-		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.973.24",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
-			"integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "^3.972.38",
-				"@aws-sdk/types": "^3.973.8",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=20.0.0"
-			},
-			"peerDependencies": {
-				"aws-crt": ">=1.0.0"
-			},
-			"peerDependenciesMeta": {
-				"aws-crt": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@aws-sdk/xml-builder": {
-			"version": "3.972.22",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
-			"integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+			"version": "3.972.25",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.25.tgz",
+			"integrity": "sha512-GH+Kjz4nPKWKHnsiQpnhP1MJdTGIcK4rAka6tzakgjjUkVgNsmPeEbbRAf09SzS1hjGu6duGHCBsxYke0BhHjQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@nodable/entities": "2.1.0",
-				"@smithy/types": "^4.14.1",
-				"fast-xml-parser": "5.7.2",
+				"@smithy/types": "^4.14.2",
+				"fast-xml-parser": "5.7.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -975,38 +630,23 @@
 				"win32"
 			]
 		},
-		"node_modules/@earendil-works/pi-agent-core": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.3.tgz",
-			"integrity": "sha512-azg09GSrckQa3ffbH09YEZC7DyHgmNSX+vmWEoEhQvp4icbzqbqLfIeMayMNEK/aGusm1SghZC4bPlDdagDALg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@earendil-works/pi-ai": "^0.75.3",
-				"ignore": "^7.0.5",
-				"typebox": "^1.1.24",
-				"yaml": "^2.8.2"
-			},
-			"engines": {
-				"node": ">=22.19.0"
-			}
-		},
 		"node_modules/@earendil-works/pi-ai": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.3.tgz",
-			"integrity": "sha512-UKccS+ADlkSVJ49a00346jUfXmUi6zzzB+pPWotsyA6SxhKr2ejjkGQksGyR1DyNVrsEP/WWlsOSTUUwVlzNaA==",
+			"version": "0.75.5",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+			"integrity": "sha512-zf1F5kXk1pqZeFShXOqq9ibUk8QdtRoLCDPAjO+hj44e3EUs9/GFO2qnhTC5+JA2uwVCx+WCNe1PiCjlBYWm5w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@anthropic-ai/sdk": "^0.91.1",
-				"@aws-sdk/client-bedrock-runtime": "^3.1030.0",
-				"@google/genai": "^1.40.0",
-				"@mistralai/mistralai": "^2.2.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.1",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
 				"openai": "6.26.0",
-				"partial-json": "^0.1.7",
-				"typebox": "^1.1.24"
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
 			},
 			"bin": {
 				"pi-ai": "dist/cli.js"
@@ -1016,29 +656,30 @@
 			}
 		},
 		"node_modules/@earendil-works/pi-coding-agent": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.3.tgz",
-			"integrity": "sha512-LIi5/CdUBfcLp3BAtpLx1BfnHDLmDOQVdzYfS1H9fjjCw2dcPr9voSI5ncrhvZdgyFSnfHck4BCbNcfZk+TEHQ==",
+			"version": "0.75.5",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.5.tgz",
+			"integrity": "sha512-O3CCQDYy28D4uwtP6zZkdEwzHN6X22v49Sb0+SZTC7x37V/YfmogrWPiaFoWeoc2hmdKhSATI7ZAK5bQbJG5NA==",
 			"dev": true,
+			"hasShrinkwrap": true,
 			"license": "MIT",
 			"dependencies": {
-				"@earendil-works/pi-agent-core": "^0.75.3",
-				"@earendil-works/pi-ai": "^0.75.3",
-				"@earendil-works/pi-tui": "^0.75.3",
-				"@silvia-odwyer/photon-node": "^0.3.4",
-				"chalk": "^5.5.0",
-				"cross-spawn": "^7.0.6",
-				"diff": "^8.0.2",
-				"glob": "^13.0.1",
-				"highlight.js": "^10.7.3",
-				"hosted-git-info": "^9.0.2",
-				"ignore": "^7.0.5",
-				"jiti": "^2.7.0",
-				"minimatch": "^10.2.3",
-				"proper-lockfile": "^4.1.2",
-				"typebox": "^1.1.24",
-				"undici": "^8.3.0",
-				"yaml": "^2.8.2"
+				"@earendil-works/pi-agent-core": "^0.75.5",
+				"@earendil-works/pi-ai": "^0.75.5",
+				"@earendil-works/pi-tui": "^0.75.5",
+				"@silvia-odwyer/photon-node": "0.3.4",
+				"chalk": "5.6.2",
+				"cross-spawn": "7.0.6",
+				"diff": "8.0.4",
+				"glob": "13.0.6",
+				"highlight.js": "10.7.3",
+				"hosted-git-info": "9.0.3",
+				"ignore": "7.0.5",
+				"jiti": "2.7.0",
+				"minimatch": "10.2.5",
+				"proper-lockfile": "4.1.2",
+				"typebox": "1.1.38",
+				"undici": "8.3.0",
+				"yaml": "2.9.0"
 			},
 			"bin": {
 				"pi": "dist/cli.js"
@@ -1047,24 +688,1907 @@
 				"node": ">=22.19.0"
 			},
 			"optionalDependencies": {
-				"@mariozechner/clipboard": "^0.3.6"
+				"@mariozechner/clipboard": "0.3.6"
 			}
 		},
-		"node_modules/@earendil-works/pi-tui": {
-			"version": "0.75.3",
-			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.3.tgz",
-			"integrity": "sha512-UbhtCsae+b3Y8/ZxtBPhiOrkD66gOHvJbfvLZwhBBsNtQuvUkZY5t9MQwmb8QcDYkFRnXHaq3FcEy1hjRSfj6w==",
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@anthropic-ai/sdk": {
+			"version": "0.91.1",
+			"resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+			"integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"get-east-asian-width": "^1.3.0",
-				"marked": "^15.0.12"
+				"json-schema-to-ts": "^3.1.1"
+			},
+			"bin": {
+				"anthropic-ai-sdk": "bin/cli"
+			},
+			"peerDependencies": {
+				"zod": "^3.25.0 || ^4.0.0"
+			},
+			"peerDependenciesMeta": {
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/crc32": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+			"integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-browser": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+			"integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-js": "^5.2.0",
+				"@aws-crypto/supports-web-crypto": "^5.2.0",
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"@aws-sdk/util-locate-window": "^3.0.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/sha256-js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+			"integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/util": "^5.2.0",
+				"@aws-sdk/types": "^3.222.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/supports-web-crypto": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+			"integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-crypto/util": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+			"integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.222.0",
+				"@smithy/util-utf8": "^2.0.0",
+				"tslib": "^2.6.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/client-bedrock-runtime": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1048.0.tgz",
+			"integrity": "sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-node": "^3.972.42",
+				"@aws-sdk/eventstream-handler-node": "^3.972.16",
+				"@aws-sdk/middleware-eventstream": "^3.972.12",
+				"@aws-sdk/middleware-websocket": "^3.972.19",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/core": {
+			"version": "3.974.11",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.11.tgz",
+			"integrity": "sha512-QpnINq5FZH6EOaDEkmHdT7eUunbvD27pDNQypaWjFyYz7Zl1q3UCMQErBZxpmfGfI7MvI2TlK8KTkgNpv8b1ug==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@aws-sdk/xml-builder": "^3.972.24",
+				"@aws/lambda-invoke-store": "^0.2.2",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"bowser": "^2.11.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-env": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.37.tgz",
+			"integrity": "sha512-/jpPvEh6f7ntmIzf7dNxoNX6Q8vt8UpesCjbW6mFfk4V1NW6bIy9qxcQ6WbA8As5yQhsZOe+xeNd4xHX8kdY2Q==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-http": {
+			"version": "3.972.39",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.39.tgz",
+			"integrity": "sha512-pIgTpisWyWg7X1bUbzSjuUYosYTD0Ghz2M0hkSTmb3a6i3qV3uU+NYJPI/E2XSC0HcsZh5rsLPzeXrkb2DS0Cg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-ini": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.41.tgz",
+			"integrity": "sha512-u2tyjaxJJzW8UtW4SM1ZcPMDwO6y+kV+llvou+Adts0FAKyzes5jG4izQN+KX3yE8ZROpS5y1LJ//xL2iSf76w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-login": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-login": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.41.tgz",
+			"integrity": "sha512-0LBitxXiAiaE5nlFPfpNIww/8FRY/I7WIndWsc9GmNFOM7cE1wNpVNQEGEk9Outg5l8xl+3vybxFyUy4l9q/LQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-node": {
+			"version": "3.972.42",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.42.tgz",
+			"integrity": "sha512-D4oon2zbqqsWOJUM99Gm3/ZyJ0IJvTXVN3PyloGb3kQEyI36fjCZheZj422lAgTWWd6TSHgiImLt3RIaLdv3dQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/credential-provider-env": "^3.972.37",
+				"@aws-sdk/credential-provider-http": "^3.972.39",
+				"@aws-sdk/credential-provider-ini": "^3.972.41",
+				"@aws-sdk/credential-provider-process": "^3.972.37",
+				"@aws-sdk/credential-provider-sso": "^3.972.41",
+				"@aws-sdk/credential-provider-web-identity": "^3.972.41",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/credential-provider-imds": "^4.3.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-process": {
+			"version": "3.972.37",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.37.tgz",
+			"integrity": "sha512-7nVaHBUaWIddASYfVaA9O4D5ZVjewU3sCol9WqZPGfW0nR+0WqE0xHZnD/U2L33PlOB8KNXGKZ6wOES/QijKzg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-sso": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.41.tgz",
+			"integrity": "sha512-IOWAWEHe5LkjSKkkUUX9ciV6Y1scHTsnfEkdt5yyC4Slrc7AGbkLPrpntjqh18ksJAMOaVhoBsO8p2WyTcY2wQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/token-providers": "3.1048.0",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/credential-provider-web-identity": {
+			"version": "3.972.41",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.41.tgz",
+			"integrity": "sha512-mbACk9Yypa8nm4iGZLs0PofOXEcTDOUw6wDnsPXNDNSd2WNXs1tSo+6nc/fh0jLYdfVZThhBL98PHW4aXFsG5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/eventstream-handler-node": {
+			"version": "3.972.16",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
+			"integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-eventstream": {
+			"version": "3.972.12",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
+			"integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/middleware-websocket": {
+			"version": "3.972.19",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.19.tgz",
+			"integrity": "sha512-mkEhOGYozqKQkbFaVrjwr0faiwwZza1v5/jSY6Tucm3bD+uKTazIUH/4Yo6aMnQD2ua2W9cMP6s8mvwTcjtqHw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/nested-clients": {
+			"version": "3.997.9",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.9.tgz",
+			"integrity": "sha512-jPR3rnmRI4hWYyzfmTGBr7NblMp8QYYeflHXba1H6+7CGrWVqWKQzaXFQ4qbExqPRsXN3T3L3JxFhr6aouXUGQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/sha256-browser": "5.2.0",
+				"@aws-crypto/sha256-js": "5.2.0",
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/signature-v4-multi-region": "^3.996.27",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/fetch-http-handler": "^5.4.2",
+				"@smithy/node-http-handler": "^4.7.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/signature-v4-multi-region": {
+			"version": "3.996.27",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
+			"integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/signature-v4": "^5.4.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/token-providers": {
+			"version": "3.1048.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1048.0.tgz",
+			"integrity": "sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-sdk/core": "^3.974.11",
+				"@aws-sdk/nested-clients": "^3.997.9",
+				"@aws-sdk/types": "^3.973.8",
+				"@smithy/core": "^3.24.2",
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/types": {
+			"version": "3.973.8",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+			"integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/types": "^4.14.1",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/util-locate-window": {
+			"version": "3.965.5",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+			"integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws-sdk/xml-builder": {
+			"version": "3.972.24",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
+			"integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@nodable/entities": "2.1.0",
+				"@smithy/types": "^4.14.1",
+				"fast-xml-parser": "5.7.3",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@aws/lambda-invoke-store": {
+			"version": "0.2.4",
+			"resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+			"integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@babel/runtime": {
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+			"integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
+			"version": "0.75.5",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.5.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@earendil-works/pi-ai": "^0.75.5",
+				"ignore": "7.0.5",
+				"typebox": "1.1.38",
+				"yaml": "2.9.0"
 			},
 			"engines": {
 				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
+			"version": "0.75.5",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.5.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@anthropic-ai/sdk": "0.91.1",
+				"@aws-sdk/client-bedrock-runtime": "3.1048.0",
+				"@google/genai": "1.52.0",
+				"@mistralai/mistralai": "2.2.1",
+				"@smithy/node-http-handler": "4.7.3",
+				"http-proxy-agent": "7.0.2",
+				"https-proxy-agent": "7.0.6",
+				"openai": "6.26.0",
+				"partial-json": "0.1.7",
+				"typebox": "1.1.38"
+			},
+			"bin": {
+				"pi-ai": "dist/cli.js"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
+			"version": "0.75.5",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "15.0.12"
+			},
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@google/genai": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"google-auth-library": "^10.3.0",
+				"p-retry": "^4.6.2",
+				"protobufjs": "^7.5.4",
+				"ws": "^8.18.0"
+			},
+			"engines": {
+				"node": ">=20.0.0"
+			},
+			"peerDependencies": {
+				"@modelcontextprotocol/sdk": "^1.25.2"
+			},
+			"peerDependenciesMeta": {
+				"@modelcontextprotocol/sdk": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
+			"integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">= 10"
 			},
 			"optionalDependencies": {
-				"koffi": "^2.9.0"
+				"@mariozechner/clipboard-darwin-arm64": "0.3.6",
+				"@mariozechner/clipboard-darwin-universal": "0.3.6",
+				"@mariozechner/clipboard-darwin-x64": "0.3.6",
+				"@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
+				"@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
+				"@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
+				"@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
+				"@mariozechner/clipboard-linux-x64-musl": "0.3.6",
+				"@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
+				"@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-arm64": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
+			"integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-universal": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
+			"integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-darwin-x64": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
+			"integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
+			"integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
+			"integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
+			"integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
+			"integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-linux-x64-musl": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
+			"integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
+			"integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
+			"integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
+			"integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25.0 || ^4.0.0",
+				"zod-to-json-schema": "^3.25.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodable"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+			"integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/base64": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+			"integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/codegen": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/fetch": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/float": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+			"integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/path": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+			"integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/pool": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+			"integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/utf8": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@silvia-odwyer/photon-node": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+			"integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/core": {
+			"version": "3.24.3",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
+			"integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/credential-provider-imds": {
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
+			"integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/fetch-http-handler": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
+			"integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/is-array-buffer": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/node-http-handler": {
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/signature-v4": {
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
+			"integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/types": {
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-buffer-from": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/is-array-buffer": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@smithy/util-utf8": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@smithy/util-buffer-from": "^2.2.0",
+				"tslib": "^2.6.2"
+			},
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/@types/node": {
+			"version": "22.19.19",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+			"integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/agent-base": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/balanced-match": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/base64-js": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bignumber.js": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+			"integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/bowser": {
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+			"integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"balanced-match": "^4.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/buffer-equal-constant-time": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/chalk": {
+			"version": "5.6.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+			"integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^12.17.0 || ^14.13 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/cross-spawn": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"path-key": "^3.1.0",
+				"shebang-command": "^2.0.0",
+				"which": "^2.0.1"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/data-uri-to-buffer": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+			"integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/debug": {
+			"version": "4.4.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+			"integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ms": "^2.1.3"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"peerDependenciesMeta": {
+				"supports-color": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/diff": {
+			"version": "8.0.4",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
+			"integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ecdsa-sig-formatter": {
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+			"integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/extend": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-builder": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fast-xml-parser": {
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@nodable/entities": "^2.1.0",
+				"fast-xml-builder": "^1.1.7",
+				"path-expression-matcher": "^1.5.0",
+				"strnum": "^2.2.3"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/fetch-blob": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+			"integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"node-domexception": "^1.0.0",
+				"web-streams-polyfill": "^3.0.3"
+			},
+			"engines": {
+				"node": "^12.20 || >= 14.13"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/formdata-polyfill": {
+			"version": "4.0.10",
+			"resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+			"integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fetch-blob": "^3.1.2"
+			},
+			"engines": {
+				"node": ">=12.20.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gaxios": {
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+			"integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"extend": "^3.0.2",
+				"https-proxy-agent": "^7.0.1",
+				"node-fetch": "^3.3.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/gcp-metadata": {
+			"version": "8.1.2",
+			"resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+			"integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"gaxios": "^7.0.0",
+				"google-logging-utils": "^1.0.0",
+				"json-bigint": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/get-east-asian-width": {
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/glob": {
+			"version": "13.0.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"minimatch": "^10.2.2",
+				"minipass": "^7.1.3",
+				"path-scurry": "^2.0.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-auth-library": {
+			"version": "10.6.2",
+			"resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+			"integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"base64-js": "^1.3.0",
+				"ecdsa-sig-formatter": "^1.0.11",
+				"gaxios": "^7.1.4",
+				"gcp-metadata": "8.1.2",
+				"google-logging-utils": "1.1.3",
+				"jws": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/google-logging-utils": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+			"integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/graceful-fs": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/highlight.js": {
+			"version": "10.7.3",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+			"integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": "*"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/hosted-git-info": {
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+			"integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"lru-cache": "^11.1.0"
+			},
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/http-proxy-agent": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.0",
+				"debug": "^4.3.4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/https-proxy-agent": {
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "^7.1.2",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 14"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ignore": {
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/isexe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jiti": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+			"integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-bigint": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+			"integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bignumber.js": "^9.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/json-schema-to-ts": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+			"integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.18.3",
+				"ts-algebra": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jwa": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+			"integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"buffer-equal-constant-time": "^1.0.1",
+				"ecdsa-sig-formatter": "1.0.11",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/jws": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+			"integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jwa": "^2.0.1",
+				"safe-buffer": "^5.0.1"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/long": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+			"integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+			"dev": true,
+			"license": "Apache-2.0"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/lru-cache": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.4.0.tgz",
+			"integrity": "sha512-W+R+kFL4HgVxONq2bhXPi3bGpzGe/yEhVOp233qw9wCRtgncJ15P3bC+e4zZMu4Cq7d+WAJjXGW0uUkifhcatA==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
+			"version": "15.0.12",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"marked": "bin/marked.js"
+			},
+			"engines": {
+				"node": ">= 18"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
+			"version": "10.2.5",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+			"integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"brace-expansion": "^5.0.5"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/minipass": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ms": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-domexception": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/jimmywarting"
+				},
+				{
+					"type": "github",
+					"url": "https://paypal.me/jimmywarting"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.5.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/node-fetch": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+			"integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"data-uri-to-buffer": "^4.0.0",
+				"fetch-blob": "^3.1.4",
+				"formdata-polyfill": "^4.0.10"
+			},
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/node-fetch"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/openai": {
+			"version": "6.26.0",
+			"resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
+			"integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"openai": "bin/cli"
+			},
+			"peerDependencies": {
+				"ws": "^8.18.0",
+				"zod": "^3.25 || ^4.0"
+			},
+			"peerDependenciesMeta": {
+				"ws": {
+					"optional": true
+				},
+				"zod": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry": {
+			"version": "4.6.2",
+			"resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+			"integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/retry": "0.12.0",
+				"retry": "^0.13.1"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/p-retry/node_modules/@types/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/partial-json": {
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/partial-json/-/partial-json-0.1.7.tgz",
+			"integrity": "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-expression-matcher": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-key": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/path-scurry": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"dependencies": {
+				"lru-cache": "^11.0.0",
+				"minipass": "^7.1.2"
+			},
+			"engines": {
+				"node": "18 || 20 || >=22"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+			"integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.4",
+				"retry": "^0.12.0",
+				"signal-exit": "^3.0.2"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/proper-lockfile/node_modules/retry": {
+			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+			"integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
+			"version": "7.5.9",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
+			"integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@protobufjs/aspromise": "^1.1.2",
+				"@protobufjs/base64": "^1.1.2",
+				"@protobufjs/codegen": "^2.0.5",
+				"@protobufjs/eventemitter": "^1.1.0",
+				"@protobufjs/fetch": "^1.1.1",
+				"@protobufjs/float": "^1.0.2",
+				"@protobufjs/inquire": "^1.1.2",
+				"@protobufjs/path": "^1.1.2",
+				"@protobufjs/pool": "^1.1.0",
+				"@protobufjs/utf8": "^1.1.1",
+				"@types/node": ">=13.7.0",
+				"long": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/retry": {
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+			"integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"shebang-regex": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-regex": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/signal-exit": {
+			"version": "3.0.7",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
+			"license": "ISC"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/strnum": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ts-algebra": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+			"integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/tslib": {
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+			"dev": true,
+			"license": "0BSD"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
+			"version": "1.1.38",
+			"resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
+			"integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+			"integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/undici-types": {
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/web-streams-polyfill": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+			"integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/which": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"isexe": "^2.0.0"
+			},
+			"bin": {
+				"node-which": "bin/node-which"
+			},
+			"engines": {
+				"node": ">= 8"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
+			"version": "8.20.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+			"integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"dev": true,
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod": {
+			"version": "3.25.76",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+			"integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
+			}
+		},
+		"node_modules/@earendil-works/pi-coding-agent/node_modules/zod-to-json-schema": {
+			"version": "3.25.2",
+			"resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+			"integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+			"dev": true,
+			"license": "ISC",
+			"peerDependencies": {
+				"zod": "^3.25.28 || ^4"
+			}
+		},
+		"node_modules/@earendil-works/pi-tui": {
+			"version": "0.75.5",
+			"resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.5.tgz",
+			"integrity": "sha512-LkXUM1/49pvzzeI39Y5wjBMlgafcCf67HCLhB9Z7yuXHy4XgT+VqxWcZVW5hBdhQsHZd0znjJotfGH1BzxMfiA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "1.6.0",
+				"marked": "15.0.12"
+			},
+			"engines": {
+				"node": ">=22.19.0"
 			}
 		},
 		"node_modules/@emnapi/core": {
@@ -1102,9 +2626,9 @@
 			}
 		},
 		"node_modules/@google/genai": {
-			"version": "1.51.0",
-			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.51.0.tgz",
-			"integrity": "sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==",
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+			"integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -1478,21 +3002,20 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-			"integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+			"integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/fetch": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-			"integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+			"integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"@protobufjs/aspromise": "^1.1.1",
-				"@protobufjs/inquire": "^1.1.0"
+				"@protobufjs/aspromise": "^1.1.1"
 			}
 		},
 		"node_modules/@protobufjs/float": {
@@ -1503,9 +3026,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/inquire": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+			"integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -1819,40 +3342,15 @@
 			"dev": true,
 			"license": "Apache-2.0"
 		},
-		"node_modules/@smithy/config-resolver": {
-			"version": "4.4.17",
-			"resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
-			"integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-config-provider": "^4.2.2",
-				"@smithy/util-endpoints": "^3.4.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
 		"node_modules/@smithy/core": {
-			"version": "3.23.17",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
-			"integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+			"version": "3.24.4",
+			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.4.tgz",
+			"integrity": "sha512-3UNRKEyQyAgVgM0LGlerCLm+ChZWZ1GPfde+jBEW6bm6bSBGU1p0EbblaUV3unbhwvidjLA5Zs3sOs7mnZwvAw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-body-length-browser": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-stream": "^4.5.25",
-				"@smithy/util-utf8": "^4.2.2",
-				"@smithy/uuid": "^1.1.2",
+				"@aws-crypto/crc32": "5.2.0",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1860,91 +3358,14 @@
 			}
 		},
 		"node_modules/@smithy/credential-provider-imds": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
-			"integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.4.tgz",
+			"integrity": "sha512-vKW0MEFRU4Y3MkVZUkpJm+g9qyPGLCXhc0YLggUdSdBB4g7IaSSsCE75P9rBXyWHrXY1UYSQUl8/DwsTR7QciA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-codec": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
-			"integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@aws-crypto/crc32": "5.2.0",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-browser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
-			"integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-config-resolver": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
-			"integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
-			"integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-serde-universal": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/eventstream-serde-universal": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
-			"integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/eventstream-codec": "^4.2.14",
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.4",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1952,46 +3373,14 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.3.17",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
-			"integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.4.tgz",
+			"integrity": "sha512-qM7AUKI4G6d7lNgaZD3lA1tWSolh5r6gcixfTZAPstVURfjIbvreVTPz+994M0yC3HbX4YYhDRgr31Xy3XwWOQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/hash-node": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
-			"integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/invalid-dependency": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
-			"integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.4",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -1999,215 +3388,27 @@
 			}
 		},
 		"node_modules/@smithy/is-array-buffer": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
-			"integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+			"integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-content-length": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
-			"integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.4.32",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
-			"integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-serde": "^4.2.20",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"@smithy/url-parser": "^4.2.14",
-				"@smithy/util-middleware": "^4.2.14",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-retry": {
-			"version": "4.5.7",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
-			"integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/service-error-classification": "^4.3.1",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-retry": "^4.3.6",
-				"@smithy/uuid": "^1.1.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-serde": {
-			"version": "4.2.20",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
-			"integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/middleware-stack": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
-			"integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/node-config-provider": {
-			"version": "4.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
-			"integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/shared-ini-file-loader": "^4.4.9",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
-			"integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
+			"integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/querystring-builder": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/property-provider": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
-			"integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/protocol-http": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
-			"integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-builder": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
-			"integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/querystring-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
-			"integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/service-error-classification": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
-			"integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/shared-ini-file-loader": {
-			"version": "4.4.9",
-			"resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
-			"integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
+				"@smithy/core": "^3.24.3",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2215,38 +3416,14 @@
 			}
 		},
 		"node_modules/@smithy/signature-v4": {
-			"version": "5.3.14",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
-			"integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+			"version": "5.4.4",
+			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.4.tgz",
+			"integrity": "sha512-e5UtkMvsatzBfbeBZjEOt0k0Z3BEsjTFL/n6fdO5vtBLe67tdy0dX7xw2DU7uZ3acwoHyeCqpU2Fzb7pxwHb6Q==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-middleware": "^4.2.14",
-				"@smithy/util-uri-escape": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/smithy-client": {
-			"version": "4.12.13",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
-			"integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/core": "^3.23.17",
-				"@smithy/middleware-endpoint": "^4.4.32",
-				"@smithy/middleware-stack": "^4.2.14",
-				"@smithy/protocol-http": "^5.3.14",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-stream": "^4.5.25",
+				"@smithy/core": "^3.24.4",
+				"@smithy/types": "^4.14.2",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -2254,65 +3431,9 @@
 			}
 		},
 		"node_modules/@smithy/types": {
-			"version": "4.14.1",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
-			"integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/url-parser": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
-			"integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/querystring-parser": "^4.2.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-base64": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
-			"integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-browser": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
-			"integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-body-length-node": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
-			"integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+			"version": "4.14.2",
+			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
+			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -2323,182 +3444,31 @@
 			}
 		},
 		"node_modules/@smithy/util-buffer-from": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
-			"integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+			"integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/is-array-buffer": "^4.2.2",
+				"@smithy/is-array-buffer": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-config-provider": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
-			"integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.3.49",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
-			"integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.2.54",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
-			"integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/config-resolver": "^4.4.17",
-				"@smithy/credential-provider-imds": "^4.2.14",
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/property-provider": "^4.2.14",
-				"@smithy/smithy-client": "^4.12.13",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-endpoints": {
-			"version": "3.4.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
-			"integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/node-config-provider": "^4.3.14",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-hex-encoding": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
-			"integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-middleware": {
-			"version": "4.2.14",
-			"resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
-			"integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-retry": {
-			"version": "4.3.8",
-			"resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
-			"integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/service-error-classification": "^4.3.1",
-				"@smithy/types": "^4.14.1",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-stream": {
-			"version": "4.5.25",
-			"resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
-			"integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.3.17",
-				"@smithy/node-http-handler": "^4.6.1",
-				"@smithy/types": "^4.14.1",
-				"@smithy/util-base64": "^4.3.2",
-				"@smithy/util-buffer-from": "^4.2.2",
-				"@smithy/util-hex-encoding": "^4.2.2",
-				"@smithy/util-utf8": "^4.2.2",
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/util-uri-escape": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
-			"integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@smithy/util-utf8": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
-			"integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+			"integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/util-buffer-from": "^4.2.2",
+				"@smithy/util-buffer-from": "^2.2.0",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/@smithy/uuid": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
-			"integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.6.2"
-			},
-			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@standard-schema/spec": {
@@ -3406,9 +4376,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.7",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.7.tgz",
-			"integrity": "sha512-Yh7/7rQuMXICNr0oMYDR2yHP6oUvmQsTToFeOWj/kIDhAwQ+c4Ol/lbcwOmEM5OHYQmh6S6EQSQ1sljCKP36bQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -3418,13 +4388,14 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
+				"path-expression-matcher": "^1.5.0",
+				"xml-naming": "^0.1.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+			"version": "5.7.3",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
 			"dev": true,
 			"funding": [
 				{
@@ -3435,7 +4406,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.5",
+				"fast-xml-builder": "^1.1.7",
 				"path-expression-matcher": "^1.5.0",
 				"strnum": "^2.2.3"
 			},
@@ -3864,16 +4835,6 @@
 			],
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/ignore": {
-			"version": "7.0.5",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -3996,18 +4957,6 @@
 			"dependencies": {
 				"jwa": "^2.0.1",
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/koffi": {
-			"version": "2.16.2",
-			"resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-			"integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"funding": {
-				"url": "https://liberapay.com/Koromix"
 			}
 		},
 		"node_modules/lightningcss": {
@@ -4866,9 +5815,9 @@
 			}
 		},
 		"node_modules/protobufjs": {
-			"version": "7.5.6",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
-			"integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+			"integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
@@ -4876,15 +5825,15 @@
 				"@protobufjs/aspromise": "^1.1.2",
 				"@protobufjs/base64": "^1.1.2",
 				"@protobufjs/codegen": "^2.0.5",
-				"@protobufjs/eventemitter": "^1.1.0",
-				"@protobufjs/fetch": "^1.1.0",
+				"@protobufjs/eventemitter": "^1.1.1",
+				"@protobufjs/fetch": "^1.1.1",
 				"@protobufjs/float": "^1.0.2",
-				"@protobufjs/inquire": "^1.1.1",
+				"@protobufjs/inquire": "^1.1.2",
 				"@protobufjs/path": "^1.1.2",
 				"@protobufjs/pool": "^1.1.0",
 				"@protobufjs/utf8": "^1.1.1",
 				"@types/node": ">=13.7.0",
-				"long": "^5.0.0"
+				"long": "^5.3.2"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -5363,9 +6312,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+			"integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -5840,6 +6789,22 @@
 				"utf-8-validate": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -59,9 +59,9 @@
 		"typebox": "*"
 	},
 	"devDependencies": {
-		"@earendil-works/pi-ai": "^0.75.3",
-		"@earendil-works/pi-coding-agent": "^0.75.3",
-		"@earendil-works/pi-tui": "^0.75.3",
+		"@earendil-works/pi-ai": "^0.75.5",
+		"@earendil-works/pi-coding-agent": "^0.75.5",
+		"@earendil-works/pi-tui": "^0.75.5",
 		"typebox": "^1.1.38",
 		"typescript": "^6.0.3",
 		"vitest": "^4.1.6"


### PR DESCRIPTION
## Summary

- Bump `@earendil-works/pi-ai`, `pi-coding-agent`, and `pi-tui` dev dependencies from `^0.75.3` to `^0.75.5`.
- No extension code changes required: Cursor agents do not execute pi's edit tool, so pi's new SDK `details.patch` field does not apply here. Edit replay remains display-only via `diffString`.
- Investigated `compat.forceAdaptiveThinking`: not applicable to Cursor models. That flag is for custom Anthropic-compatible providers using `api: "anthropic-messages"`. This extension registers Cursor models as custom provider configs and streams through `@cursor/sdk`, not pi-ai's Anthropic API path.

## Validation

- [x] `npm run typecheck`
- [x] `npm test` (289 passed)
- [x] `npm pack --dry-run`
- [x] Interactive tmux TUI smoke (checklist section 3): `SUM=42`, exit 0, empty stderr, JSONL assistant usage valid, diagnostics safety scan clean

## Test plan

- [x] Unit + typecheck + pack
- [x] One interactive tmux live smoke with `cursor/composer-2.5`
- [ ] Full release checklist before publish (not requested for this PR)


Made with [Cursor](https://cursor.com)