### PR TITLE
Add maintainer Cursor SDK event capture probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,20 @@ PI_CURSOR_PI_TOOL_BRIDGE_DEBUG=1 pi --model cursor/composer-2.5
 
 For Cursor provider/runtime changes, follow the manual [Cursor live smoke checklist](docs/cursor-live-smoke-checklist.md) before release. See [Cursor testing lessons](docs/cursor-testing-lessons.md) for auth.json seeding, isolated `/tmp` harness layout, JSONL replay-error scans, and other regression traps. Assume every runtime surface is in scope. The checklist uses real `pi -e . --cursor-no-fast --model cursor/composer-2.5` runs with temporary session dirs and requires the visible TUI/output, scrubbed diagnostics, and persisted JSONL to agree. Do not mark a release ready with optional, deferred, mostly-passing, or unobserved smoke checks outstanding.
 
+### Maintainer Cursor SDK event capture
+
+To compare raw `run.stream()`, `onDelta`, and `onStep` timelines for one local SDK run without writing a throwaway probe:
+
+```bash
+CURSOR_API_KEY=... npm run debug:sdk-events -- \
+  --cwd ~/Projects \
+  --model composer-2.5 \
+  --prompt 'Describe this workspace in one sentence.' \
+  --out /tmp/pi-cursor-sdk-sdk-events-manual
+```
+
+Stdout prints artifact paths and summary counts only. Raw payloads are written under `/tmp/...` by default and may contain local paths or secrets — do not commit them. See [Cursor testing lessons](docs/cursor-testing-lessons.md#cursor-sdk-event-capture-probe).
+
 ## Fallback models
 
 If no key is available from `/login`, `CURSOR_API_KEY`, or `--api-key`, model discovery fails, or discovery returns no models, the extension registers a bundled fallback snapshot of the latest reviewed Cursor SDK model catalog and notifies interactive users when possible.

--- a/README.md
+++ b/README.md
@@ -236,17 +236,7 @@ For Cursor provider/runtime changes, follow the manual [Cursor live smoke checkl
 
 ### Maintainer Cursor SDK event capture
 
-To compare raw `run.stream()`, `onDelta`, and `onStep` timelines for one local SDK run without writing a throwaway probe:
-
-```bash
-CURSOR_API_KEY=... npm run debug:sdk-events -- \
-  --cwd ~/Projects \
-  --model composer-2.5 \
-  --prompt 'Describe this workspace in one sentence.' \
-  --out /tmp/pi-cursor-sdk-sdk-events-manual
-```
-
-Stdout prints artifact paths and summary counts only. Raw payloads are written under `/tmp/...` by default and may contain local paths or secrets — do not commit them. See [Cursor testing lessons](docs/cursor-testing-lessons.md#cursor-sdk-event-capture-probe).
+Use `npm run debug:sdk-events` to capture timestamped `run.stream()`, `onDelta`, and `onStep` timelines for one local SDK run. See [Cursor testing lessons](docs/cursor-testing-lessons.md#cursor-sdk-event-capture-probe) for usage, artifact layout, and safety notes.
 
 ## Fallback models
 

--- a/docs/cursor-testing-lessons.md
+++ b/docs/cursor-testing-lessons.md
@@ -213,6 +213,31 @@ Then follow the full manual [Cursor live smoke checklist](./cursor-live-smoke-ch
 
 If live smoke auth is unavailable, report the release as **blocked**, not skipped-ready.
 
+## Cursor SDK event capture probe
+
+When debugging TUI/progress/replay timing gaps, capture raw Cursor SDK surfaces side-by-side instead of writing a throwaway probe:
+
+```bash
+CURSOR_API_KEY=... npm run debug:sdk-events -- \
+  --cwd ~/Projects \
+  --model composer-2.5 \
+  --prompt 'Scan all of my projects and give me ideas that would be great to add the Cursor SDK to' \
+  --out /tmp/pi-cursor-sdk-sdk-events-manual
+```
+
+The script writes timestamped artifacts under `--out` (default `/tmp/pi-cursor-sdk-sdk-events-<timestamp>`):
+
+- `stream-events.jsonl` — `run.stream()` messages
+- `on-delta.jsonl` — `agent.send(..., { onDelta })` updates
+- `on-step.jsonl` — `agent.send(..., { onStep })` steps
+- `wait-result.json` — final `run.wait()` metadata
+- optional `conversation.json` with `--include-conversation`
+- `summary.json` — event counts and timing gaps
+
+Stdout prints artifact paths and summary counts only. Raw payloads stay on disk and may contain local paths, project text, tool args/results, or secrets — do not commit or share them.
+
+Hard repo rule: Cursor SDK behavior claims must come from the installed `@cursor/sdk` package and/or https://cursor.com/docs/sdk/typescript, not from memory or ad-hoc probes alone.
+
 ## Related docs and scripts
 
 - [Cursor live smoke checklist](./cursor-live-smoke-checklist.md)
@@ -220,4 +245,5 @@ If live smoke auth is unavailable, report the release as **blocked**, not skippe
 - `scripts/isolated-cursor-smoke.sh`
 - `scripts/tmux-live-smoke.sh`
 - `scripts/validate-smoke-jsonl.mjs`
+- `scripts/debug-sdk-events.mjs`
 - `test/helpers/cursor-provider-harness.ts` — controllable native replay pi mock (`createNativeToolDisplayPiForTest`)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
 		"scripts/isolated-cursor-smoke.sh",
 		"scripts/validate-smoke-jsonl.mjs",
 		"scripts/debug-sdk-events.mjs",
+		"scripts/lib/cursor-probe-utils.mjs",
+		"scripts/lib/cursor-sdk-output-filter.mjs",
 		"README.md",
 		"docs/cursor-model-ux-spec.md",
 		"docs/cursor-live-smoke-checklist.md",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 		"scripts/tmux-live-smoke.sh",
 		"scripts/isolated-cursor-smoke.sh",
 		"scripts/validate-smoke-jsonl.mjs",
+		"scripts/debug-sdk-events.mjs",
 		"README.md",
 		"docs/cursor-model-ux-spec.md",
 		"docs/cursor-live-smoke-checklist.md",
@@ -49,7 +50,8 @@
 		"smoke:live": "scripts/tmux-live-smoke.sh",
 		"smoke:isolated": "scripts/isolated-cursor-smoke.sh",
 		"smoke:steering": "node scripts/steering-rpc-smoke.mjs",
-		"smoke:jsonl": "node scripts/validate-smoke-jsonl.mjs"
+		"smoke:jsonl": "node scripts/validate-smoke-jsonl.mjs",
+		"debug:sdk-events": "node scripts/debug-sdk-events.mjs"
 	},
 	"dependencies": {
 		"@cursor/sdk": "^1.0.13",

--- a/scripts/debug-sdk-events.mjs
+++ b/scripts/debug-sdk-events.mjs
@@ -11,14 +11,33 @@ const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
 const CURSOR_SETTING_SOURCES_ENV = "PI_CURSOR_SETTING_SOURCES";
 
-function readSdkVersion() {
-	const sdkEntry = require.resolve("@cursor/sdk");
-	const sdkPackagePath = join(dirname(sdkEntry), "../../package.json");
-	return JSON.parse(readFileSync(sdkPackagePath, "utf8")).version;
-}
+const ARTIFACTS = {
+	metadata: "metadata.json",
+	streamEvents: "stream-events.jsonl",
+	onDelta: "on-delta.jsonl",
+	onStep: "on-step.jsonl",
+	waitResult: "wait-result.json",
+	conversation: "conversation.json",
+	summary: "summary.json",
+};
+
 const DEFAULT_MODEL = "composer-2.5";
 const RAW_ARTIFACT_WARNING =
 	"Raw artifact files may contain local paths, project text, tool args/results, or secrets from the workspace. Do not commit or share them.";
+
+function readSdkVersion() {
+	try {
+		const sdkEntry = require.resolve("@cursor/sdk");
+		const sdkPackagePath = join(dirname(sdkEntry), "../../package.json");
+		return JSON.parse(readFileSync(sdkPackagePath, "utf8")).version;
+	} catch {
+		return "unknown";
+	}
+}
+
+function artifactPath(artifactDir, name) {
+	return join(artifactDir, ARTIFACTS[name]);
+}
 
 function printHelp() {
 	console.log(`Capture timestamped Cursor SDK event timelines for one local run.
@@ -40,7 +59,7 @@ Options:
 
 Stdout:
   Prints artifact paths and summary counts only. Raw payloads stay on disk under:
-  stream-events.jsonl (run.stream()), on-delta.jsonl (onDelta), on-step.jsonl (onStep).
+  ${ARTIFACTS.streamEvents} (run.stream()), ${ARTIFACTS.onDelta} (onDelta), ${ARTIFACTS.onStep} (onStep).
 
 Exit codes:
   0  capture completed
@@ -207,16 +226,36 @@ function writeJsonl(path, records) {
 	writeFileSync(path, `${records.map((record) => JSON.stringify(record)).join("\n")}${records.length ? "\n" : ""}`);
 }
 
-function buildSummary({ artifactDir, streamEvents, deltaEvents, stepEvents, waitResult, conversation, includeConversation }) {
+function pushTimed(records, startedAt, key, value) {
+	records.push({
+		ts: new Date().toISOString(),
+		elapsedMs: Date.now() - startedAt,
+		[key]: value,
+	});
+}
+
+function writeEventArtifacts(artifactDir, { streamEvents, deltaEvents, stepEvents }) {
+	writeJsonl(artifactPath(artifactDir, "streamEvents"), streamEvents);
+	writeJsonl(artifactPath(artifactDir, "onDelta"), deltaEvents);
+	writeJsonl(artifactPath(artifactDir, "onStep"), stepEvents);
+}
+
+function summarizeConversation(conversation) {
+	if (!conversation) return undefined;
+	if (Array.isArray(conversation)) return { turnCount: conversation.length };
+	return conversation;
+}
+
+export function buildSummary({ artifactDir, streamEvents, deltaEvents, stepEvents, waitResult, conversation, includeConversation }) {
 	return {
 		artifactDir,
 		files: {
-			metadata: join(artifactDir, "metadata.json"),
-			streamEvents: join(artifactDir, "stream-events.jsonl"),
-			onDelta: join(artifactDir, "on-delta.jsonl"),
-			onStep: join(artifactDir, "on-step.jsonl"),
-			waitResult: join(artifactDir, "wait-result.json"),
-			conversation: includeConversation ? join(artifactDir, "conversation.json") : undefined,
+			metadata: artifactPath(artifactDir, "metadata"),
+			streamEvents: artifactPath(artifactDir, "streamEvents"),
+			onDelta: artifactPath(artifactDir, "onDelta"),
+			onStep: artifactPath(artifactDir, "onStep"),
+			waitResult: artifactPath(artifactDir, "waitResult"),
+			conversation: includeConversation ? artifactPath(artifactDir, "conversation") : undefined,
 		},
 		counts: {
 			stream: countByType(streamEvents, (record) => eventType(record.event)),
@@ -235,11 +274,7 @@ function buildSummary({ artifactDir, streamEvents, deltaEvents, stepEvents, wait
 					hasResultText: Boolean(waitResult.result?.trim()),
 				}
 			: undefined,
-		conversation: conversation
-			? Array.isArray(conversation)
-				? { turnCount: conversation.length }
-				: conversation
-			: undefined,
+		conversation: summarizeConversation(conversation),
 		warnings: [RAW_ARTIFACT_WARNING],
 	};
 }
@@ -263,7 +298,7 @@ async function captureEvents(args) {
 		includeConversation: args.includeConversation,
 		warnings: [RAW_ARTIFACT_WARNING],
 	};
-	writeFileSync(join(artifactDir, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+	writeFileSync(artifactPath(artifactDir, "metadata"), `${JSON.stringify(metadata, null, 2)}\n`);
 
 	const streamEvents = [];
 	const deltaEvents = [];
@@ -280,51 +315,32 @@ async function captureEvents(args) {
 		const run = await agent.send(
 			{ text: args.prompt },
 			{
-				onDelta: ({ update }) => {
-					deltaEvents.push({
-						ts: new Date().toISOString(),
-						elapsedMs: Date.now() - startedAt,
-						update,
-					});
-				},
-				onStep: ({ step }) => {
-					stepEvents.push({
-						ts: new Date().toISOString(),
-						elapsedMs: Date.now() - startedAt,
-						step,
-					});
-				},
+				onDelta: ({ update }) => pushTimed(deltaEvents, startedAt, "update", update),
+				onStep: ({ step }) => pushTimed(stepEvents, startedAt, "step", step),
 			},
 		);
 
 		for await (const event of run.stream()) {
-			streamEvents.push({
-				ts: new Date().toISOString(),
-				elapsedMs: Date.now() - startedAt,
-				event,
-			});
+			pushTimed(streamEvents, startedAt, "event", event);
 		}
 
 		const waitResult = await run.wait();
-		writeFileSync(join(artifactDir, "wait-result.json"), `${JSON.stringify(waitResult, null, 2)}\n`);
+		writeFileSync(artifactPath(artifactDir, "waitResult"), `${JSON.stringify(waitResult, null, 2)}\n`);
 
 		let conversation;
 		if (args.includeConversation) {
 			if (run.supports("conversation")) {
 				conversation = await run.conversation();
-				writeFileSync(join(artifactDir, "conversation.json"), `${JSON.stringify(conversation, null, 2)}\n`);
 			} else {
 				conversation = {
 					skipped: true,
 					reason: run.unsupportedReason("conversation") ?? "conversation unsupported",
 				};
-				writeFileSync(join(artifactDir, "conversation.json"), `${JSON.stringify(conversation, null, 2)}\n`);
 			}
+			writeFileSync(artifactPath(artifactDir, "conversation"), `${JSON.stringify(conversation, null, 2)}\n`);
 		}
 
-		writeJsonl(join(artifactDir, "stream-events.jsonl"), streamEvents);
-		writeJsonl(join(artifactDir, "on-delta.jsonl"), deltaEvents);
-		writeJsonl(join(artifactDir, "on-step.jsonl"), stepEvents);
+		writeEventArtifacts(artifactDir, { streamEvents, deltaEvents, stepEvents });
 
 		const summary = buildSummary({
 			artifactDir,
@@ -335,12 +351,10 @@ async function captureEvents(args) {
 			conversation,
 			includeConversation: args.includeConversation,
 		});
-		writeFileSync(join(artifactDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+		writeFileSync(artifactPath(artifactDir, "summary"), `${JSON.stringify(summary, null, 2)}\n`);
 		printStdoutSummary(summary);
 	} catch (error) {
-		writeJsonl(join(artifactDir, "stream-events.jsonl"), streamEvents);
-		writeJsonl(join(artifactDir, "on-delta.jsonl"), deltaEvents);
-		writeJsonl(join(artifactDir, "on-step.jsonl"), stepEvents);
+		writeEventArtifacts(artifactDir, { streamEvents, deltaEvents, stepEvents });
 		const message = error instanceof Error ? error.message : String(error);
 		fail(message, [args.apiKey]);
 	} finally {

--- a/scripts/debug-sdk-events.mjs
+++ b/scripts/debug-sdk-events.mjs
@@ -1,0 +1,371 @@
+#!/usr/bin/env node
+/**
+ * Maintainer-only Cursor SDK event capture probe.
+ * Captures timestamped run.stream(), onDelta, and onStep surfaces for one run.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json");
+const CURSOR_SETTING_SOURCES_ENV = "PI_CURSOR_SETTING_SOURCES";
+
+function readSdkVersion() {
+	const sdkEntry = require.resolve("@cursor/sdk");
+	const sdkPackagePath = join(dirname(sdkEntry), "../../package.json");
+	return JSON.parse(readFileSync(sdkPackagePath, "utf8")).version;
+}
+const DEFAULT_MODEL = "composer-2.5";
+const RAW_ARTIFACT_WARNING =
+	"Raw artifact files may contain local paths, project text, tool args/results, or secrets from the workspace. Do not commit or share them.";
+
+function printHelp() {
+	console.log(`Capture timestamped Cursor SDK event timelines for one local run.
+
+Usage:
+  CURSOR_API_KEY=... npm run debug:sdk-events -- [options]
+  node scripts/debug-sdk-events.mjs [options]
+
+Options:
+  --cwd <path>                 Agent working directory. Default: process.cwd().
+  --model <id>                 Cursor model id. Default: ${DEFAULT_MODEL}.
+  --prompt <text>              Required user prompt for the run.
+  --out <dir>                  Artifact directory. Default: /tmp/pi-cursor-sdk-sdk-events-<timestamp>.
+  --setting-sources <value>    Comma-separated Cursor setting sources, or all/none.
+                               Default: PI_CURSOR_SETTING_SOURCES env, otherwise all.
+  --include-conversation       Also capture run.conversation() when supported.
+  --api-key <key>              Cursor API key. Prefer CURSOR_API_KEY to avoid shell history.
+  -h, --help                   Show this help.
+
+Stdout:
+  Prints artifact paths and summary counts only. Raw payloads stay on disk under:
+  stream-events.jsonl (run.stream()), on-delta.jsonl (onDelta), on-step.jsonl (onStep).
+
+Exit codes:
+  0  capture completed
+  1  invalid arguments, missing auth, or Cursor SDK failure
+
+Safety:
+  - Never prints CURSOR_API_KEY or --api-key values.
+  - Default artifact root is outside the repo (/tmp/...).
+  - ${RAW_ARTIFACT_WARNING}
+  - Verify Cursor SDK behavior against the installed @cursor/sdk package and/or
+    https://cursor.com/docs/sdk/typescript before drawing integration conclusions.`);
+}
+
+function fail(message, secrets = []) {
+	const scrubbed = scrubSensitiveText(message, secrets);
+	console.error(`debug-sdk-events: ${scrubbed}`);
+	process.exit(1);
+}
+
+function scrubSensitiveText(text, secrets = []) {
+	let scrubbed = text;
+	for (const secret of secrets) {
+		if (secret) scrubbed = scrubbed.split(secret).join("[REDACTED]");
+	}
+	return scrubbed
+		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+		.replace(/(api[_-]?key|authorization|auth[_-]?token)(["'\s:=]+)[^"'\s,}]+/gi, "$1$2[REDACTED]");
+}
+
+function resolveSettingSources(raw) {
+	if (!raw) return ["all"];
+	const normalized = raw.trim().toLowerCase();
+	if (["0", "false", "off", "none", "omit", "disabled"].includes(normalized)) return undefined;
+	if (["1", "true", "on", "all"].includes(normalized)) return ["all"];
+	return raw
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+}
+
+export function parseDebugSdkEventsArgs(argv, env = process.env) {
+	const args = {
+		cwd: process.cwd(),
+		model: DEFAULT_MODEL,
+		prompt: undefined,
+		out: undefined,
+		settingSources: resolveSettingSources(env[CURSOR_SETTING_SOURCES_ENV]),
+		includeConversation: false,
+		apiKey: env.CURSOR_API_KEY?.trim() || undefined,
+		help: false,
+	};
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg === "-h" || arg === "--help") {
+			args.help = true;
+			continue;
+		}
+		if (arg === "--include-conversation") {
+			args.includeConversation = true;
+			continue;
+		}
+		if (arg === "--cwd") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--cwd requires a path");
+			args.cwd = resolve(value);
+			continue;
+		}
+		if (arg.startsWith("--cwd=")) {
+			args.cwd = resolve(arg.slice("--cwd=".length));
+			continue;
+		}
+		if (arg === "--model") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--model requires a value");
+			args.model = value.trim();
+			continue;
+		}
+		if (arg.startsWith("--model=")) {
+			args.model = arg.slice("--model=".length).trim();
+			continue;
+		}
+		if (arg === "--prompt") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--prompt requires a value");
+			args.prompt = value;
+			continue;
+		}
+		if (arg.startsWith("--prompt=")) {
+			args.prompt = arg.slice("--prompt=".length);
+			continue;
+		}
+		if (arg === "--out") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--out requires a directory path");
+			args.out = resolve(value);
+			continue;
+		}
+		if (arg.startsWith("--out=")) {
+			args.out = resolve(arg.slice("--out=".length));
+			continue;
+		}
+		if (arg === "--setting-sources") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--setting-sources requires a value");
+			args.settingSources = resolveSettingSources(value);
+			continue;
+		}
+		if (arg.startsWith("--setting-sources=")) {
+			args.settingSources = resolveSettingSources(arg.slice("--setting-sources=".length));
+			continue;
+		}
+		if (arg === "--api-key") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--api-key requires a value");
+			args.apiKey = value.trim();
+			continue;
+		}
+		if (arg.startsWith("--api-key=")) {
+			args.apiKey = arg.slice("--api-key=".length).trim();
+			continue;
+		}
+		fail(`unknown argument: ${arg}`);
+	}
+	return args;
+}
+
+function defaultOutDir() {
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	return join("/tmp", `pi-cursor-sdk-sdk-events-${stamp}`);
+}
+
+function eventType(value) {
+	if (value && typeof value === "object" && typeof value.type === "string") return value.type;
+	return "unknown";
+}
+
+function countByType(records, selector) {
+	const counts = {};
+	for (const record of records) {
+		const type = selector(record);
+		counts[type] = (counts[type] ?? 0) + 1;
+	}
+	return counts;
+}
+
+function timingSummary(records) {
+	if (records.length === 0) {
+		return { eventCount: 0, firstMs: undefined, lastMs: undefined, maxGapMs: undefined };
+	}
+	const elapsed = records.map((record) => record.elapsedMs);
+	let maxGapMs = 0;
+	for (let index = 1; index < elapsed.length; index++) {
+		maxGapMs = Math.max(maxGapMs, elapsed[index] - elapsed[index - 1]);
+	}
+	return {
+		eventCount: records.length,
+		firstMs: elapsed[0],
+		lastMs: elapsed[elapsed.length - 1],
+		maxGapMs,
+	};
+}
+
+function writeJsonl(path, records) {
+	writeFileSync(path, `${records.map((record) => JSON.stringify(record)).join("\n")}${records.length ? "\n" : ""}`);
+}
+
+function buildSummary({ artifactDir, streamEvents, deltaEvents, stepEvents, waitResult, conversation, includeConversation }) {
+	return {
+		artifactDir,
+		files: {
+			metadata: join(artifactDir, "metadata.json"),
+			streamEvents: join(artifactDir, "stream-events.jsonl"),
+			onDelta: join(artifactDir, "on-delta.jsonl"),
+			onStep: join(artifactDir, "on-step.jsonl"),
+			waitResult: join(artifactDir, "wait-result.json"),
+			conversation: includeConversation ? join(artifactDir, "conversation.json") : undefined,
+		},
+		counts: {
+			stream: countByType(streamEvents, (record) => eventType(record.event)),
+			onDelta: countByType(deltaEvents, (record) => eventType(record.update)),
+			onStep: countByType(stepEvents, (record) => eventType(record.step)),
+		},
+		timing: {
+			stream: timingSummary(streamEvents),
+			onDelta: timingSummary(deltaEvents),
+			onStep: timingSummary(stepEvents),
+		},
+		wait: waitResult
+			? {
+					status: waitResult.status,
+					durationMs: waitResult.durationMs,
+					hasResultText: Boolean(waitResult.result?.trim()),
+				}
+			: undefined,
+		conversation: conversation
+			? Array.isArray(conversation)
+				? { turnCount: conversation.length }
+				: conversation
+			: undefined,
+		warnings: [RAW_ARTIFACT_WARNING],
+	};
+}
+
+function printStdoutSummary(summary) {
+	console.log(JSON.stringify(summary, null, 2));
+}
+
+async function captureEvents(args) {
+	const artifactDir = args.out ?? defaultOutDir();
+	mkdirSync(artifactDir, { recursive: true });
+	const startedAt = Date.now();
+	const metadata = {
+		capturedAt: new Date(startedAt).toISOString(),
+		cwd: args.cwd,
+		model: args.model,
+		settingSources: args.settingSources ?? null,
+		prompt: args.prompt,
+		packageVersion: packageJson.version,
+		sdkVersion: readSdkVersion(),
+		includeConversation: args.includeConversation,
+		warnings: [RAW_ARTIFACT_WARNING],
+	};
+	writeFileSync(join(artifactDir, "metadata.json"), `${JSON.stringify(metadata, null, 2)}\n`);
+
+	const streamEvents = [];
+	const deltaEvents = [];
+	const stepEvents = [];
+	let agent;
+	try {
+		const { Agent } = await import("@cursor/sdk");
+		agent = await Agent.create({
+			apiKey: args.apiKey,
+			model: { id: args.model },
+			local: args.settingSources ? { cwd: args.cwd, settingSources: args.settingSources } : { cwd: args.cwd },
+		});
+
+		const run = await agent.send(
+			{ text: args.prompt },
+			{
+				onDelta: ({ update }) => {
+					deltaEvents.push({
+						ts: new Date().toISOString(),
+						elapsedMs: Date.now() - startedAt,
+						update,
+					});
+				},
+				onStep: ({ step }) => {
+					stepEvents.push({
+						ts: new Date().toISOString(),
+						elapsedMs: Date.now() - startedAt,
+						step,
+					});
+				},
+			},
+		);
+
+		for await (const event of run.stream()) {
+			streamEvents.push({
+				ts: new Date().toISOString(),
+				elapsedMs: Date.now() - startedAt,
+				event,
+			});
+		}
+
+		const waitResult = await run.wait();
+		writeFileSync(join(artifactDir, "wait-result.json"), `${JSON.stringify(waitResult, null, 2)}\n`);
+
+		let conversation;
+		if (args.includeConversation) {
+			if (run.supports("conversation")) {
+				conversation = await run.conversation();
+				writeFileSync(join(artifactDir, "conversation.json"), `${JSON.stringify(conversation, null, 2)}\n`);
+			} else {
+				conversation = {
+					skipped: true,
+					reason: run.unsupportedReason("conversation") ?? "conversation unsupported",
+				};
+				writeFileSync(join(artifactDir, "conversation.json"), `${JSON.stringify(conversation, null, 2)}\n`);
+			}
+		}
+
+		writeJsonl(join(artifactDir, "stream-events.jsonl"), streamEvents);
+		writeJsonl(join(artifactDir, "on-delta.jsonl"), deltaEvents);
+		writeJsonl(join(artifactDir, "on-step.jsonl"), stepEvents);
+
+		const summary = buildSummary({
+			artifactDir,
+			streamEvents,
+			deltaEvents,
+			stepEvents,
+			waitResult,
+			conversation,
+			includeConversation: args.includeConversation,
+		});
+		writeFileSync(join(artifactDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`);
+		printStdoutSummary(summary);
+	} catch (error) {
+		writeJsonl(join(artifactDir, "stream-events.jsonl"), streamEvents);
+		writeJsonl(join(artifactDir, "on-delta.jsonl"), deltaEvents);
+		writeJsonl(join(artifactDir, "on-step.jsonl"), stepEvents);
+		const message = error instanceof Error ? error.message : String(error);
+		fail(message, [args.apiKey]);
+	} finally {
+		agent?.close();
+	}
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+	const args = parseDebugSdkEventsArgs(argv, env);
+	if (args.help) {
+		printHelp();
+		process.exit(0);
+	}
+	if (!args.prompt?.trim()) {
+		fail("--prompt is required");
+	}
+	if (!args.apiKey) {
+		fail("Cursor API key is required. Set CURSOR_API_KEY or pass --api-key.");
+	}
+	await captureEvents(args);
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+	main().catch((error) => {
+		const message = error instanceof Error ? error.message : String(error);
+		fail(message);
+	});
+}

--- a/scripts/debug-sdk-events.mjs
+++ b/scripts/debug-sdk-events.mjs
@@ -3,13 +3,18 @@
  * Maintainer-only Cursor SDK event capture probe.
  * Captures timestamped run.stream(), onDelta, and onStep surfaces for one run.
  */
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
+import {
+	CURSOR_SETTING_SOURCES_ENV,
+	resolveCursorSettingSources,
+	scrubSensitiveText,
+} from "./lib/cursor-probe-utils.mjs";
+import { installCursorSdkOutputFilter, suppressCursorSdkOutput } from "./lib/cursor-sdk-output-filter.mjs";
 
 const require = createRequire(import.meta.url);
 const packageJson = require("../package.json");
-const CURSOR_SETTING_SOURCES_ENV = "PI_CURSOR_SETTING_SOURCES";
 
 const ARTIFACTS = {
 	metadata: "metadata.json",
@@ -74,30 +79,9 @@ Safety:
 }
 
 function fail(message, secrets = []) {
-	const scrubbed = scrubSensitiveText(message, secrets);
+	const scrubbed = scrubSensitiveText(message, secrets[0]);
 	console.error(`debug-sdk-events: ${scrubbed}`);
 	process.exit(1);
-}
-
-function scrubSensitiveText(text, secrets = []) {
-	let scrubbed = text;
-	for (const secret of secrets) {
-		if (secret) scrubbed = scrubbed.split(secret).join("[REDACTED]");
-	}
-	return scrubbed
-		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
-		.replace(/(api[_-]?key|authorization|auth[_-]?token)(["'\s:=]+)[^"'\s,}]+/gi, "$1$2[REDACTED]");
-}
-
-function resolveSettingSources(raw) {
-	if (!raw) return ["all"];
-	const normalized = raw.trim().toLowerCase();
-	if (["0", "false", "off", "none", "omit", "disabled"].includes(normalized)) return undefined;
-	if (["1", "true", "on", "all"].includes(normalized)) return ["all"];
-	return raw
-		.split(",")
-		.map((entry) => entry.trim())
-		.filter(Boolean);
 }
 
 export function parseDebugSdkEventsArgs(argv, env = process.env) {
@@ -106,7 +90,7 @@ export function parseDebugSdkEventsArgs(argv, env = process.env) {
 		model: DEFAULT_MODEL,
 		prompt: undefined,
 		out: undefined,
-		settingSources: resolveSettingSources(env[CURSOR_SETTING_SOURCES_ENV]),
+		settingSources: resolveCursorSettingSources(env[CURSOR_SETTING_SOURCES_ENV]),
 		includeConversation: false,
 		apiKey: env.CURSOR_API_KEY?.trim() || undefined,
 		help: false,
@@ -164,11 +148,11 @@ export function parseDebugSdkEventsArgs(argv, env = process.env) {
 		if (arg === "--setting-sources") {
 			const value = argv[++index];
 			if (!value || value.startsWith("--")) fail("--setting-sources requires a value");
-			args.settingSources = resolveSettingSources(value);
+			args.settingSources = resolveCursorSettingSources(value);
 			continue;
 		}
 		if (arg.startsWith("--setting-sources=")) {
-			args.settingSources = resolveSettingSources(arg.slice("--setting-sources=".length));
+			args.settingSources = resolveCursorSettingSources(arg.slice("--setting-sources=".length));
 			continue;
 		}
 		if (arg === "--api-key") {
@@ -196,48 +180,88 @@ function eventType(value) {
 	return "unknown";
 }
 
-function countByType(records, selector) {
-	const counts = {};
-	for (const record of records) {
-		const type = selector(record);
-		counts[type] = (counts[type] ?? 0) + 1;
-	}
-	return counts;
-}
-
-function timingSummary(records) {
-	if (records.length === 0) {
-		return { eventCount: 0, firstMs: undefined, lastMs: undefined, maxGapMs: undefined };
-	}
-	const elapsed = records.map((record) => record.elapsedMs);
-	let maxGapMs = 0;
-	for (let index = 1; index < elapsed.length; index++) {
-		maxGapMs = Math.max(maxGapMs, elapsed[index] - elapsed[index - 1]);
-	}
+export function createTimingTracker() {
 	return {
-		eventCount: records.length,
-		firstMs: elapsed[0],
-		lastMs: elapsed[elapsed.length - 1],
-		maxGapMs,
+		eventCount: 0,
+		firstMs: undefined,
+		lastMs: undefined,
+		maxGapMs: undefined,
+		record(elapsedMs) {
+			if (this.eventCount === 0) {
+				this.firstMs = elapsedMs;
+			} else {
+				this.maxGapMs = Math.max(this.maxGapMs ?? 0, elapsedMs - (this.lastMs ?? elapsedMs));
+			}
+			this.eventCount += 1;
+			this.lastMs = elapsedMs;
+		},
+		snapshot() {
+			return {
+				eventCount: this.eventCount,
+				firstMs: this.firstMs,
+				lastMs: this.lastMs,
+				maxGapMs: this.maxGapMs,
+			};
+		},
 	};
 }
 
-function writeJsonl(path, records) {
-	writeFileSync(path, `${records.map((record) => JSON.stringify(record)).join("\n")}${records.length ? "\n" : ""}`);
-}
+export function createEventJsonlSink(artifactDir, startedAt) {
+	const paths = {
+		streamEvents: artifactPath(artifactDir, "streamEvents"),
+		onDelta: artifactPath(artifactDir, "onDelta"),
+		onStep: artifactPath(artifactDir, "onStep"),
+	};
+	for (const path of Object.values(paths)) {
+		writeFileSync(path, "");
+	}
+	const counts = {
+		stream: {},
+		onDelta: {},
+		onStep: {},
+	};
+	const timing = {
+		stream: createTimingTracker(),
+		onDelta: createTimingTracker(),
+		onStep: createTimingTracker(),
+	};
 
-function pushTimed(records, startedAt, key, value) {
-	records.push({
-		ts: new Date().toISOString(),
-		elapsedMs: Date.now() - startedAt,
-		[key]: value,
-	});
-}
+	function append(pathKey, countKey, recordKey, value) {
+		const elapsedMs = Date.now() - startedAt;
+		const record = {
+			ts: new Date().toISOString(),
+			elapsedMs,
+			[recordKey]: value,
+		};
+		appendFileSync(paths[pathKey], `${JSON.stringify(record)}\n`);
+		const type = eventType(value);
+		counts[countKey][type] = (counts[countKey][type] ?? 0) + 1;
+		timing[countKey].record(elapsedMs);
+		return record;
+	}
 
-function writeEventArtifacts(artifactDir, { streamEvents, deltaEvents, stepEvents }) {
-	writeJsonl(artifactPath(artifactDir, "streamEvents"), streamEvents);
-	writeJsonl(artifactPath(artifactDir, "onDelta"), deltaEvents);
-	writeJsonl(artifactPath(artifactDir, "onStep"), stepEvents);
+	return {
+		appendStream: (event) => append("streamEvents", "stream", "event", event),
+		appendDelta: (update) => append("onDelta", "onDelta", "update", update),
+		appendStep: (step) => append("onStep", "onStep", "step", step),
+		getSummaryState() {
+			return {
+				counts: {
+					stream: { ...counts.stream },
+					onDelta: { ...counts.onDelta },
+					onStep: { ...counts.onStep },
+				},
+				timing: {
+					stream: timing.stream.snapshot(),
+					onDelta: timing.onDelta.snapshot(),
+					onStep: timing.onStep.snapshot(),
+				},
+			};
+		},
+		close() {
+			return Promise.resolve();
+		},
+	};
 }
 
 function summarizeConversation(conversation) {
@@ -246,7 +270,14 @@ function summarizeConversation(conversation) {
 	return conversation;
 }
 
-export function buildSummary({ artifactDir, streamEvents, deltaEvents, stepEvents, waitResult, conversation, includeConversation }) {
+export function buildSummary({
+	artifactDir,
+	counts,
+	timing,
+	waitResult,
+	conversation,
+	includeConversation,
+}) {
 	return {
 		artifactDir,
 		files: {
@@ -257,16 +288,8 @@ export function buildSummary({ artifactDir, streamEvents, deltaEvents, stepEvent
 			waitResult: artifactPath(artifactDir, "waitResult"),
 			conversation: includeConversation ? artifactPath(artifactDir, "conversation") : undefined,
 		},
-		counts: {
-			stream: countByType(streamEvents, (record) => eventType(record.event)),
-			onDelta: countByType(deltaEvents, (record) => eventType(record.update)),
-			onStep: countByType(stepEvents, (record) => eventType(record.step)),
-		},
-		timing: {
-			stream: timingSummary(streamEvents),
-			onDelta: timingSummary(deltaEvents),
-			onStep: timingSummary(stepEvents),
-		},
+		counts,
+		timing,
 		wait: waitResult
 			? {
 					status: waitResult.status,
@@ -300,37 +323,42 @@ async function captureEvents(args) {
 	};
 	writeFileSync(artifactPath(artifactDir, "metadata"), `${JSON.stringify(metadata, null, 2)}\n`);
 
-	const streamEvents = [];
-	const deltaEvents = [];
-	const stepEvents = [];
+	const restoreOutputFilter = installCursorSdkOutputFilter();
+	const eventSink = createEventJsonlSink(artifactDir, startedAt);
 	let agent;
 	try {
-		const { Agent } = await import("@cursor/sdk");
-		agent = await Agent.create({
-			apiKey: args.apiKey,
-			model: { id: args.model },
-			local: args.settingSources ? { cwd: args.cwd, settingSources: args.settingSources } : { cwd: args.cwd },
-		});
-
-		const run = await agent.send(
-			{ text: args.prompt },
-			{
-				onDelta: ({ update }) => pushTimed(deltaEvents, startedAt, "update", update),
-				onStep: ({ step }) => pushTimed(stepEvents, startedAt, "step", step),
-			},
+		const { Agent } = await suppressCursorSdkOutput(() => import("@cursor/sdk"));
+		agent = await suppressCursorSdkOutput(() =>
+			Agent.create({
+				apiKey: args.apiKey,
+				model: { id: args.model },
+				local: args.settingSources ? { cwd: args.cwd, settingSources: args.settingSources } : { cwd: args.cwd },
+			}),
 		);
 
-		for await (const event of run.stream()) {
-			pushTimed(streamEvents, startedAt, "event", event);
-		}
+		const run = await suppressCursorSdkOutput(() =>
+			agent.send(
+				{ text: args.prompt },
+				{
+					onDelta: ({ update }) => eventSink.appendDelta(update),
+					onStep: ({ step }) => eventSink.appendStep(step),
+				},
+			),
+		);
 
-		const waitResult = await run.wait();
+		await suppressCursorSdkOutput(async () => {
+			for await (const event of run.stream()) {
+				eventSink.appendStream(event);
+			}
+		});
+
+		const waitResult = await suppressCursorSdkOutput(() => run.wait());
 		writeFileSync(artifactPath(artifactDir, "waitResult"), `${JSON.stringify(waitResult, null, 2)}\n`);
 
 		let conversation;
 		if (args.includeConversation) {
 			if (run.supports("conversation")) {
-				conversation = await run.conversation();
+				conversation = await suppressCursorSdkOutput(() => run.conversation());
 			} else {
 				conversation = {
 					skipped: true,
@@ -340,13 +368,9 @@ async function captureEvents(args) {
 			writeFileSync(artifactPath(artifactDir, "conversation"), `${JSON.stringify(conversation, null, 2)}\n`);
 		}
 
-		writeEventArtifacts(artifactDir, { streamEvents, deltaEvents, stepEvents });
-
 		const summary = buildSummary({
 			artifactDir,
-			streamEvents,
-			deltaEvents,
-			stepEvents,
+			...eventSink.getSummaryState(),
 			waitResult,
 			conversation,
 			includeConversation: args.includeConversation,
@@ -354,11 +378,15 @@ async function captureEvents(args) {
 		writeFileSync(artifactPath(artifactDir, "summary"), `${JSON.stringify(summary, null, 2)}\n`);
 		printStdoutSummary(summary);
 	} catch (error) {
-		writeEventArtifacts(artifactDir, { streamEvents, deltaEvents, stepEvents });
 		const message = error instanceof Error ? error.message : String(error);
 		fail(message, [args.apiKey]);
 	} finally {
-		agent?.close();
+		await eventSink.close().catch(() => {});
+		try {
+			agent?.close();
+		} finally {
+			restoreOutputFilter();
+		}
 	}
 }
 

--- a/scripts/lib/cursor-probe-utils.mjs
+++ b/scripts/lib/cursor-probe-utils.mjs
@@ -1,0 +1,32 @@
+export const CURSOR_SETTING_SOURCES_ENV = "PI_CURSOR_SETTING_SOURCES";
+
+function escapeRegExp(value) {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function resolveCursorSettingSources(raw) {
+	const trimmed = raw?.trim();
+	if (!trimmed) return ["all"];
+	const normalized = trimmed.toLowerCase();
+	if (["0", "false", "off", "none", "omit", "disabled"].includes(normalized)) return undefined;
+	if (["1", "true", "on", "all"].includes(normalized)) return ["all"];
+	return trimmed
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+}
+
+export function scrubSensitiveText(text, apiKey) {
+	let scrubbed = text;
+	const trimmedKey = apiKey?.trim();
+	if (trimmedKey) {
+		scrubbed = scrubbed.replace(new RegExp(escapeRegExp(trimmedKey), "g"), "[redacted]");
+	}
+	return scrubbed
+		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+		.replace(/((?:^|[\s,{])cookie["']?\s*[:=]\s*["']?)[^\n]+/gi, "$1[redacted]")
+		.replace(
+			/((?:authorization|api[_-]?key|apiKey|token|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)[^"'\s,;}]+/gi,
+			"$1[redacted]",
+		);
+}

--- a/scripts/lib/cursor-sdk-output-filter.mjs
+++ b/scripts/lib/cursor-sdk-output-filter.mjs
@@ -1,0 +1,86 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export const CURSOR_SDK_STARTUP_NOISE_PATTERNS = [
+	"[hooks]",
+	"managed_skills.",
+	"CursorPluginsAgentSkillsService load completed",
+	"LocalCursorRulesService load completed",
+	"AgentSkillsCursorRulesService load completed",
+	"Error initializing ignore mapping for",
+	"Ripgrep path not configured. Call configureRipgrepPath() at startup.",
+];
+
+const cursorSdkOutputSuppression = new AsyncLocalStorage();
+
+export function isCursorSdkOutputSuppressed() {
+	return cursorSdkOutputSuppression.getStore() === true;
+}
+
+export function suppressCursorSdkOutput(operation) {
+	return cursorSdkOutputSuppression.run(true, operation);
+}
+
+export function isCursorSdkStartupNoise(text) {
+	return CURSOR_SDK_STARTUP_NOISE_PATTERNS.some((pattern) => text.includes(pattern));
+}
+
+function createFilteredProcessWrite(write, stream) {
+	return (chunk, encodingOrCallback, callback) => {
+		const text = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+		if (isCursorSdkOutputSuppressed() || isCursorSdkStartupNoise(text)) {
+			const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+			done?.();
+			return true;
+		}
+		return write.call(stream, chunk, encodingOrCallback, callback);
+	};
+}
+
+function createFilteredConsoleMethod(method) {
+	return (...args) => {
+		const text = args.map((arg) => (typeof arg === "string" ? arg : String(arg))).join(" ");
+		if (isCursorSdkOutputSuppressed() || isCursorSdkStartupNoise(text)) return;
+		method(...args);
+	};
+}
+
+let activeOutputFilterInstalls = 0;
+let outputFilterOriginals;
+
+export function installCursorSdkOutputFilter() {
+	if (activeOutputFilterInstalls === 0) {
+		outputFilterOriginals = {
+			stdoutWrite: process.stdout.write,
+			stderrWrite: process.stderr.write,
+			consoleLog: console.log,
+			consoleInfo: console.info,
+			consoleWarn: console.warn,
+			consoleError: console.error,
+			consoleDebug: console.debug,
+		};
+		process.stdout.write = createFilteredProcessWrite(outputFilterOriginals.stdoutWrite, process.stdout);
+		process.stderr.write = createFilteredProcessWrite(outputFilterOriginals.stderrWrite, process.stderr);
+		console.log = createFilteredConsoleMethod(outputFilterOriginals.consoleLog);
+		console.info = createFilteredConsoleMethod(outputFilterOriginals.consoleInfo);
+		console.warn = createFilteredConsoleMethod(outputFilterOriginals.consoleWarn);
+		console.error = createFilteredConsoleMethod(outputFilterOriginals.consoleError);
+		console.debug = createFilteredConsoleMethod(outputFilterOriginals.consoleDebug);
+	}
+	activeOutputFilterInstalls += 1;
+
+	let restored = false;
+	return () => {
+		if (restored) return;
+		restored = true;
+		activeOutputFilterInstalls = Math.max(activeOutputFilterInstalls - 1, 0);
+		if (activeOutputFilterInstalls > 0 || !outputFilterOriginals) return;
+		process.stdout.write = outputFilterOriginals.stdoutWrite;
+		process.stderr.write = outputFilterOriginals.stderrWrite;
+		console.log = outputFilterOriginals.consoleLog;
+		console.info = outputFilterOriginals.consoleInfo;
+		console.warn = outputFilterOriginals.consoleWarn;
+		console.error = outputFilterOriginals.consoleError;
+		console.debug = outputFilterOriginals.consoleDebug;
+		outputFilterOriginals = undefined;
+	};
+}

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -8,7 +8,7 @@ import {
 	type AssistantMessage,
 } from "@earendil-works/pi-ai";
 import { Agent, createAgentPlatform } from "@cursor/sdk";
-import type { SDKAgent, SettingSource } from "@cursor/sdk";
+import type { SDKAgent } from "@cursor/sdk";
 import { installCursorMcpToolTimeoutOverride } from "./cursor-mcp-timeout-override.js";
 import { installCursorSdkOutputFilter, suppressCursorSdkOutput } from "./cursor-sdk-output-filter.js";
 import { buildCursorSendPrompt } from "./context.js";
@@ -78,8 +78,7 @@ const GENERIC_CURSOR_SDK_ERROR_MESSAGE =
 	"Cursor SDK request failed. The API key may be missing, invalid, or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
 const AUTH_CURSOR_SDK_ERROR_MESSAGE =
 	"Cursor SDK request failed because the API key may be invalid or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
-const CURSOR_SETTING_SOURCES_ENV = "PI_CURSOR_SETTING_SOURCES";
-
+import { resolveCursorSettingSources } from "./cursor-setting-sources.js";
 import { scrubSensitiveText } from "./cursor-sensitive-text.js";
 import { hasUsableText } from "./cursor-record-utils.js";
 
@@ -97,18 +96,6 @@ function resolveCursorApiKey(apiKey?: string): string | undefined {
 	if (!trimmed) return undefined;
 	if (trimmed === CURSOR_API_KEY_ENV_VAR) return process.env.CURSOR_API_KEY?.trim();
 	return trimmed;
-}
-
-function resolveCursorSettingSources(): SettingSource[] | undefined {
-	const raw = process.env[CURSOR_SETTING_SOURCES_ENV]?.trim();
-	if (!raw) return ["all"];
-	const normalized = raw.toLowerCase();
-	if (["0", "false", "off", "none", "omit", "disabled"].includes(normalized)) return undefined;
-	if (["1", "true", "on", "all"].includes(normalized)) return ["all"];
-	return raw
-		.split(",")
-		.map((entry) => entry.trim())
-		.filter((entry): entry is SettingSource => Boolean(entry));
 }
 
 function sanitizeError(error: unknown, apiKey?: string): string {
@@ -173,7 +160,7 @@ export function streamCursor(
 			const cwd = getCursorSessionCwd();
 			const fastEnabled = getEffectiveFastForModelId(model.id);
 			const selection = buildCursorModelSelection(model.id, options?.reasoning ?? "off", fastEnabled);
-			const settingSources = resolveCursorSettingSources();
+			const settingSources = resolveCursorSettingSources(process.env.PI_CURSOR_SETTING_SOURCES);
 
 			installCursorMcpToolTimeoutOverride();
 			restoreCursorSdkOutputFilter = installCursorSdkOutputFilter();

--- a/src/cursor-setting-sources.ts
+++ b/src/cursor-setting-sources.ts
@@ -1,0 +1,15 @@
+import type { SettingSource } from "@cursor/sdk";
+
+export const CURSOR_SETTING_SOURCES_ENV = "PI_CURSOR_SETTING_SOURCES";
+
+export function resolveCursorSettingSources(raw?: string): SettingSource[] | undefined {
+	const trimmed = raw?.trim();
+	if (!trimmed) return ["all"];
+	const normalized = trimmed.toLowerCase();
+	if (["0", "false", "off", "none", "omit", "disabled"].includes(normalized)) return undefined;
+	if (["1", "true", "on", "all"].includes(normalized)) return ["all"];
+	return trimmed
+		.split(",")
+		.map((entry) => entry.trim())
+		.filter((entry): entry is SettingSource => Boolean(entry));
+}

--- a/test/cursor-setting-sources.test.ts
+++ b/test/cursor-setting-sources.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { resolveCursorSettingSources, CURSOR_SETTING_SOURCES_ENV } from "../src/cursor-setting-sources.js";
+
+describe("resolveCursorSettingSources", () => {
+	it("defaults to all when unset", () => {
+		expect(resolveCursorSettingSources(undefined)).toEqual(["all"]);
+		expect(resolveCursorSettingSources("")).toEqual(["all"]);
+	});
+
+	it("maps disable aliases to undefined", () => {
+		for (const raw of ["none", "0", "false", "off", "omit", "disabled"]) {
+			expect(resolveCursorSettingSources(raw)).toBeUndefined();
+		}
+	});
+
+	it("maps enable aliases to all", () => {
+		for (const raw of ["all", "1", "true", "on"]) {
+			expect(resolveCursorSettingSources(raw)).toEqual(["all"]);
+		}
+	});
+
+	it("parses comma-separated lists", () => {
+		expect(resolveCursorSettingSources("project,user")).toEqual(["project", "user"]);
+	});
+
+	it("exports the provider env var name", () => {
+		expect(CURSOR_SETTING_SOURCES_ENV).toBe("PI_CURSOR_SETTING_SOURCES");
+	});
+});

--- a/test/debug-sdk-events.test.ts
+++ b/test/debug-sdk-events.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { parseDebugSdkEventsArgs } from "../scripts/debug-sdk-events.mjs";
+import { buildSummary, parseDebugSdkEventsArgs } from "../scripts/debug-sdk-events.mjs";
 
 const scriptPath = "scripts/debug-sdk-events.mjs";
 
@@ -10,6 +10,21 @@ function run(args: string[], env: Record<string, string | undefined> = {}) {
 		encoding: "utf8",
 		env: { ...process.env, ...env },
 	});
+}
+
+function collectStrings(value: unknown, strings: string[] = []): string[] {
+	if (typeof value === "string") {
+		strings.push(value);
+		return strings;
+	}
+	if (Array.isArray(value)) {
+		for (const entry of value) collectStrings(entry, strings);
+		return strings;
+	}
+	if (value && typeof value === "object") {
+		for (const entry of Object.values(value)) collectStrings(entry, strings);
+	}
+	return strings;
 }
 
 describe("debug-sdk-events maintainer probe", () => {
@@ -38,6 +53,39 @@ describe("debug-sdk-events maintainer probe", () => {
 		expect(parseDebugSdkEventsArgs(["--setting-sources", "none", "--prompt", "x"], {})).toMatchObject({
 			settingSources: undefined,
 		});
+	});
+
+	it("builds stdout-safe summaries without raw SDK payloads", () => {
+		const artifactDir = "/tmp/pi-cursor-sdk-sdk-events-test";
+		const summary = buildSummary({
+			artifactDir,
+			streamEvents: [
+				{
+					ts: "2026-05-24T00:00:00.000Z",
+					elapsedMs: 0,
+					event: { type: "assistant", message: { content: [{ type: "text", text: "secret payload" }] } },
+				},
+			],
+			deltaEvents: [{ ts: "2026-05-24T00:00:00.100Z", elapsedMs: 100, update: { type: "text-delta", text: "delta" } }],
+			stepEvents: [{ ts: "2026-05-24T00:00:00.200Z", elapsedMs: 200, step: { type: "toolCall", message: { name: "read" } } }],
+			waitResult: { status: "finished", durationMs: 250, result: "done" },
+			conversation: [{ role: "user", content: "hello" }],
+			includeConversation: true,
+		});
+
+		expect(summary.counts).toEqual({
+			stream: { assistant: 1 },
+			onDelta: { "text-delta": 1 },
+			onStep: { toolCall: 1 },
+		});
+		expect(summary.wait).toEqual({ status: "finished", durationMs: 250, hasResultText: true });
+		expect(summary.conversation).toEqual({ turnCount: 1 });
+		expect(summary.files.streamEvents).toBe(`${artifactDir}/stream-events.jsonl`);
+
+		const stdoutPayload = JSON.stringify(summary);
+		expect(stdoutPayload).not.toContain("secret payload");
+		expect(stdoutPayload).not.toContain('"text": "delta"');
+		expect(collectStrings(summary)).not.toContain("hello");
 	});
 
 	it("shows help and validates script syntax without live Cursor auth", () => {

--- a/test/debug-sdk-events.test.ts
+++ b/test/debug-sdk-events.test.ts
@@ -1,0 +1,68 @@
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+import { parseDebugSdkEventsArgs } from "../scripts/debug-sdk-events.mjs";
+
+const scriptPath = "scripts/debug-sdk-events.mjs";
+
+function run(args: string[], env: Record<string, string | undefined> = {}) {
+	return spawnSync(process.execPath, [scriptPath, ...args], {
+		cwd: process.cwd(),
+		encoding: "utf8",
+		env: { ...process.env, ...env },
+	});
+}
+
+describe("debug-sdk-events maintainer probe", () => {
+	it("parses args and setting source overrides", () => {
+		expect(
+			parseDebugSdkEventsArgs(["--cwd", "/tmp/work", "--model", "composer-2.5", "--prompt", "hello"], {
+				CURSOR_API_KEY: "key",
+				PI_CURSOR_SETTING_SOURCES: "all",
+			}),
+		).toMatchObject({
+			cwd: "/tmp/work",
+			model: "composer-2.5",
+			prompt: "hello",
+			apiKey: "key",
+			settingSources: ["all"],
+		});
+
+		expect(
+			parseDebugSdkEventsArgs(["--setting-sources", "project,user", "--prompt", "x"], {
+				PI_CURSOR_SETTING_SOURCES: "all",
+			}),
+		).toMatchObject({
+			settingSources: ["project", "user"],
+		});
+
+		expect(parseDebugSdkEventsArgs(["--setting-sources", "none", "--prompt", "x"], {})).toMatchObject({
+			settingSources: undefined,
+		});
+	});
+
+	it("shows help and validates script syntax without live Cursor auth", () => {
+		expect(spawnSync(process.execPath, ["--check", scriptPath], { cwd: process.cwd(), encoding: "utf8" }).status).toBe(0);
+
+		const help = run(["--help"]);
+		expect(help.status).toBe(0);
+		expect(help.stdout).toContain("Capture timestamped Cursor SDK event timelines");
+		expect(help.stdout).toContain("run.stream()");
+		expect(help.stdout).toContain("onDelta");
+		expect(help.stdout).toContain("onStep");
+		expect(help.stdout).toContain("https://cursor.com/docs/sdk/typescript");
+	});
+
+	it("fails fast on missing prompt and missing api key without printing secrets", () => {
+		const leakedKey = "super-secret-cursor-key-12345";
+
+		const missingPrompt = run(["--api-key", leakedKey], { CURSOR_API_KEY: undefined });
+		expect(missingPrompt.status).toBe(1);
+		expect(missingPrompt.stderr).toContain("--prompt is required");
+		expect(`${missingPrompt.stdout}${missingPrompt.stderr}`).not.toContain(leakedKey);
+
+		const missingKey = run(["--prompt", "hello"], { CURSOR_API_KEY: undefined });
+		expect(missingKey.status).toBe(1);
+		expect(missingKey.stderr).toContain("Cursor API key is required");
+		expect(`${missingKey.stdout}${missingKey.stderr}`).not.toContain("hello");
+	});
+});

--- a/test/debug-sdk-events.test.ts
+++ b/test/debug-sdk-events.test.ts
@@ -1,6 +1,23 @@
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { buildSummary, parseDebugSdkEventsArgs } from "../scripts/debug-sdk-events.mjs";
+import { CURSOR_SDK_STARTUP_NOISE_PATTERNS as providerNoisePatterns } from "../src/cursor-sdk-output-filter.js";
+import { resolveCursorSettingSources as resolveProviderSettingSources } from "../src/cursor-setting-sources.js";
+import { scrubSensitiveText as scrubProviderSensitiveText } from "../src/cursor-sensitive-text.js";
+import { CURSOR_SDK_STARTUP_NOISE_PATTERNS as scriptNoisePatterns } from "../scripts/lib/cursor-sdk-output-filter.mjs";
+import {
+	CURSOR_SETTING_SOURCES_ENV,
+	resolveCursorSettingSources as resolveScriptSettingSources,
+	scrubSensitiveText as scrubScriptSensitiveText,
+} from "../scripts/lib/cursor-probe-utils.mjs";
+import {
+	buildSummary,
+	createEventJsonlSink,
+	parseDebugSdkEventsArgs,
+} from "../scripts/debug-sdk-events.mjs";
+import { installCursorSdkOutputFilter, suppressCursorSdkOutput } from "../scripts/lib/cursor-sdk-output-filter.mjs";
 
 const scriptPath = "scripts/debug-sdk-events.mjs";
 
@@ -59,15 +76,16 @@ describe("debug-sdk-events maintainer probe", () => {
 		const artifactDir = "/tmp/pi-cursor-sdk-sdk-events-test";
 		const summary = buildSummary({
 			artifactDir,
-			streamEvents: [
-				{
-					ts: "2026-05-24T00:00:00.000Z",
-					elapsedMs: 0,
-					event: { type: "assistant", message: { content: [{ type: "text", text: "secret payload" }] } },
-				},
-			],
-			deltaEvents: [{ ts: "2026-05-24T00:00:00.100Z", elapsedMs: 100, update: { type: "text-delta", text: "delta" } }],
-			stepEvents: [{ ts: "2026-05-24T00:00:00.200Z", elapsedMs: 200, step: { type: "toolCall", message: { name: "read" } } }],
+			counts: {
+				stream: { assistant: 1 },
+				onDelta: { "text-delta": 1 },
+				onStep: { toolCall: 1 },
+			},
+			timing: {
+				stream: { eventCount: 1, firstMs: 0, lastMs: 0, maxGapMs: undefined },
+				onDelta: { eventCount: 1, firstMs: 100, lastMs: 100, maxGapMs: undefined },
+				onStep: { eventCount: 1, firstMs: 200, lastMs: 200, maxGapMs: undefined },
+			},
 			waitResult: { status: "finished", durationMs: 250, result: "done" },
 			conversation: [{ role: "user", content: "hello" }],
 			includeConversation: true,
@@ -86,6 +104,100 @@ describe("debug-sdk-events maintainer probe", () => {
 		expect(stdoutPayload).not.toContain("secret payload");
 		expect(stdoutPayload).not.toContain('"text": "delta"');
 		expect(collectStrings(summary)).not.toContain("hello");
+	});
+
+	it("appends JSONL event records incrementally and preserves partial artifacts", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-sdk-events-"));
+		writeFileSync(join(artifactDir, "stream-events.jsonl"), "stale\n");
+		const startedAt = Date.now();
+		const sink = createEventJsonlSink(artifactDir, startedAt);
+		try {
+			sink.appendStream({ type: "assistant", message: { content: [{ type: "text", text: "partial" }] } });
+			sink.appendDelta({ type: "text-delta", text: "delta" });
+			sink.appendStep({ type: "toolCall", message: { name: "read" } });
+
+			const streamEvents = readFileSync(join(artifactDir, "stream-events.jsonl"), "utf8");
+			expect(streamEvents).not.toContain("stale");
+			expect(streamEvents.trim().split("\n")).toHaveLength(1);
+			expect(JSON.parse(streamEvents.trim()).event.type).toBe("assistant");
+
+			const deltaEvents = readFileSync(join(artifactDir, "on-delta.jsonl"), "utf8");
+			expect(JSON.parse(deltaEvents.trim()).update.type).toBe("text-delta");
+
+			expect(sink.getSummaryState().counts.stream).toEqual({ assistant: 1 });
+			expect(readFileSync(join(artifactDir, "on-step.jsonl"), "utf8").trim()).not.toBe("");
+		} finally {
+			await sink.close();
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
+	it("matches provider setting-source parsing and secret scrubbing helpers", () => {
+		expect(CURSOR_SETTING_SOURCES_ENV).toBe("PI_CURSOR_SETTING_SOURCES");
+		expect(scriptNoisePatterns).toEqual(providerNoisePatterns);
+
+		for (const raw of [undefined, "", "all", "none", "project,user", "OFF", "0"]) {
+			expect(resolveScriptSettingSources(raw)).toEqual(resolveProviderSettingSources(raw));
+		}
+
+		const leakedKey = "super-secret-cursor-key-12345";
+		const sample = `Bearer ${leakedKey} api_key=${leakedKey}`;
+		expect(scrubScriptSensitiveText(sample, leakedKey)).toBe(scrubProviderSensitiveText(sample, leakedKey));
+	});
+
+	it("filters SDK startup noise from stdout while allowing the final summary", async () => {
+		const terminalWrites: string[] = [];
+		const originalStdoutWrite = process.stdout.write;
+		process.stdout.write = ((
+			chunk: string | Uint8Array,
+			encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+			callback?: (error?: Error | null) => void,
+		) => {
+			terminalWrites.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			const done = typeof encodingOrCallback === "function" ? encodingOrCallback : callback;
+			done?.();
+			return true;
+		}) as typeof process.stdout.write;
+
+		const restore = installCursorSdkOutputFilter();
+		try {
+			await suppressCursorSdkOutput(async () => {
+				process.stdout.write("managed_skills.example load completed\n");
+				console.log("[hooks] SessionStart trigger matcher is not supported in Cursor");
+			});
+
+			process.stdout.write(`${JSON.stringify({ artifactDir: "/tmp/example", counts: { stream: { assistant: 1 } } })}\n`);
+		} finally {
+			restore();
+			process.stdout.write = originalStdoutWrite;
+		}
+
+		const output = terminalWrites.join("");
+		expect(output).not.toContain("managed_skills.");
+		expect(output).not.toContain("[hooks]");
+		expect(output).toContain('"/tmp/example"');
+	});
+
+	it("runs packaged help from node_modules without importing TypeScript helpers", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-package-runtime-"));
+		const packageRoot = join(root, "node_modules", "pi-cursor-sdk");
+		try {
+			mkdirSync(join(packageRoot, "scripts", "lib"), { recursive: true });
+			mkdirSync(join(packageRoot, "src"), { recursive: true });
+			cpSync("package.json", join(packageRoot, "package.json"));
+			cpSync(scriptPath, join(packageRoot, scriptPath));
+			cpSync("scripts/lib/cursor-probe-utils.mjs", join(packageRoot, "scripts/lib/cursor-probe-utils.mjs"));
+			cpSync("scripts/lib/cursor-sdk-output-filter.mjs", join(packageRoot, "scripts/lib/cursor-sdk-output-filter.mjs"));
+			cpSync("src/cursor-setting-sources.ts", join(packageRoot, "src/cursor-setting-sources.ts"));
+			cpSync("src/cursor-sensitive-text.ts", join(packageRoot, "src/cursor-sensitive-text.ts"));
+
+			const result = spawnSync(process.execPath, [scriptPath, "--help"], { cwd: packageRoot, encoding: "utf8" });
+			expect(result.status).toBe(0);
+			expect(result.stdout).toContain("Capture timestamped Cursor SDK event timelines");
+			expect(result.stderr).not.toContain("ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
 	});
 
 	it("shows help and validates script syntax without live Cursor auth", () => {

--- a/test/smoke-tooling.test.ts
+++ b/test/smoke-tooling.test.ts
@@ -11,11 +11,13 @@ describe("smoke tooling package checks", () => {
 		expect(run("bash", ["-n", "scripts/isolated-cursor-smoke.sh"]).status).toBe(0);
 		expect(run(process.execPath, ["--check", "scripts/steering-rpc-smoke.mjs"]).status).toBe(0);
 		expect(run(process.execPath, ["--check", "scripts/validate-smoke-jsonl.mjs"]).status).toBe(0);
+		expect(run(process.execPath, ["--check", "scripts/debug-sdk-events.mjs"]).status).toBe(0);
 
 		const liveHelp = run("scripts/tmux-live-smoke.sh", ["--help"]);
 		const isolatedHelp = run("scripts/isolated-cursor-smoke.sh", ["--help"]);
 		const steeringHelp = run(process.execPath, ["scripts/steering-rpc-smoke.mjs", "--help"]);
 		const jsonlHelp = run(process.execPath, ["scripts/validate-smoke-jsonl.mjs", "--help"]);
+		const sdkEventsHelp = run(process.execPath, ["scripts/debug-sdk-events.mjs", "--help"]);
 
 		expect(liveHelp.status).toBe(0);
 		expect(liveHelp.stdout).toContain("retry-empty-output");
@@ -26,6 +28,8 @@ describe("smoke tooling package checks", () => {
 		expect(jsonlHelp.status).toBe(0);
 		expect(jsonlHelp.stdout).toContain("Validate assistant presence");
 		expect(jsonlHelp.stdout).toContain("--replay-errors");
+		expect(sdkEventsHelp.status).toBe(0);
+		expect(sdkEventsHelp.stdout).toContain("Capture timestamped Cursor SDK event timelines");
 	});
 
 	it("packages smoke scripts and avoids reusing the v0.1.16 tarball version", () => {
@@ -41,6 +45,7 @@ describe("smoke tooling package checks", () => {
 		expect(paths.has("scripts/isolated-cursor-smoke.sh")).toBe(true);
 		expect(paths.has("scripts/steering-rpc-smoke.mjs")).toBe(true);
 		expect(paths.has("scripts/validate-smoke-jsonl.mjs")).toBe(true);
+		expect(paths.has("scripts/debug-sdk-events.mjs")).toBe(true);
 		expect(paths.has("CHANGELOG.md")).toBe(true);
 		expect(paths.has("README.md")).toBe(true);
 		expect([...paths].some((path) => path.startsWith("dist/") || path.startsWith("coverage/") || path.startsWith(".pi/") || path.includes("smoke-dir"))).toBe(false);


### PR DESCRIPTION
## Summary
- Adds `scripts/debug-sdk-events.mjs` and `npm run debug:sdk-events` to capture timestamped `run.stream()`, `onDelta`, and `onStep` timelines for one local Cursor SDK run.
- Writes artifacts under `/tmp/...` by default (metadata, JSONL event logs, wait result, optional conversation, summary counts/timing gaps) while keeping stdout to paths and summary only.
- Documents maintainer usage in README and `docs/cursor-testing-lessons.md`; adds unit tests for help, arg parsing, and no-key failure without secret leakage.

Closes #33.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm pack --dry-run`
- [ ] Live probe run with `CURSOR_API_KEY=... npm run debug:sdk-events -- --prompt '...'` (requires maintainer auth)


Made with [Cursor](https://cursor.com)