### PR TITLE
Fix live smoke retry and TUI polling

### DIFF
--- a/docs/cursor-live-smoke-checklist.md
+++ b/docs/cursor-live-smoke-checklist.md
@@ -22,13 +22,13 @@ mkdir -p "$SMOKE_DIR"
 pi -e . --list-models cursor
 ```
 
-The repo also ships partial automation for the prerequisite/basic/default-settings/non-interactive math/steering/diagnostic/JSONL subset:
+The repo also ships partial automation for the prerequisite/basic/default-settings/non-interactive math/TUI output polling/steering/diagnostic/JSONL subset:
 
 ```bash
 npm run smoke:live
 ```
 
-The script is a helper only; it does not perform the visual/interactive TUI observation in section 3. Release readiness still requires the manual checks below for TUI behavior, bridge, standalone native replay, abort/cancel, packaging, cleanup, and any touched runtime surface not covered by the helper.
+The script is a helper only; it polls the section 3 TUI for answer/footer evidence and then cleans up the tmux session, but it does not replace manual visual review of the full TUI checklist. Release readiness still requires the manual checks below for detailed TUI behavior, bridge, standalone native replay, abort/cancel, packaging, cleanup, and any touched runtime surface not covered by the helper.
 
 Pass criteria:
 

--- a/scripts/tmux-live-smoke.sh
+++ b/scripts/tmux-live-smoke.sh
@@ -39,10 +39,10 @@ Prerequisites:
 
 Coverage:
   - prereq model listing
-  - basic non-interactive prompt, with one bounded retry for empty timeout exits
-  - default ambient settings prompt
-  - simple non-interactive math prompt
-  - interactive TUI output/footer polling with cleanup
+  - basic non-interactive prompt (retry-empty-timeout; strict output assertion)
+  - default ambient settings prompt (strict; no retry)
+  - simple non-interactive math prompt (strict; no retry)
+  - interactive TUI math/footer polling with cleanup
   - RPC steering after native replay tool execution (tmux-isolated)
   - diagnostics safety scan
   - JSONL assistant usage validation
@@ -159,14 +159,21 @@ run_direct_attempt() {
 	return $?
 }
 
+run_direct_fail() {
+	local name="$1"
+	local code="$2"
+	local stderr="$3"
+	cat "$stderr" >&2 || true
+	fail "$name exited $code"
+}
+
 run_direct() {
 	local name="$1"
 	local timeout_secs="$2"
-	shift 2
+	local policy="$3"
+	shift 3
 	local stdout="$SMOKE_DIR/${name}.stdout.txt"
 	local stderr="$SMOKE_DIR/${name}.stderr.txt"
-	local first_stdout="$SMOKE_DIR/${name}.attempt1.stdout.txt"
-	local first_stderr="$SMOKE_DIR/${name}.attempt1.stderr.txt"
 	local code=0
 
 	if run_direct_attempt "$name" "$timeout_secs" "$stdout" "$stderr" "$@"; then
@@ -175,25 +182,35 @@ run_direct() {
 	fi
 	code=$?
 
-	if is_empty_timeout_exit "$code" "$stdout"; then
-		mv "$stdout" "$first_stdout" 2>/dev/null || true
-		mv "$stderr" "$first_stderr" 2>/dev/null || true
-		log "$name retrying once after empty timeout-like exit $code"
-		if run_direct_attempt "$name" "$timeout_secs" "$stdout" "$stderr" "$@"; then
-			log "$name PASS after retry (first exit $code; first stderr: $first_stderr)"
-			return 0
-		fi
-		local retry_code=$?
-		printf '[smoke] %s first attempt exited %s with empty stdout; retry exited %s\n' "$name" "$code" "$retry_code" >&2
-		printf '[smoke] %s first stderr tail:\n' "$name" >&2
-		tail_file "$first_stderr" 80 >&2
-		printf '[smoke] %s retry stderr tail:\n' "$name" >&2
-		tail_file "$stderr" 80 >&2
-		fail "$name retry failed after empty timeout-like exit"
-	fi
-
-	cat "$stderr" >&2 || true
-	fail "$name exited $code"
+	case "$policy" in
+		strict)
+			run_direct_fail "$name" "$code" "$stderr"
+			;;
+		retry-empty-timeout)
+			local first_stdout="$SMOKE_DIR/${name}.attempt1.stdout.txt"
+			local first_stderr="$SMOKE_DIR/${name}.attempt1.stderr.txt"
+			if ! is_empty_timeout_exit "$code" "$stdout"; then
+				run_direct_fail "$name" "$code" "$stderr"
+			fi
+			mv "$stdout" "$first_stdout" 2>/dev/null || true
+			mv "$stderr" "$first_stderr" 2>/dev/null || true
+			log "$name retrying once after empty timeout-like exit $code"
+			if run_direct_attempt "$name" "$timeout_secs" "$stdout" "$stderr" "$@"; then
+				log "$name PASS after retry (first exit $code; first stderr: $first_stderr)"
+				return 0
+			fi
+			local retry_code=$?
+			printf '[smoke] %s first attempt exited %s with empty stdout; retry exited %s\n' "$name" "$code" "$retry_code" >&2
+			printf '[smoke] %s first stderr tail:\n' "$name" >&2
+			tail_file "$first_stderr" 80 >&2
+			printf '[smoke] %s retry stderr tail:\n' "$name" >&2
+			tail_file "$stderr" 80 >&2
+			fail "$name retry failed after empty timeout-like exit"
+			;;
+		*)
+			fail "$name unknown run_direct policy: $policy (expected strict or retry-empty-timeout)"
+			;;
+	esac
 }
 
 quote_command() {
@@ -206,7 +223,7 @@ quote_command() {
 	printf '%s ' "${quoted[@]}"
 }
 
-run_tui_poll() {
+run_tui_math_footer_poll() {
 	local name="$1"
 	local timeout_secs="$2"
 	shift 2
@@ -325,28 +342,28 @@ if ! PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" --list-models cursor 2>"$SMO
 fi
 log "prereq PASS"
 
-run_direct basic 600 \
+run_direct basic 600 retry-empty-timeout \
 	env PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/basic" \
 	--no-tools \
 	-p 'Live smoke. Reply exactly: PI_CURSOR_SMOKE_OK'
 assert_file_contains basic "$SMOKE_DIR/basic.stdout.txt" "PI_CURSOR_SMOKE_OK" "PI_CURSOR_SMOKE_OK"
 
-run_direct default-settings 300 \
+run_direct default-settings 300 strict \
 	"${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/default-settings" \
 	--no-tools \
 	-p 'Default settings smoke. Include PRODUCT=42 in the final answer.'
 assert_file_contains default-settings "$SMOKE_DIR/default-settings.stdout.txt" "PRODUCT=42" "PRODUCT=42"
 
-run_direct noninteractive-math 300 \
+run_direct noninteractive-math 300 strict \
 	env PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/noninteractive-math" \
 	--no-tools \
 	-p 'Noninteractive math smoke. Compute 19 + 23. Reply only with SUM=42.'
 assert_file_contains noninteractive-math "$SMOKE_DIR/noninteractive-math.stdout.txt" "SUM=42" "SUM=42"
 
-run_tui_poll tui 420 \
+run_tui_math_footer_poll tui 420 \
 	env PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/tui" \
 	--no-tools \

--- a/scripts/tmux-live-smoke.sh
+++ b/scripts/tmux-live-smoke.sh
@@ -39,15 +39,16 @@ Prerequisites:
 
 Coverage:
   - prereq model listing
-  - basic non-interactive prompt
+  - basic non-interactive prompt, with one bounded retry for empty timeout exits
   - default ambient settings prompt
-  - simple non-interactive math prompt (not visual TUI coverage)
+  - simple non-interactive math prompt
+  - interactive TUI output/footer polling with cleanup
   - RPC steering after native replay tool execution (tmux-isolated)
   - diagnostics safety scan
   - JSONL assistant usage validation
 
 Not covered here:
-  visual/interactive TUI observation, bridge MCP, standalone native replay, abort/cancel, packaging, full checklist sections 3-9
+  bridge MCP, standalone native replay, abort/cancel, packaging, full checklist sections 4-9
 
 Options:
   -h, --help                    Show this help.
@@ -115,21 +116,84 @@ run_with_timeout() {
 	return "$code"
 }
 
+tail_file() {
+	local file="$1"
+	local lines="${2:-80}"
+	if [[ -s "$file" ]]; then
+		tail -n "$lines" "$file" || true
+	else
+		printf '<empty: %s>\n' "$file"
+	fi
+}
+
+assert_file_contains() {
+	local name="$1"
+	local file="$2"
+	local pattern="$3"
+	local label="$4"
+	if ! rg -q "$pattern" "$file"; then
+		printf '[smoke] %s missing %s in %s\n' "$name" "$label" "$file" >&2
+		printf '[smoke] %s transcript tail:\n' "$name" >&2
+		tail_file "$file" 120 >&2
+		fail "$name missing ${label}"
+	fi
+}
+
+is_empty_timeout_exit() {
+	local code="$1"
+	local stdout="$2"
+	[[ ! -s "$stdout" && ( "$code" == "124" || "$code" == "137" || "$code" == "143" ) ]]
+}
+
+run_direct_attempt() {
+	local name="$1"
+	local timeout_secs="$2"
+	local stdout="$3"
+	local stderr="$4"
+	shift 4
+	rm -f "$stdout" "$stderr"
+
+	if run_with_timeout "$timeout_secs" "$@" >"$stdout" 2>"$stderr"; then
+		return 0
+	fi
+	return $?
+}
+
 run_direct() {
 	local name="$1"
 	local timeout_secs="$2"
 	shift 2
 	local stdout="$SMOKE_DIR/${name}.stdout.txt"
 	local stderr="$SMOKE_DIR/${name}.stderr.txt"
-	rm -f "$stdout" "$stderr"
+	local first_stdout="$SMOKE_DIR/${name}.attempt1.stdout.txt"
+	local first_stderr="$SMOKE_DIR/${name}.attempt1.stderr.txt"
+	local code=0
 
-	if run_with_timeout "$timeout_secs" "$@" >"$stdout" 2>"$stderr"; then
+	if run_direct_attempt "$name" "$timeout_secs" "$stdout" "$stderr" "$@"; then
 		log "$name PASS"
-	else
-		local code=$?
-		cat "$stderr" >&2 || true
-		fail "$name exited $code"
+		return 0
 	fi
+	code=$?
+
+	if is_empty_timeout_exit "$code" "$stdout"; then
+		mv "$stdout" "$first_stdout" 2>/dev/null || true
+		mv "$stderr" "$first_stderr" 2>/dev/null || true
+		log "$name retrying once after empty timeout-like exit $code"
+		if run_direct_attempt "$name" "$timeout_secs" "$stdout" "$stderr" "$@"; then
+			log "$name PASS after retry (first exit $code; first stderr: $first_stderr)"
+			return 0
+		fi
+		local retry_code=$?
+		printf '[smoke] %s first attempt exited %s with empty stdout; retry exited %s\n' "$name" "$code" "$retry_code" >&2
+		printf '[smoke] %s first stderr tail:\n' "$name" >&2
+		tail_file "$first_stderr" 80 >&2
+		printf '[smoke] %s retry stderr tail:\n' "$name" >&2
+		tail_file "$stderr" 80 >&2
+		fail "$name retry failed after empty timeout-like exit"
+	fi
+
+	cat "$stderr" >&2 || true
+	fail "$name exited $code"
 }
 
 quote_command() {
@@ -140,6 +204,48 @@ quote_command() {
 		quoted+=("$arg")
 	done
 	printf '%s ' "${quoted[@]}"
+}
+
+run_tui_poll() {
+	local name="$1"
+	local timeout_secs="$2"
+	shift 2
+	local session="pi-cursor-smoke-${name}-$$"
+	local capture="$SMOKE_DIR/${name}.capture.txt"
+	local script
+	local command
+	command="$(quote_command "$@")"
+	rm -f "$capture"
+
+	printf -v script 'cd %q || exit 97
+exec %s
+' "$ROOT" "$command"
+	tmux new-session -d -s "$session" -x 120 -y 40 -- "$SHELL_BIN" -lc "$script"
+	TMUX_SESSIONS+=("$session")
+
+	local elapsed=0
+	local missing=""
+	while true; do
+		tmux capture-pane -pt "$session" >"$capture" 2>/dev/null || true
+		missing=""
+		rg -q "SUM=42" "$capture" || missing="${missing} SUM=42"
+		rg -q "\\(cursor\\) composer-2\\.5" "$capture" || missing="${missing} footer (cursor) composer-2.5"
+		if [[ -z "$missing" ]]; then
+			tmux kill-session -t "$session" 2>/dev/null || true
+			log "$name PASS"
+			return 0
+		fi
+
+		sleep 2
+		elapsed=$((elapsed + 2))
+		if (( elapsed >= timeout_secs )); then
+			tmux kill-session -t "$session" 2>/dev/null || true
+			printf '[smoke] %s timed out after %ss; missing:%s\n' "$name" "$timeout_secs" "$missing" >&2
+			printf '[smoke] %s capture tail:\n' "$name" >&2
+			tail_file "$capture" 120 >&2
+			fail "$name timed out waiting for TUI evidence"
+		fi
+	done
 }
 
 run_tmux() {
@@ -210,7 +316,7 @@ mkdir -p "$SMOKE_DIR"
 printf '%s\n' "$SMOKE_DIR" >"$SMOKE_DIR/smoke-dir.txt"
 
 log "SMOKE_DIR=$SMOKE_DIR"
-log "partial live smoke: prereq, basic, default-settings, noninteractive-math, steering, diagnostics, jsonl"
+log "partial live smoke: prereq, basic, default-settings, noninteractive-math, tui, steering, diagnostics, jsonl"
 
 if ! PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" --list-models cursor 2>"$SMOKE_DIR/prereq.stderr.txt" | tee "$SMOKE_DIR/prereq.models.txt" | rg -q "composer-2\\.5"; then
 	if ! model_listed "$SMOKE_DIR/prereq.stderr.txt"; then
@@ -219,26 +325,32 @@ if ! PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" --list-models cursor 2>"$SMO
 fi
 log "prereq PASS"
 
-run_direct basic 300 \
+run_direct basic 600 \
 	env PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/basic" \
 	--no-tools \
 	-p 'Live smoke. Reply exactly: PI_CURSOR_SMOKE_OK'
-rg -q "PI_CURSOR_SMOKE_OK" "$SMOKE_DIR/basic.stdout.txt" || fail "basic missing PI_CURSOR_SMOKE_OK"
+assert_file_contains basic "$SMOKE_DIR/basic.stdout.txt" "PI_CURSOR_SMOKE_OK" "PI_CURSOR_SMOKE_OK"
 
 run_direct default-settings 300 \
 	"${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/default-settings" \
 	--no-tools \
 	-p 'Default settings smoke. Include PRODUCT=42 in the final answer.'
-rg -q "PRODUCT=42" "$SMOKE_DIR/default-settings.stdout.txt" || fail "default-settings missing PRODUCT=42"
+assert_file_contains default-settings "$SMOKE_DIR/default-settings.stdout.txt" "PRODUCT=42" "PRODUCT=42"
 
 run_direct noninteractive-math 300 \
 	env PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" \
 	--session-dir "$SMOKE_DIR/noninteractive-math" \
 	--no-tools \
 	-p 'Noninteractive math smoke. Compute 19 + 23. Reply only with SUM=42.'
-rg -q "SUM=42" "$SMOKE_DIR/noninteractive-math.stdout.txt" || fail "noninteractive math missing SUM=42"
+assert_file_contains noninteractive-math "$SMOKE_DIR/noninteractive-math.stdout.txt" "SUM=42" "SUM=42"
+
+run_tui_poll tui 420 \
+	env PI_CURSOR_SETTING_SOURCES=none "${PI_BASE[@]}" \
+	--session-dir "$SMOKE_DIR/tui" \
+	--no-tools \
+	'TUI smoke. Compute 19 + 23. Reply only with SUM=<number>.'
 
 run_tmux steering 420 1 \
 	env "SMOKE_SESSION_DIR=$SMOKE_DIR/steering" node "$ROOT/scripts/steering-rpc-smoke.mjs"


### PR DESCRIPTION
## Summary

Fixes #27 and fixes #28.

Plan and remediation scope:
- #27: make direct live-smoke checks tolerate one empty timeout-like startup failure with a bounded retry, while preserving strict failure when retry output is bad or missing.
- #28: add automated interactive TUI polling that watches tmux capture output for both `SUM=42` and the `(cursor) composer-2.5` footer, then kills the session instead of waiting for `pi` to exit.
- Adjacent cleanup: centralize smoke transcript-tail failure reporting and update the live smoke checklist/help text so docs match the new helper coverage.

## Validation

- `bash -n scripts/tmux-live-smoke.sh`
- `scripts/tmux-live-smoke.sh --help`
- `npm test`
- `npm run typecheck`
- `SMOKE_DIR=/tmp/pi-cursor-sdk-live-smoke-issue-27-28 npm run smoke:live`
- `tmux list-sessions | grep 'pi-cursor-smoke' || true` (confirmed no leftover smoke sessions)
- `npm pack --dry-run`

## Notes

- The live smoke command used the ambient `CURSOR_API_KEY`; no secret values were printed or stored.
- Do not merge until approval.
