### PR TITLE
Add provider SDK event debug capture for investigations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-session-send-policy.ts` owns session send planning (`bootstrap` vs `incremental`), periodic agent rebootstrap threshold, and prompt mode selection.
 - `src/cursor-provider-live-run-drain.ts` owns live-run drain/replay mirroring, pre-send continuation, and native replay turn emission.
 - `src/cursor-provider-turn-coordinator.ts` owns SDK delta/step handling, tool completion routing, and trace/native-replay emission during a turn.
+- `src/cursor-sdk-event-debug.ts` owns opt-in raw Cursor SDK `onDelta`/`onStep`/`wait` capture for provider debugging under `.debug/`.
 - `src/cursor-sdk-output-filter.ts` suppresses Cursor SDK integrator bootstrap noise from pi's TUI.
 - `src/cursor-edit-diff.ts` owns canonical edit diff fallback resolution for replay/display paths.
 - `src/cursor-record-utils.ts` owns shared record/string-key parsing helpers used across bridge and transcript layers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,6 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-native-tool-display-state.ts` owns native replay display state, env gating, and record/consume helpers.
 - `src/cursor-tool-transcript.ts`, `src/cursor-transcript-utils.ts`, `src/cursor-transcript-tool-formatters.ts`, and `src/cursor-tool-names.ts` handle display-only Cursor native tool replay and transcript labels.
 - `src/cursor-mcp-timeout-override.ts` owns Cursor SDK MCP call timeout overrides for long-running local MCP tools.
-- `src/cursor-agents-context.ts` owns Cursor-model suppression of pi `<project_context>` / `AGENTS.md` duplication and `PI_CURSOR_PRESERVE_PI_AGENTS_MD`.
 - `src/cursor-state.ts` owns `/cursor-fast`, `--cursor-fast`, `--cursor-no-fast`, session state, and global fast defaults.
 - `src/context.ts`, `src/context-window-cache.ts`, and `src/bundled-context-windows.ts` handle prompt conversion and context-window caches.
 - `test/**/*.test.ts` contains Vitest coverage for provider registration, discovery, state, context, bridge, replay, and streaming behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,10 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-session-send-policy.ts` owns session send planning (`bootstrap` vs `incremental`), periodic agent rebootstrap threshold, and prompt mode selection.
 - `src/cursor-provider-live-run-drain.ts` owns live-run drain/replay mirroring, pre-send continuation, and native replay turn emission.
 - `src/cursor-provider-turn-coordinator.ts` owns SDK delta/step handling, tool completion routing, and trace/native-replay emission during a turn.
-- `src/cursor-sdk-event-debug.ts` owns opt-in raw Cursor SDK `onDelta`/`onStep`/`wait` capture for provider debugging under `.debug/`.
+- `src/cursor-sdk-event-debug.ts` owns opt-in provider event artifact capture for Cursor SDK callbacks, stream events, replay/drain/bridge decisions, final partials, and summaries under `.debug/cursor-sdk-events/`.
+- `src/cursor-sdk-event-debug-constants.ts` owns debug artifact/env names and default artifact base-dir resolution.
+- `src/cursor-sdk-event-debug-session.ts` owns debug session grouping, turn artifact directory allocation, and session manifest updates.
+- `src/cursor-agents-context.ts` owns Cursor-model suppression of pi `<project_context>` / `AGENTS.md` duplication and `PI_CURSOR_PRESERVE_PI_AGENTS_MD`.
 - `src/cursor-sdk-output-filter.ts` suppresses Cursor SDK integrator bootstrap noise from pi's TUI.
 - `src/cursor-edit-diff.ts` owns canonical edit diff fallback resolution for replay/display paths.
 - `src/cursor-record-utils.ts` owns shared record/string-key parsing helpers used across bridge and transcript layers.
@@ -69,6 +72,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - Watch tests while developing: `npm run test:watch`
 - Local development run, requires a Cursor key: `CURSOR_API_KEY="your-key" pi -e . --model cursor/composer-2.5`
 - List Cursor models, requires pi and usually a Cursor key: `pi --list-models cursor`
+- Capture provider/SDK event artifacts for one prompt, requires a Cursor key: `CURSOR_API_KEY="your-key" npm run debug:provider-events -- --prompt "hello"`
 
 There is no lint or format script in `package.json` at this time.
 
@@ -105,6 +109,7 @@ Use a short written plan before multi-file behavior changes, SDK integration cha
 
 - NEVER store Cursor API keys in repo files, `~/.pi/agent/cursor-sdk.json`, tests, logs, snapshots, or docs examples.
 - Scrub Cursor SDK errors and output that may contain API keys, bearer tokens, cookies, sessions, or auth headers.
+- `PI_CURSOR_SDK_EVENT_DEBUG=1` and `npm run debug:provider-events` write raw local artifacts that may include prompts, tool args/results, local paths, or secrets; keep them under gitignored `.debug/`, do not print or commit them, and keep run-scoped debug state explicit rather than process-global.
 - Ambient Cursor settings/rules loading is enabled by default through `PI_CURSOR_SETTING_SOURCES=all`; keep SDK startup log filtering intact so settings/skills output does not corrupt pi's TUI.
 - Live `pi`/Cursor smoke tests may call external services and require Cursor auth in `~/.pi/agent/auth.json` and/or `CURSOR_API_KEY`; run them for Cursor provider/runtime changes. If auth is unavailable, report live smoke as release-blocked instead of skipped-ready. See `docs/cursor-testing-lessons.md` for isolated harness auth seeding.
 - For Cursor provider/runtime changes, follow `docs/cursor-live-smoke-checklist.md`. Assume every runtime surface is in scope. Use real `pi -e . --cursor-no-fast --model cursor/composer-2.5` invocations, a temporary `--session-dir`, manual observation, and no secret printing. Do not mark release-ready with optional/deferred/mostly-passing smoke items outstanding.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,11 @@ For Cursor provider/runtime changes, follow the manual [Cursor live smoke checkl
 
 ### Maintainer Cursor SDK event capture
 
-Use `npm run debug:sdk-events` to capture timestamped `run.stream()`, `onDelta`, and `onStep` timelines for one local SDK run. See [Cursor testing lessons](docs/cursor-testing-lessons.md#cursor-sdk-event-capture-probe) for usage, artifact layout, and safety notes.
+Use `npm run debug:sdk-events` to capture timestamped `run.stream()`, `onDelta`, and `onStep` timelines for one direct `@cursor/sdk` run.
+
+Use `npm run debug:provider-events` to capture the same `onDelta`/`onStep` payloads **through pi's Cursor provider** (session agent reuse, bridge, native replay, send planning). Artifacts default under gitignored `.debug/cursor-sdk-events/`. Interactive multi-turn pi sessions group turns under `.debug/cursor-sdk-events/sessions/<session-slug>/turn-NNN-.../` with a `session.json` index. You can also opt in during any pi run with `PI_CURSOR_SDK_EVENT_DEBUG=1`; capture is file-only by default so the pi TUI stays normal.
+
+See [Cursor testing lessons](docs/cursor-testing-lessons.md#cursor-sdk-event-capture-probe) for usage, artifact layout, and safety notes.
 
 ## Fallback models
 

--- a/docs/cursor-testing-lessons.md
+++ b/docs/cursor-testing-lessons.md
@@ -238,6 +238,79 @@ Stdout prints artifact paths and summary counts only. Raw payloads stay on disk 
 
 Hard repo rule: Cursor SDK behavior claims must come from the installed `@cursor/sdk` package and/or https://cursor.com/docs/sdk/typescript, not from memory or ad-hoc probes alone.
 
+## Pi provider SDK event capture
+
+When debugging pi parsing, replay routing, bridge timing, or send-plan behavior, capture the raw `onDelta`/`onStep` payloads **as the Cursor provider receives them** instead of using the direct SDK probe above.
+
+One-shot maintainer script (RPC pi run, gitignored artifacts by default):
+
+```bash
+CURSOR_API_KEY=... npm run debug:provider-events -- \
+  --cwd . \
+  --model cursor/composer-2.5 \
+  --prompt 'Repro prompt here' \
+  --out .debug/cursor-sdk-events/manual-repro
+```
+
+Or read a prompt from disk:
+
+```bash
+CURSOR_API_KEY=... npm run debug:provider-events -- \
+  --prompt-file .debug/repro-prompt.txt \
+  --out .debug/cursor-sdk-events/manual-repro
+```
+
+Artifacts under `--out` (default `.debug/cursor-sdk-events/<timestamp>/` under `--cwd`):
+
+- `metadata.json` — model, cwd, send-plan/provider metadata
+- `context-snapshot.json` — full pi `Context` passed into the provider turn
+- `send-payload.json` — exact `agent.send()` input (text + images)
+- `on-delta.jsonl` — raw `InteractionUpdate` objects passed to `turnCoordinator.handleDelta`
+- `on-step.jsonl` — raw `onStep` payloads passed to `turnCoordinator.handleStep`
+- `stream-events.jsonl` — raw `run.stream()` events when supported
+- `pi-stream-events.jsonl` — exact pi stream events emitted to the TUI (`text_delta`, `thinking_delta`, replay cards, `done`, etc.)
+- `provider-events.jsonl` — provider lifecycle markers (`agent_send_start`, `agent_send_returned`, …)
+- `live-run-events.jsonl` — queued native replay / bridge live-run events
+- `bridge-events.jsonl` — bridge lifecycle/request diagnostics (file-only; no stderr unless bridge debug is also enabled)
+- `bridge-raw.jsonl` — raw bridged MCP args/results
+- `display-decisions.jsonl` — per-tool native replay routing (`queue_replay`, `emit_trace`, `inactive_trace`, dedupe skips, bridge ignores) with transcript/trace text
+- `coordinator-events.jsonl` — turn-coordinator side effects (task progress labels, etc.)
+- `drain-events.jsonl` — live-run pre-send drain and per-turn drain lifecycle (`turn_start`, `turn_end`, inactive replay traces, native display registration)
+- `timeline.jsonl` — merged cross-layer timeline (one grep-friendly stream for the whole turn)
+- `pi-session-snapshot.jsonl` — copy of pi session JSONL at turn finalize (session dir also gets latest `pi-session.jsonl`)
+- `final-partial.json` — assistant partial emitted to pi at end of the provider turn
+- `errors.jsonl` — provider/stream/conversation failures
+- `wait-result.json` — `run.wait()` result
+- `conversation.json` — `run.conversation()` when supported
+- `summary.json` — counts and artifact paths
+
+During any normal pi session you can also opt in with:
+
+```bash
+PI_CURSOR_SDK_EVENT_DEBUG=1 pi -e . --model cursor/composer-2.5
+```
+
+Multi-turn sessions group automatically by pi session file:
+
+```text
+.debug/cursor-sdk-events/sessions/<session-slug>/
+  session.json                 # index of all turns in this pi session
+  turn-001-<timestamp>/        # first provider turn
+  turn-002-<timestamp>/        # second provider turn
+  ...
+```
+
+Each turn still gets the full per-turn artifact bundle above. Use `session.json` to jump between turns while debugging incremental send, bridge resolution, or native replay continuation across pi messages. For tool-heavy turns, trace/thinking replay often drains on the **next** pi message — check turn N+1 `drain-events.jsonl` and `pi-stream-events.jsonl` alongside turn N `display-decisions.jsonl`.
+
+Optional env:
+
+- `PI_CURSOR_SDK_EVENT_DEBUG_DIR` — base directory (default `.debug/cursor-sdk-events`)
+- `PI_CURSOR_SDK_EVENT_DEBUG_SESSION_DIR` — exact session root for all turns in the current pi session
+- `PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR` — exact artifact directory for one isolated turn (the maintainer script sets this via `--out`; bypasses session grouping)
+- `PI_CURSOR_SDK_EVENT_DEBUG_STDERR=1` — also print the summary line to stderr (off by default so the pi TUI stays normal)
+
+Capture is file-only by default: no stderr markers, and bridge diagnostics during SDK event debug go to `bridge-events.jsonl` instead of `[pi-cursor-sdk:bridge]` unless you separately set `PI_CURSOR_PI_TOOL_BRIDGE_DEBUG=1`. Raw payloads stay on disk and may contain secrets — do not commit or share them.
+
 ## Related docs and scripts
 
 - [Cursor live smoke checklist](./cursor-live-smoke-checklist.md)
@@ -246,4 +319,5 @@ Hard repo rule: Cursor SDK behavior claims must come from the installed `@cursor
 - `scripts/tmux-live-smoke.sh`
 - `scripts/validate-smoke-jsonl.mjs`
 - `scripts/debug-sdk-events.mjs`
+- `scripts/debug-provider-events.mjs`
 - `test/helpers/cursor-provider-harness.ts` — controllable native replay pi mock (`createNativeToolDisplayPiForTest`)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"scripts/isolated-cursor-smoke.sh",
 		"scripts/validate-smoke-jsonl.mjs",
 		"scripts/debug-sdk-events.mjs",
+		"scripts/debug-provider-events.mjs",
 		"scripts/lib/cursor-probe-utils.mjs",
 		"scripts/lib/cursor-sdk-output-filter.mjs",
 		"README.md",
@@ -53,7 +54,8 @@
 		"smoke:isolated": "scripts/isolated-cursor-smoke.sh",
 		"smoke:steering": "node scripts/steering-rpc-smoke.mjs",
 		"smoke:jsonl": "node scripts/validate-smoke-jsonl.mjs",
-		"debug:sdk-events": "node scripts/debug-sdk-events.mjs"
+		"debug:sdk-events": "node scripts/debug-sdk-events.mjs",
+		"debug:provider-events": "node scripts/debug-provider-events.mjs"
 	},
 	"dependencies": {
 		"@cursor/sdk": "^1.0.13",

--- a/scripts/debug-provider-events.mjs
+++ b/scripts/debug-provider-events.mjs
@@ -1,0 +1,373 @@
+#!/usr/bin/env node
+/**
+ * Maintainer probe: run one prompt through pi's Cursor provider and capture raw SDK callbacks.
+ */
+import { mkdirSync, readFileSync } from "node:fs";
+import { spawn } from "node:child_process";
+import { createRequire } from "node:module";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	CURSOR_SETTING_SOURCES_ENV,
+	resolveCursorSettingSources,
+	scrubSensitiveText,
+} from "./lib/cursor-probe-utils.mjs";
+
+const require = createRequire(import.meta.url);
+const root = fileURLToPath(new URL("..", import.meta.url));
+const packageJson = require("../package.json");
+const DEFAULT_MODEL = "cursor/composer-2.5";
+const DEFAULT_OUT_BASE = ".debug/cursor-sdk-events";
+const CHILD_SHUTDOWN_GRACE_MS = 2_000;
+const SDK_EVENT_DEBUG_LOG_PREFIX = "[pi-cursor-sdk:sdk-events]";
+
+function readSdkVersion() {
+	try {
+		const sdkEntry = require.resolve("@cursor/sdk");
+		const sdkPackagePath = join(dirname(sdkEntry), "../../package.json");
+		return JSON.parse(readFileSync(sdkPackagePath, "utf8")).version;
+	} catch {
+		return "unknown";
+	}
+}
+
+function printHelp() {
+	console.log(`Capture raw Cursor SDK onDelta/onStep payloads through pi's provider path.
+
+Usage:
+  CURSOR_API_KEY=... npm run debug:provider-events -- [options]
+  node scripts/debug-provider-events.mjs [options]
+
+Options:
+  --cwd <path>                 Working directory for pi and artifacts. Default: repo root.
+  --model <id>                 pi model id. Default: ${DEFAULT_MODEL}.
+  --prompt <text>              Required user prompt for the run.
+  --prompt-file <path>         Read prompt text from a file instead of --prompt.
+  --out <dir>                  Artifact directory. Default: ${DEFAULT_OUT_BASE}/<timestamp> under --cwd.
+  --setting-sources <value>    Cursor setting sources (comma-separated, all, or none).
+                               Default: PI_CURSOR_SETTING_SOURCES env, otherwise all.
+  --session-dir <path>         pi session directory. Default: <out>/session.
+  --api-key <key>              Cursor API key. Prefer CURSOR_API_KEY to avoid shell history.
+  -h, --help                   Show this help.
+
+Artifacts (gitignored when under .debug/):
+  metadata.json                Model, cwd, send plan metadata.
+  on-delta.jsonl               Raw InteractionUpdate payloads from agent.send(onDelta).
+  on-step.jsonl                Raw onStep payloads from agent.send(onStep).
+  wait-result.json             run.wait() result object.
+  summary.json                 Counts and artifact paths.
+
+Stdout:
+  Prints one JSON summary line on success. Raw payloads stay on disk only.
+
+Exit codes:
+  0  capture completed
+  1  invalid arguments, missing auth, pi failure, or missing capture summary
+
+Safety:
+  - Never prints CURSOR_API_KEY or --api-key values.
+  - Raw artifact files may contain local paths, tool args/results, or secrets. Do not commit or share them.`);
+}
+
+function fail(message, secrets = []) {
+	const scrubbed = scrubSensitiveText(message, secrets[0]);
+	console.error(`debug-provider-events: ${scrubbed}`);
+	process.exit(1);
+}
+
+export function parseDebugProviderEventsArgs(argv, env = process.env) {
+	const args = {
+		cwd: root,
+		model: DEFAULT_MODEL,
+		prompt: undefined,
+		promptFile: undefined,
+		out: undefined,
+		settingSources: resolveCursorSettingSources(env[CURSOR_SETTING_SOURCES_ENV]),
+		sessionDir: undefined,
+		apiKey: env.CURSOR_API_KEY?.trim() || undefined,
+		help: false,
+	};
+	for (let index = 0; index < argv.length; index++) {
+		const arg = argv[index];
+		if (arg === "-h" || arg === "--help") {
+			args.help = true;
+			continue;
+		}
+		if (arg === "--cwd") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--cwd requires a path");
+			args.cwd = resolve(value);
+			continue;
+		}
+		if (arg.startsWith("--cwd=")) {
+			args.cwd = resolve(arg.slice("--cwd=".length));
+			continue;
+		}
+		if (arg === "--model") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--model requires a value");
+			args.model = value.trim();
+			continue;
+		}
+		if (arg.startsWith("--model=")) {
+			args.model = arg.slice("--model=".length).trim();
+			continue;
+		}
+		if (arg === "--prompt") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--prompt requires a value");
+			args.prompt = value;
+			continue;
+		}
+		if (arg.startsWith("--prompt=")) {
+			args.prompt = arg.slice("--prompt=".length);
+			continue;
+		}
+		if (arg === "--prompt-file") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--prompt-file requires a path");
+			args.promptFile = resolve(value);
+			continue;
+		}
+		if (arg.startsWith("--prompt-file=")) {
+			args.promptFile = resolve(arg.slice("--prompt-file=".length));
+			continue;
+		}
+		if (arg === "--out") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--out requires a directory path");
+			args.out = resolve(value);
+			continue;
+		}
+		if (arg.startsWith("--out=")) {
+			args.out = resolve(arg.slice("--out=".length));
+			continue;
+		}
+		if (arg === "--session-dir") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--session-dir requires a path");
+			args.sessionDir = resolve(value);
+			continue;
+		}
+		if (arg.startsWith("--session-dir=")) {
+			args.sessionDir = resolve(arg.slice("--session-dir=".length));
+			continue;
+		}
+		if (arg === "--setting-sources") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--setting-sources requires a value");
+			args.settingSources = resolveCursorSettingSources(value);
+			continue;
+		}
+		if (arg.startsWith("--setting-sources=")) {
+			args.settingSources = resolveCursorSettingSources(arg.slice("--setting-sources=".length));
+			continue;
+		}
+		if (arg === "--api-key") {
+			const value = argv[++index];
+			if (!value || value.startsWith("--")) fail("--api-key requires a value");
+			args.apiKey = value.trim();
+			continue;
+		}
+		if (arg.startsWith("--api-key=")) {
+			args.apiKey = arg.slice("--api-key=".length).trim();
+			continue;
+		}
+		fail(`unknown argument: ${arg}`);
+	}
+	return args;
+}
+
+function defaultOutDir(cwd) {
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	return join(cwd, DEFAULT_OUT_BASE, stamp);
+}
+
+function parseEvents(stdout) {
+	const events = [];
+	for (const line of stdout.split("\n")) {
+		if (!line.trim()) continue;
+		try {
+			events.push(JSON.parse(line));
+		} catch {
+			// ignore partial lines
+		}
+	}
+	return events;
+}
+
+function waitForChildClose(child) {
+	if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve(child.exitCode ?? 1);
+	return new Promise((resolve) => {
+		child.once("close", (code) => resolve(code ?? 1));
+	});
+}
+
+function signalChild(child, signal) {
+	if (!child.pid) return;
+	try {
+		if (process.platform === "win32") {
+			child.kill(signal);
+		} else {
+			process.kill(-child.pid, signal);
+		}
+	} catch {
+		try {
+			child.kill(signal);
+		} catch {
+			// child already exited
+		}
+	}
+}
+
+async function terminateChild(child) {
+	child.stdin.destroy();
+	if (child.exitCode !== null || child.signalCode !== null) return;
+	signalChild(child, "SIGTERM");
+	const killTimer = setTimeout(() => signalChild(child, "SIGKILL"), CHILD_SHUTDOWN_GRACE_MS);
+	try {
+		await waitForChildClose(child);
+	} finally {
+		clearTimeout(killTimer);
+	}
+}
+
+function readCaptureSummary(artifactDir, stderr) {
+	const summaryPath = join(artifactDir, "summary.json");
+	try {
+		return JSON.parse(readFileSync(summaryPath, "utf8"));
+	} catch {
+		for (const line of stderr.split("\n").reverse()) {
+			const markerIndex = line.indexOf(SDK_EVENT_DEBUG_LOG_PREFIX);
+			if (markerIndex === -1) continue;
+			const payload = line.slice(markerIndex + SDK_EVENT_DEBUG_LOG_PREFIX.length).trim();
+			try {
+				return JSON.parse(payload);
+			} catch {
+				// keep scanning
+			}
+		}
+	}
+	return undefined;
+}
+
+export async function runDebugProviderEvents(args) {
+	if (args.promptFile) {
+		args.prompt = readFileSync(args.promptFile, "utf8");
+	}
+	if (!args.prompt?.trim()) fail("--prompt or --prompt-file is required");
+	if (!args.apiKey) fail("CURSOR_API_KEY or --api-key is required");
+
+	const artifactDir = args.out ?? defaultOutDir(args.cwd);
+	const sessionDir = args.sessionDir ?? join(artifactDir, "session");
+	mkdirSync(artifactDir, { recursive: true });
+	mkdirSync(sessionDir, { recursive: true });
+
+	const piArgs = [
+		"-e",
+		root,
+		"--cursor-no-fast",
+		"--model",
+		args.model,
+		"--mode",
+		"rpc",
+		"--session-dir",
+		sessionDir,
+	];
+	const env = {
+		...process.env,
+		CURSOR_API_KEY: args.apiKey,
+		PI_CURSOR_SDK_EVENT_DEBUG: "1",
+		PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+		PI_CURSOR_SETTING_SOURCES: args.settingSources?.join(",") ?? "all",
+		PI_CURSOR_NATIVE_TOOL_DISPLAY: envFlag(process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY, "1"),
+		PI_CURSOR_PI_TOOL_BRIDGE: envFlag(process.env.PI_CURSOR_PI_TOOL_BRIDGE, "1"),
+	};
+
+	const child = spawn("pi", piArgs, {
+		cwd: args.cwd,
+		env,
+		stdio: ["pipe", "pipe", "pipe"],
+		detached: process.platform !== "win32",
+	});
+	let closed = false;
+	let stdout = "";
+	let stderr = "";
+	child.stdout.on("data", (chunk) => {
+		stdout += chunk.toString();
+	});
+	child.stderr.on("data", (chunk) => {
+		stderr += chunk.toString();
+	});
+
+	const send = (obj) => {
+		if (!child.stdin.writable) fail("pi stdin closed before prompt could be sent");
+		child.stdin.write(`${JSON.stringify(obj)}\n`);
+	};
+
+	try {
+		send({ type: "prompt", message: args.prompt });
+		await new Promise((resolve, reject) => {
+			const timeoutMs = Number(process.env.PI_PROVIDER_EVENT_DEBUG_TIMEOUT_MS ?? 600_000);
+			const start = Date.now();
+			const tick = () => {
+				const events = parseEvents(stdout);
+				if (events.some((event) => event.type === "agent_end")) {
+					resolve(events);
+					return;
+				}
+				if (Date.now() - start > timeoutMs) {
+					reject(new Error(`timeout after ${timeoutMs}ms`));
+					return;
+				}
+				setTimeout(tick, 250);
+			};
+			tick();
+		});
+		child.stdin.end();
+		const exitCode = await waitForChildClose(child);
+		closed = true;
+		if (exitCode !== 0) {
+			fail(`pi exited ${exitCode}\nstderr=${scrubSensitiveText(stderr.slice(-2000), args.apiKey)}`, [args.apiKey]);
+		}
+
+		const captureSummary = readCaptureSummary(artifactDir, stderr);
+		if (!captureSummary?.artifactDir) {
+			fail(`missing summary.json in ${artifactDir}`, [args.apiKey]);
+		}
+
+		return {
+			artifactDir: captureSummary.artifactDir,
+			artifacts: captureSummary.artifacts,
+			counts: captureSummary.counts,
+			elapsedMs: captureSummary.elapsedMs,
+			model: args.model,
+			cwd: args.cwd,
+			sessionDir,
+			extensionVersion: packageJson.version,
+			sdkVersion: readSdkVersion(),
+			waitResultRecorded: captureSummary.waitResultRecorded,
+		};
+	} finally {
+		if (!closed) await terminateChild(child);
+	}
+}
+
+function envFlag(raw, defaultValue) {
+	if (raw === undefined || raw === "") return defaultValue;
+	return raw;
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+	const args = parseDebugProviderEventsArgs(argv, env);
+	if (args.help) {
+		printHelp();
+		return;
+	}
+	console.log(JSON.stringify(await runDebugProviderEvents(args)));
+}
+
+main().catch((error) => {
+	console.error(error instanceof Error ? error.message : String(error));
+	process.exitCode = 1;
+});

--- a/scripts/debug-provider-events.mjs
+++ b/scripts/debug-provider-events.mjs
@@ -367,7 +367,9 @@ async function main(argv = process.argv.slice(2), env = process.env) {
 	console.log(JSON.stringify(await runDebugProviderEvents(args)));
 }
 
-main().catch((error) => {
-	console.error(error instanceof Error ? error.message : String(error));
-	process.exitCode = 1;
-});
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	});
+}

--- a/src/cursor-live-run-coordinator.ts
+++ b/src/cursor-live-run-coordinator.ts
@@ -10,6 +10,7 @@ import {
 import type { CursorNativeToolDisplayItem } from "./cursor-native-tool-display.js";
 import type { CursorPiBridgeToolRequest, CursorPiToolBridgeRun } from "./cursor-pi-tool-bridge.js";
 import { getCursorSessionScopeKey } from "./cursor-session-scope.js";
+import { recordActiveCursorSdkLiveRunEvent } from "./cursor-sdk-event-debug.js";
 
 export class CursorLiveRunAbortError extends Error {
 	constructor() {
@@ -315,6 +316,7 @@ export function createCursorLiveRunCoordinator(deps: CursorLiveRunCoordinatorDep
 		queueEvent(run, event): void {
 			if (run.disposed) return;
 			run.pendingEvents.push(event);
+			recordActiveCursorSdkLiveRunEvent(event);
 			notifyProgress(run);
 		},
 

--- a/src/cursor-live-run-coordinator.ts
+++ b/src/cursor-live-run-coordinator.ts
@@ -10,7 +10,7 @@ import {
 import type { CursorNativeToolDisplayItem } from "./cursor-native-tool-display.js";
 import type { CursorPiBridgeToolRequest, CursorPiToolBridgeRun } from "./cursor-pi-tool-bridge.js";
 import { getCursorSessionScopeKey } from "./cursor-session-scope.js";
-import { recordActiveCursorSdkLiveRunEvent } from "./cursor-sdk-event-debug.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
 
 export class CursorLiveRunAbortError extends Error {
 	constructor() {
@@ -49,6 +49,7 @@ export interface CursorLiveRun {
 	errorMessage?: string;
 	abortMessage?: string;
 	chainUserInputAfterCompletion: boolean;
+	debugRecorder?: CursorSdkEventDebugRecorder;
 }
 
 export interface CursorLiveRunCreateParams {
@@ -59,6 +60,7 @@ export interface CursorLiveRunCreateParams {
 	sessionAgentScopeKey?: string;
 	promptInputTokens: number;
 	textDeltas?: string[];
+	debugRecorder?: CursorSdkEventDebugRecorder;
 }
 
 export interface CursorLiveRunCoordinatorDeps {
@@ -270,6 +272,7 @@ export function createCursorLiveRunCoordinator(deps: CursorLiveRunCoordinatorDep
 				cancelled: false,
 				disposed: false,
 				chainUserInputAfterCompletion: false,
+				debugRecorder: params.debugRecorder,
 			};
 			privateStates.set(run, {
 				waiters: new Set(),
@@ -316,7 +319,7 @@ export function createCursorLiveRunCoordinator(deps: CursorLiveRunCoordinatorDep
 		queueEvent(run, event): void {
 			if (run.disposed) return;
 			run.pendingEvents.push(event);
-			recordActiveCursorSdkLiveRunEvent(event);
+			run.debugRecorder?.recordLiveRunEvent(event);
 			notifyProgress(run);
 		},
 

--- a/src/cursor-pi-tool-bridge-diagnostics.ts
+++ b/src/cursor-pi-tool-bridge-diagnostics.ts
@@ -1,9 +1,6 @@
 import { stableNameHash } from "./cursor-pi-tool-bridge-mcp.js";
 import { parseEnvBoolean } from "./cursor-env-boolean.js";
-import {
-	recordActiveCursorSdkBridgeDiagnostic,
-	resolveCursorSdkEventDebugEnabled,
-} from "./cursor-sdk-event-debug.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
 
 export const CURSOR_PI_TOOL_BRIDGE_DEBUG_ENV = "PI_CURSOR_PI_TOOL_BRIDGE_DEBUG";
 export const CURSOR_PI_TOOL_BRIDGE_DIAGNOSTIC_PREFIX = "[pi-cursor-sdk:bridge]";
@@ -173,13 +170,15 @@ export function serializeCursorPiToolBridgeDiagnostic(event: CursorPiToolBridgeD
 	return assertNeverDiagnosticEvent(event);
 }
 
-export function writeCursorPiToolBridgeDiagnostic(env: Record<string, string | undefined>, event: CursorPiToolBridgeDiagnosticEvent): void {
-	if (resolveCursorSdkEventDebugEnabled(env)) {
-		try {
-			recordActiveCursorSdkBridgeDiagnostic(event);
-		} catch {
-			// Diagnostics must never affect bridge execution.
-		}
+export function writeCursorPiToolBridgeDiagnostic(
+	env: Record<string, string | undefined>,
+	event: CursorPiToolBridgeDiagnosticEvent,
+	debugRecorder?: CursorSdkEventDebugRecorder,
+): void {
+	try {
+		debugRecorder?.recordBridgeDiagnostic(event);
+	} catch {
+		// Diagnostics must never affect bridge execution.
 	}
 	if (!resolveCursorPiToolBridgeDebugEnabled(env)) return;
 	try {

--- a/src/cursor-pi-tool-bridge-diagnostics.ts
+++ b/src/cursor-pi-tool-bridge-diagnostics.ts
@@ -1,5 +1,9 @@
 import { stableNameHash } from "./cursor-pi-tool-bridge-mcp.js";
 import { parseEnvBoolean } from "./cursor-env-boolean.js";
+import {
+	recordActiveCursorSdkBridgeDiagnostic,
+	resolveCursorSdkEventDebugEnabled,
+} from "./cursor-sdk-event-debug.js";
 
 export const CURSOR_PI_TOOL_BRIDGE_DEBUG_ENV = "PI_CURSOR_PI_TOOL_BRIDGE_DEBUG";
 export const CURSOR_PI_TOOL_BRIDGE_DIAGNOSTIC_PREFIX = "[pi-cursor-sdk:bridge]";
@@ -170,6 +174,13 @@ export function serializeCursorPiToolBridgeDiagnostic(event: CursorPiToolBridgeD
 }
 
 export function writeCursorPiToolBridgeDiagnostic(env: Record<string, string | undefined>, event: CursorPiToolBridgeDiagnosticEvent): void {
+	if (resolveCursorSdkEventDebugEnabled(env)) {
+		try {
+			recordActiveCursorSdkBridgeDiagnostic(event);
+		} catch {
+			// Diagnostics must never affect bridge execution.
+		}
+	}
 	if (!resolveCursorPiToolBridgeDebugEnabled(env)) return;
 	try {
 		process.stderr.write(`${CURSOR_PI_TOOL_BRIDGE_DIAGNOSTIC_PREFIX} ${JSON.stringify(serializeCursorPiToolBridgeDiagnostic(event))}\n`);

--- a/src/cursor-pi-tool-bridge-run.ts
+++ b/src/cursor-pi-tool-bridge-run.ts
@@ -16,6 +16,7 @@ import {
 	type CursorPiToolBridgeRequestDiagnosticFields,
 	writeCursorPiToolBridgeDiagnostic,
 } from "./cursor-pi-tool-bridge-diagnostics.js";
+import { recordActiveCursorSdkBridgeRaw } from "./cursor-sdk-event-debug.js";
 import type {
 	CursorPiBridgeToolRequest,
 	CursorPiToolBridgeRun,
@@ -290,9 +291,11 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 				}
 				this.queuedRequests.push(request);
 				this.emitRequestQueuedDiagnostic(request);
+				recordActiveCursorSdkBridgeRaw({ kind: "queued", request });
 				return;
 			}
 			this.emitRequestQueuedDiagnostic(request);
+			recordActiveCursorSdkBridgeRaw({ kind: "queued", request });
 			this.dispatchPendingToolRequest(pending, this.onToolRequest);
 		});
 	}
@@ -321,6 +324,7 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 		pending.settled = true;
 		this.removePending(pending);
 		this.emitRequestResolvedDiagnostic(pending.request, result.isError === true);
+		recordActiveCursorSdkBridgeRaw({ kind: "resolved", request: pending.request, result });
 		pending.resolve(result);
 	}
 
@@ -329,6 +333,12 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 		pending.settled = true;
 		this.removePending(pending);
 		this.emitRequestRejectedDiagnostic(pending.request, kind);
+		recordActiveCursorSdkBridgeRaw({
+			kind: "rejected",
+			request: pending.request,
+			error: error.message,
+			rejectionKind: kind,
+		});
 		pending.reject(error);
 	}
 

--- a/src/cursor-pi-tool-bridge-run.ts
+++ b/src/cursor-pi-tool-bridge-run.ts
@@ -16,7 +16,6 @@ import {
 	type CursorPiToolBridgeRequestDiagnosticFields,
 	writeCursorPiToolBridgeDiagnostic,
 } from "./cursor-pi-tool-bridge-diagnostics.js";
-import { recordActiveCursorSdkBridgeRaw } from "./cursor-sdk-event-debug.js";
 import type {
 	CursorPiBridgeToolRequest,
 	CursorPiToolBridgeRun,
@@ -68,6 +67,7 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 	private readonly pendingByBridgeCallId = new Map<string, PendingBridgeCall>();
 	private readonly pendingByCursorMcpCallId = new Map<string, PendingBridgeCall>();
 	private onToolRequest?: (request: CursorPiBridgeToolRequest) => void;
+	private debugRecorder: CursorPiToolBridgeRunOptions["debugRecorder"];
 	private liveRunHandlerDetached = false;
 	private mcpServer?: McpProtocolServer;
 	private mcpTransport?: StreamableHTTPServerTransport;
@@ -86,6 +86,7 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 		this.snapshot = snapshot;
 		this.enabled = enabled;
 		this.onToolRequest = options.onToolRequest;
+		this.debugRecorder = options.debugRecorder;
 		this.id = `cursor-pi-bridge-run-${randomUUID()}`;
 		this.endpointPath = `${MCP_ENDPOINT_ROOT}/${randomUUID()}/mcp`;
 		this.knownMcpToolNames = new Set(snapshot.tools.map((tool) => tool.mcpToolName));
@@ -145,6 +146,10 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 				if (pending) this.dispatchPendingToolRequest(pending, handler);
 			}
 		}
+	}
+
+	setDebugRecorder(recorder?: CursorPiToolBridgeRunOptions["debugRecorder"]): void {
+		this.debugRecorder = recorder;
 	}
 
 	resolveToolResults(toolResults: readonly ToolResultMessage[]): void {
@@ -291,11 +296,11 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 				}
 				this.queuedRequests.push(request);
 				this.emitRequestQueuedDiagnostic(request);
-				recordActiveCursorSdkBridgeRaw({ kind: "queued", request });
+				this.debugRecorder?.recordBridgeRaw({ kind: "queued", request });
 				return;
 			}
 			this.emitRequestQueuedDiagnostic(request);
-			recordActiveCursorSdkBridgeRaw({ kind: "queued", request });
+			this.debugRecorder?.recordBridgeRaw({ kind: "queued", request });
 			this.dispatchPendingToolRequest(pending, this.onToolRequest);
 		});
 	}
@@ -324,7 +329,7 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 		pending.settled = true;
 		this.removePending(pending);
 		this.emitRequestResolvedDiagnostic(pending.request, result.isError === true);
-		recordActiveCursorSdkBridgeRaw({ kind: "resolved", request: pending.request, result });
+		this.debugRecorder?.recordBridgeRaw({ kind: "resolved", request: pending.request, result });
 		pending.resolve(result);
 	}
 
@@ -333,7 +338,7 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 		pending.settled = true;
 		this.removePending(pending);
 		this.emitRequestRejectedDiagnostic(pending.request, kind);
-		recordActiveCursorSdkBridgeRaw({
+		this.debugRecorder?.recordBridgeRaw({
 			kind: "rejected",
 			request: pending.request,
 			error: error.message,
@@ -376,7 +381,7 @@ export class CursorPiToolBridgeRunImpl implements CursorPiToolBridgeRun {
 	}
 
 	private emitDiagnostic(event: CursorPiToolBridgeDiagnosticEvent): void {
-		writeCursorPiToolBridgeDiagnostic(this.env, event);
+		writeCursorPiToolBridgeDiagnostic(this.env, event, this.debugRecorder);
 	}
 
 	private pendingCount(): number {

--- a/src/cursor-pi-tool-bridge-types.ts
+++ b/src/cursor-pi-tool-bridge-types.ts
@@ -1,5 +1,6 @@
 import type { McpServerConfig } from "@cursor/sdk";
 import type { Context, ToolResultMessage } from "@earendil-works/pi-ai";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
 import type {
 	ExtensionAPI,
 	ExtensionHandler,
@@ -64,6 +65,7 @@ export interface CursorPiToolBridgeRun {
 	hasPendingPiToolCallId(piToolCallId: string): boolean;
 	isBridgeMcpToolCall(toolCall: unknown): boolean;
 	setOnToolRequest(handler?: (request: CursorPiBridgeToolRequest) => void): void;
+	setDebugRecorder(recorder?: CursorSdkEventDebugRecorder): void;
 	cancel(reason: string): void;
 	dispose(): Promise<void>;
 }
@@ -77,4 +79,5 @@ export interface CursorPiToolBridge {
 
 export interface CursorPiToolBridgeRunOptions {
 	onToolRequest?: (request: CursorPiBridgeToolRequest) => void;
+	debugRecorder?: CursorSdkEventDebugRecorder;
 }

--- a/src/cursor-provider-live-run-drain.ts
+++ b/src/cursor-provider-live-run-drain.ts
@@ -26,7 +26,7 @@ import { hasUsableText } from "./cursor-record-utils.js";
 import { formatCursorSdkAbortMessage, resolveCursorSdkAbortCause } from "./cursor-provider-errors.js";
 import { formatInactiveCursorReplayTrace } from "./cursor-native-replay-trace.js";
 import { partitionNativeToolsByActiveContext } from "./cursor-native-replay-routing.js";
-import { recordActiveCursorSdkDrainEvent } from "./cursor-sdk-event-debug.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
 
 export const DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS = 5 * 60 * 1000;
 const CURSOR_NATIVE_REPLAY_TOOL_ID_PATTERN = /^(cursor-replay-\d+-\d+)-tool-\d+$/;
@@ -180,6 +180,7 @@ function emitCursorNativeToolUseTurn(
 	run: CursorLiveRun,
 	toolResultInputTokens: number,
 	tools: CursorNativeToolDisplayItem[],
+	debugRecorder?: CursorSdkEventDebugRecorder,
 ): void {
 	const shouldTerminate = run.done && !run.finalText?.trim() && !cursorLiveRuns.peekEvent(run);
 	for (const tool of tools) {
@@ -196,7 +197,7 @@ function emitCursorNativeToolUseTurn(
 		if (block.type === "toolCall") stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial });
 		if (recordCursorNativeToolDisplay({ ...tool, terminate: shouldTerminate })) {
 			run.recordedToolDisplayIds.push(tool.id);
-			recordActiveCursorSdkDrainEvent("native_tool_display_recorded", {
+			debugRecorder?.recordDrainEvent("native_tool_display_recorded", {
 				toolId: tool.id,
 				toolName: tool.toolName,
 				terminate: shouldTerminate,
@@ -209,11 +210,15 @@ function emitCursorNativeToolUseTurn(
 	cursorLiveRuns.requestIdleDispose(run);
 }
 
-function emitInactiveCursorReplayTrace(turn: CursorLiveTurnState, tools: CursorNativeToolDisplayItem[]): void {
+function emitInactiveCursorReplayTrace(
+	turn: CursorLiveTurnState,
+	tools: CursorNativeToolDisplayItem[],
+	debugRecorder?: CursorSdkEventDebugRecorder,
+): void {
 	if (tools.length === 0) return;
 	for (const tool of tools) {
 		const traceText = formatInactiveCursorReplayTrace(tool);
-		recordActiveCursorSdkDrainEvent("inactive_replay_trace", {
+		debugRecorder?.recordDrainEvent("inactive_replay_trace", {
 			toolId: tool.id,
 			toolName: tool.toolName,
 			traceText,
@@ -258,42 +263,28 @@ async function emitCursorLiveRunPendingToolUseTurn(
 	context: Context,
 	run: CursorLiveRun,
 	toolResultInputTokens: number,
-	options: { mode: CursorLiveRunDrainMode; signal?: AbortSignal },
+	options: { mode: CursorLiveRunDrainMode; signal?: AbortSignal; debugRecorder?: CursorSdkEventDebugRecorder },
 ): Promise<"tool_use" | "handled" | undefined> {
+	const debugRecorder = options.debugRecorder ?? run.debugRecorder;
 	const eventType = cursorLiveRuns.peekEvent(run)?.type;
 	if (eventType !== "tool" && eventType !== "bridge-tool") return undefined;
 	await settleCursorLiveToolBatch(run);
 	if (options.signal?.aborted) throw new CursorLiveRunAbortError();
 	if (eventType === "tool") {
 		const { active, inactive } = partitionNativeToolsByActiveContext(context, cursorLiveRuns.collectNativeToolBatch(run));
-		if (options.mode === "emit") emitInactiveCursorReplayTrace(turn, inactive);
+		if (options.mode === "emit") emitInactiveCursorReplayTrace(turn, inactive, debugRecorder);
 		if (active.length === 0) {
 			// Inactive-only batch: trace was emitted above; do not emit toolUse.
 			return "handled";
 		}
 		if (options.mode === "emit") turn.emitter.closeAll();
-		emitCursorNativeToolUseTurn(stream, partial, model, context, run, toolResultInputTokens, active);
+		emitCursorNativeToolUseTurn(stream, partial, model, context, run, toolResultInputTokens, active, debugRecorder);
 	} else {
 		if (options.mode === "emit") turn.emitter.closeAll();
 		const requests = cursorLiveRuns.collectBridgeToolBatch(run);
 		emitCursorBridgeToolUseTurn(stream, partial, model, context, run, toolResultInputTokens, requests);
 	}
 	return "tool_use";
-}
-
-function finishCursorLiveRunDrainTurn(
-	outcome: CursorLiveRunDrainOutcome,
-	run: CursorLiveRun,
-	extra: Record<string, unknown> = {},
-): CursorLiveRunDrainOutcome {
-	recordActiveCursorSdkDrainEvent("turn_end", {
-		outcome,
-		runId: run.id,
-		pendingEventCount: run.pendingEvents.length,
-		done: run.done,
-		...extra,
-	});
-	return outcome;
 }
 
 export async function drainCursorLiveRunTurn(
@@ -303,83 +294,123 @@ export async function drainCursorLiveRunTurn(
 	context: Context,
 	run: CursorLiveRun,
 	toolResultInputTokens: number,
-	options: { mode: CursorLiveRunDrainMode; signal?: AbortSignal },
+	options: { mode: CursorLiveRunDrainMode; signal?: AbortSignal; debugRecorder?: CursorSdkEventDebugRecorder },
 ): Promise<CursorLiveRunDrainOutcome> {
-	recordActiveCursorSdkDrainEvent("turn_start", {
+	const debugRecorder = options.debugRecorder ?? run.debugRecorder;
+	debugRecorder?.recordDrainEvent("turn_start", {
 		mode: options.mode,
 		runId: run.id,
 		pendingEventCount: run.pendingEvents.length,
 		done: run.done,
 	});
+	let outcome: CursorLiveRunDrainOutcome | undefined;
+	let outcomeDetails: Record<string, unknown> = {};
 	const turn: CursorLiveTurnState = {
 		emitter: new CursorPartialContentEmitter(stream, partial, -1, true),
 		emittedText: "",
 	};
 
-	while (true) {
-		if (options.mode === "chain_user_input" && cursorLiveRuns.isReady(run)) {
-			await cursorLiveRuns.release(run);
-			return finishCursorLiveRunDrainTurn("chain_user_input", run);
-		}
-
-		while (cursorLiveRuns.peekEvent(run)) {
-			const toolUse = await emitCursorLiveRunPendingToolUseTurn(
-				turn,
-				stream,
-				partial,
-				model,
-				context,
-				run,
-				toolResultInputTokens,
-				options,
-			);
-			if (toolUse === "tool_use") return finishCursorLiveRunDrainTurn("tool_use", run);
-			if (toolUse === "handled") continue;
-			const event = cursorLiveRuns.shiftEvent(run);
-			if (!event || event.type === "tool" || event.type === "bridge-tool") continue;
-			if (options.mode === "emit") emitCursorLiveQueuedEvent(turn, event, run);
-		}
-
-		if (run.disposed) {
-			partial.stopReason = "aborted";
-			partial.errorMessage = formatCursorSdkAbortMessage(
-				resolveCursorSdkAbortCause({ liveRunDisposed: true }),
-			);
-			stream.push({ type: "error", reason: "aborted", error: partial });
-			return finishCursorLiveRunDrainTurn("aborted", run, { reason: "disposed" });
-		}
-		if (run.cancelled) {
-			partial.stopReason = "aborted";
-			if (run.abortMessage) partial.errorMessage = run.abortMessage;
-			stream.push({ type: "error", reason: "aborted", error: partial });
-			await cursorLiveRuns.release(run);
-			return finishCursorLiveRunDrainTurn("aborted", run, { reason: "cancelled" });
-		}
-		if (run.errorMessage) {
-			partial.stopReason = "error";
-			partial.errorMessage = run.errorMessage;
-			stream.push({ type: "error", reason: "error", error: partial });
-			await cursorLiveRuns.release(run);
-			return finishCursorLiveRunDrainTurn("error", run);
-		}
-		if (run.done) {
-			if (options.mode === "chain_user_input") {
+	try {
+		while (true) {
+			if (options.mode === "chain_user_input" && cursorLiveRuns.isReady(run)) {
 				await cursorLiveRuns.release(run);
-				return finishCursorLiveRunDrainTurn("chain_user_input", run, { reason: "run_done" });
+				outcome = "chain_user_input";
+				return outcome;
 			}
-			turn.emitter.closeAll();
-			const finalText = trimCurrentTurnAlreadyEmittedCursorText(run.finalText ?? run.textDeltas.join(""), turn.emittedText, run.emittedText);
-			if (finalText) {
-				await emitTextDeltas(stream, partial, splitTextIntoReplayDeltas(finalText));
-			}
-			applyCursorApproximateUsage(partial, model, context, cursorLiveRuns.takeTurnInputTokens(run, toolResultInputTokens));
-			partial.stopReason = "stop";
-			stream.push({ type: "done", reason: "stop", message: partial });
-			await cursorLiveRuns.release(run);
-			return finishCursorLiveRunDrainTurn("stop", run, { finalTextLength: finalText.length });
-		}
 
-		await cursorLiveRuns.waitForProgress(run, options.signal);
+			while (cursorLiveRuns.peekEvent(run)) {
+				const toolUse = await emitCursorLiveRunPendingToolUseTurn(
+					turn,
+					stream,
+					partial,
+					model,
+					context,
+					run,
+					toolResultInputTokens,
+					options,
+				);
+				if (toolUse === "tool_use") {
+					outcome = "tool_use";
+					return outcome;
+				}
+				if (toolUse === "handled") continue;
+				const event = cursorLiveRuns.shiftEvent(run);
+				if (!event || event.type === "tool" || event.type === "bridge-tool") continue;
+				if (options.mode === "emit") emitCursorLiveQueuedEvent(turn, event, run);
+			}
+
+			if (run.disposed) {
+				partial.stopReason = "aborted";
+				partial.errorMessage = formatCursorSdkAbortMessage(
+					resolveCursorSdkAbortCause({ liveRunDisposed: true }),
+				);
+				stream.push({ type: "error", reason: "aborted", error: partial });
+				outcome = "aborted";
+				outcomeDetails = { reason: "disposed" };
+				return outcome;
+			}
+			if (run.cancelled) {
+				partial.stopReason = "aborted";
+				if (run.abortMessage) partial.errorMessage = run.abortMessage;
+				stream.push({ type: "error", reason: "aborted", error: partial });
+				await cursorLiveRuns.release(run);
+				outcome = "aborted";
+				outcomeDetails = { reason: "cancelled" };
+				return outcome;
+			}
+			if (run.errorMessage) {
+				partial.stopReason = "error";
+				partial.errorMessage = run.errorMessage;
+				stream.push({ type: "error", reason: "error", error: partial });
+				await cursorLiveRuns.release(run);
+				outcome = "error";
+				return outcome;
+			}
+			if (run.done) {
+				if (options.mode === "chain_user_input") {
+					await cursorLiveRuns.release(run);
+					outcome = "chain_user_input";
+					outcomeDetails = { reason: "run_done" };
+					return outcome;
+				}
+				turn.emitter.closeAll();
+				const finalText = trimCurrentTurnAlreadyEmittedCursorText(run.finalText ?? run.textDeltas.join(""), turn.emittedText, run.emittedText);
+				if (finalText) {
+					await emitTextDeltas(stream, partial, splitTextIntoReplayDeltas(finalText));
+				}
+				applyCursorApproximateUsage(partial, model, context, cursorLiveRuns.takeTurnInputTokens(run, toolResultInputTokens));
+				partial.stopReason = "stop";
+				stream.push({ type: "done", reason: "stop", message: partial });
+				await cursorLiveRuns.release(run);
+				outcome = "stop";
+				outcomeDetails = { finalTextLength: finalText.length };
+				return outcome;
+			}
+
+			await cursorLiveRuns.waitForProgress(run, options.signal);
+		}
+	} catch (error) {
+		if (!outcome) {
+			if (error instanceof CursorLiveRunAbortError) {
+				outcome = "aborted";
+				outcomeDetails = { reason: "signal_aborted" };
+			} else {
+				outcome = "error";
+				outcomeDetails = {
+					reason: "drain_error",
+					errorMessage: error instanceof Error ? error.message : String(error),
+				};
+			}
+		}
+		throw error;
+	} finally {
+		debugRecorder?.recordDrainEvent("turn_end", {
+			outcome: outcome ?? "error",
+			runId: run.id,
+			pendingEventCount: run.pendingEvents.length,
+			done: run.done,
+			...outcomeDetails,
+		});
 	}
 }
 
@@ -389,12 +420,13 @@ export async function drainExistingCursorLiveRunBeforeSend(
 	model: Model<Api>,
 	context: Context,
 	signal?: AbortSignal,
+	turnDebugRecorder?: CursorSdkEventDebugRecorder,
 ): Promise<LiveRunPreSendOutcome> {
-	recordActiveCursorSdkDrainEvent("pre_send_start", {});
+	turnDebugRecorder?.recordDrainEvent("pre_send_start", {});
 	while (true) {
 		const run = getPendingCursorLiveRun(context) ?? getActiveCursorLiveRunForCurrentScope();
 		if (!run || run.disposed) {
-			recordActiveCursorSdkDrainEvent("pre_send_end", { outcome: "continue_send", reason: "no_pending_run" });
+			turnDebugRecorder?.recordDrainEvent("pre_send_end", { outcome: "continue_send", reason: "no_pending_run" });
 			return "continue_send";
 		}
 
@@ -412,9 +444,10 @@ export async function drainExistingCursorLiveRunBeforeSend(
 				const drainOutcome = await drainCursorLiveRunTurn(stream, partial, model, context, run, consumed.toolResultInputTokens, {
 					mode: shouldChainUserInput ? "chain_user_input" : "emit",
 					signal,
+					debugRecorder: turnDebugRecorder,
 				});
 				const mapped = drainOutcome === "chain_user_input" ? "continue_send" : "stream_ended";
-				recordActiveCursorSdkDrainEvent("pre_send_iteration", {
+				turnDebugRecorder?.recordDrainEvent("pre_send_iteration", {
 					runId: run.id,
 					drainOutcome,
 					outcome: mapped,
@@ -425,9 +458,14 @@ export async function drainExistingCursorLiveRunBeforeSend(
 			if (outcome === "continue_send" && !run.disposed && cursorLiveRuns.getActiveForScope(run.sessionAgentScopeKey) === run) {
 				continue;
 			}
-			recordActiveCursorSdkDrainEvent("pre_send_end", { outcome, runId: run.id });
+			turnDebugRecorder?.recordDrainEvent("pre_send_end", { outcome, runId: run.id });
 			return outcome;
 		} catch (error) {
+			turnDebugRecorder?.recordDrainEvent("pre_send_end", {
+				outcome: error instanceof CursorLiveRunAbortError ? "aborted" : "error",
+				runId: run.id,
+				reason: error instanceof CursorLiveRunAbortError ? "signal_aborted" : "drain_error",
+			});
 			if (error instanceof CursorLiveRunAbortError) await cursorLiveRuns.release(run);
 			throw error;
 		}

--- a/src/cursor-provider-live-run-drain.ts
+++ b/src/cursor-provider-live-run-drain.ts
@@ -26,6 +26,7 @@ import { hasUsableText } from "./cursor-record-utils.js";
 import { formatCursorSdkAbortMessage, resolveCursorSdkAbortCause } from "./cursor-provider-errors.js";
 import { formatInactiveCursorReplayTrace } from "./cursor-native-replay-trace.js";
 import { partitionNativeToolsByActiveContext } from "./cursor-native-replay-routing.js";
+import { recordActiveCursorSdkDrainEvent } from "./cursor-sdk-event-debug.js";
 
 export const DEFAULT_CURSOR_NATIVE_REPLAY_IDLE_DISPOSE_MS = 5 * 60 * 1000;
 const CURSOR_NATIVE_REPLAY_TOOL_ID_PATTERN = /^(cursor-replay-\d+-\d+)-tool-\d+$/;
@@ -195,6 +196,11 @@ function emitCursorNativeToolUseTurn(
 		if (block.type === "toolCall") stream.push({ type: "toolcall_end", contentIndex, toolCall: block, partial });
 		if (recordCursorNativeToolDisplay({ ...tool, terminate: shouldTerminate })) {
 			run.recordedToolDisplayIds.push(tool.id);
+			recordActiveCursorSdkDrainEvent("native_tool_display_recorded", {
+				toolId: tool.id,
+				toolName: tool.toolName,
+				terminate: shouldTerminate,
+			});
 		}
 	}
 	applyCursorApproximateUsage(partial, model, context, cursorLiveRuns.takeTurnInputTokens(run, toolResultInputTokens));
@@ -206,7 +212,13 @@ function emitCursorNativeToolUseTurn(
 function emitInactiveCursorReplayTrace(turn: CursorLiveTurnState, tools: CursorNativeToolDisplayItem[]): void {
 	if (tools.length === 0) return;
 	for (const tool of tools) {
-		turn.emitter.appendThinkingBlock(formatInactiveCursorReplayTrace(tool));
+		const traceText = formatInactiveCursorReplayTrace(tool);
+		recordActiveCursorSdkDrainEvent("inactive_replay_trace", {
+			toolId: tool.id,
+			toolName: tool.toolName,
+			traceText,
+		});
+		turn.emitter.appendThinkingBlock(traceText);
 	}
 }
 
@@ -269,6 +281,21 @@ async function emitCursorLiveRunPendingToolUseTurn(
 	return "tool_use";
 }
 
+function finishCursorLiveRunDrainTurn(
+	outcome: CursorLiveRunDrainOutcome,
+	run: CursorLiveRun,
+	extra: Record<string, unknown> = {},
+): CursorLiveRunDrainOutcome {
+	recordActiveCursorSdkDrainEvent("turn_end", {
+		outcome,
+		runId: run.id,
+		pendingEventCount: run.pendingEvents.length,
+		done: run.done,
+		...extra,
+	});
+	return outcome;
+}
+
 export async function drainCursorLiveRunTurn(
 	stream: AssistantMessageEventStream,
 	partial: AssistantMessage,
@@ -278,6 +305,12 @@ export async function drainCursorLiveRunTurn(
 	toolResultInputTokens: number,
 	options: { mode: CursorLiveRunDrainMode; signal?: AbortSignal },
 ): Promise<CursorLiveRunDrainOutcome> {
+	recordActiveCursorSdkDrainEvent("turn_start", {
+		mode: options.mode,
+		runId: run.id,
+		pendingEventCount: run.pendingEvents.length,
+		done: run.done,
+	});
 	const turn: CursorLiveTurnState = {
 		emitter: new CursorPartialContentEmitter(stream, partial, -1, true),
 		emittedText: "",
@@ -286,7 +319,7 @@ export async function drainCursorLiveRunTurn(
 	while (true) {
 		if (options.mode === "chain_user_input" && cursorLiveRuns.isReady(run)) {
 			await cursorLiveRuns.release(run);
-			return "chain_user_input";
+			return finishCursorLiveRunDrainTurn("chain_user_input", run);
 		}
 
 		while (cursorLiveRuns.peekEvent(run)) {
@@ -300,7 +333,7 @@ export async function drainCursorLiveRunTurn(
 				toolResultInputTokens,
 				options,
 			);
-			if (toolUse === "tool_use") return toolUse;
+			if (toolUse === "tool_use") return finishCursorLiveRunDrainTurn("tool_use", run);
 			if (toolUse === "handled") continue;
 			const event = cursorLiveRuns.shiftEvent(run);
 			if (!event || event.type === "tool" || event.type === "bridge-tool") continue;
@@ -313,26 +346,26 @@ export async function drainCursorLiveRunTurn(
 				resolveCursorSdkAbortCause({ liveRunDisposed: true }),
 			);
 			stream.push({ type: "error", reason: "aborted", error: partial });
-			return "aborted";
+			return finishCursorLiveRunDrainTurn("aborted", run, { reason: "disposed" });
 		}
 		if (run.cancelled) {
 			partial.stopReason = "aborted";
 			if (run.abortMessage) partial.errorMessage = run.abortMessage;
 			stream.push({ type: "error", reason: "aborted", error: partial });
 			await cursorLiveRuns.release(run);
-			return "aborted";
+			return finishCursorLiveRunDrainTurn("aborted", run, { reason: "cancelled" });
 		}
 		if (run.errorMessage) {
 			partial.stopReason = "error";
 			partial.errorMessage = run.errorMessage;
 			stream.push({ type: "error", reason: "error", error: partial });
 			await cursorLiveRuns.release(run);
-			return "error";
+			return finishCursorLiveRunDrainTurn("error", run);
 		}
 		if (run.done) {
 			if (options.mode === "chain_user_input") {
 				await cursorLiveRuns.release(run);
-				return "chain_user_input";
+				return finishCursorLiveRunDrainTurn("chain_user_input", run, { reason: "run_done" });
 			}
 			turn.emitter.closeAll();
 			const finalText = trimCurrentTurnAlreadyEmittedCursorText(run.finalText ?? run.textDeltas.join(""), turn.emittedText, run.emittedText);
@@ -343,7 +376,7 @@ export async function drainCursorLiveRunTurn(
 			partial.stopReason = "stop";
 			stream.push({ type: "done", reason: "stop", message: partial });
 			await cursorLiveRuns.release(run);
-			return "stop";
+			return finishCursorLiveRunDrainTurn("stop", run, { finalTextLength: finalText.length });
 		}
 
 		await cursorLiveRuns.waitForProgress(run, options.signal);
@@ -357,9 +390,13 @@ export async function drainExistingCursorLiveRunBeforeSend(
 	context: Context,
 	signal?: AbortSignal,
 ): Promise<LiveRunPreSendOutcome> {
+	recordActiveCursorSdkDrainEvent("pre_send_start", {});
 	while (true) {
 		const run = getPendingCursorLiveRun(context) ?? getActiveCursorLiveRunForCurrentScope();
-		if (!run || run.disposed) return "continue_send";
+		if (!run || run.disposed) {
+			recordActiveCursorSdkDrainEvent("pre_send_end", { outcome: "continue_send", reason: "no_pending_run" });
+			return "continue_send";
+		}
 
 		try {
 			const outcome = await cursorLiveRuns.withRunLease(run, signal, async () => {
@@ -376,11 +413,19 @@ export async function drainExistingCursorLiveRunBeforeSend(
 					mode: shouldChainUserInput ? "chain_user_input" : "emit",
 					signal,
 				});
-				return drainOutcome === "chain_user_input" ? "continue_send" : "stream_ended";
+				const mapped = drainOutcome === "chain_user_input" ? "continue_send" : "stream_ended";
+				recordActiveCursorSdkDrainEvent("pre_send_iteration", {
+					runId: run.id,
+					drainOutcome,
+					outcome: mapped,
+					shouldChainUserInput,
+				});
+				return mapped;
 			});
 			if (outcome === "continue_send" && !run.disposed && cursorLiveRuns.getActiveForScope(run.sessionAgentScopeKey) === run) {
 				continue;
 			}
+			recordActiveCursorSdkDrainEvent("pre_send_end", { outcome, runId: run.id });
 			return outcome;
 		} catch (error) {
 			if (error instanceof CursorLiveRunAbortError) await cursorLiveRuns.release(run);

--- a/src/cursor-provider-turn-coordinator.ts
+++ b/src/cursor-provider-turn-coordinator.ts
@@ -9,7 +9,7 @@ import { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js
 import { asRecord, getField, hasUsableText } from "./cursor-record-utils.js";
 import { scrubPiToolDisplay, scrubSensitiveText } from "./cursor-sensitive-text.js";
 import { buildCursorPiToolDisplay, formatCursorToolTranscript, getCursorCreatePlanText, mergeCursorToolCalls } from "./cursor-tool-transcript.js";
-import { recordActiveCursorSdkCoordinatorEvent, recordActiveCursorSdkDisplayDecision } from "./cursor-sdk-event-debug.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
 import { getString, getToolArgs, getToolName } from "./cursor-transcript-utils.js";
 
 function formatCursorToolName(toolCall: unknown): string {
@@ -104,6 +104,7 @@ export interface CursorSdkTurnCoordinatorOptions {
 	activeToolNames?: ReadonlySet<string>;
 	nativeReplayId: string;
 	textDeltas: string[];
+	debugRecorder?: CursorSdkEventDebugRecorder;
 }
 
 export class CursorSdkTurnCoordinator {
@@ -118,6 +119,7 @@ export class CursorSdkTurnCoordinator {
 	readonly textDeltas: string[];
 
 	private readonly contentEmitter: CursorPartialContentEmitter;
+	private readonly debugRecorder?: CursorSdkEventDebugRecorder;
 	private nativeToolDisplayCounter = 0;
 	private nativeToolReplayStarted = false;
 	private cursorPlanTextCandidate: string | undefined;
@@ -141,6 +143,7 @@ export class CursorSdkTurnCoordinator {
 		this.activeToolNames = options.activeToolNames;
 		this.nativeReplayId = options.nativeReplayId;
 		this.textDeltas = options.textDeltas;
+		this.debugRecorder = options.debugRecorder;
 		this.contentEmitter = new CursorPartialContentEmitter(options.stream, options.partial, undefined, false);
 	}
 
@@ -423,7 +426,7 @@ export class CursorSdkTurnCoordinator {
 		toolName: string,
 		source: "delta" | "step",
 	): void {
-		recordActiveCursorSdkDisplayDecision({
+		this.debugRecorder?.recordDisplayDecision({
 			action: "ignore-bridge",
 			toolName,
 			identity,
@@ -431,10 +434,8 @@ export class CursorSdkTurnCoordinator {
 		});
 	}
 
-	private recordDisplayDecision(
-		decision: Parameters<typeof recordActiveCursorSdkDisplayDecision>[0],
-	): void {
-		recordActiveCursorSdkDisplayDecision(decision);
+	private recordDisplayDecision(decision: Parameters<CursorSdkEventDebugRecorder["recordDisplayDecision"]>[0]): void {
+		this.debugRecorder?.recordDisplayDecision(decision);
 	}
 
 	private emitCursorToolTrace(text: string): void {
@@ -458,7 +459,7 @@ export class CursorSdkTurnCoordinator {
 
 	private emitCursorTaskProgress(label: string): void {
 		const progressText = `Cursor task: ${label}\n`;
-		recordActiveCursorSdkCoordinatorEvent("task_progress", { label, progressText, liveRun: this.liveRun !== undefined });
+		this.debugRecorder?.recordCoordinatorEvent("task_progress", { label, progressText, liveRun: this.liveRun !== undefined });
 		if (this.liveRun) {
 			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-delta", text: progressText });
 			return;

--- a/src/cursor-provider-turn-coordinator.ts
+++ b/src/cursor-provider-turn-coordinator.ts
@@ -9,6 +9,7 @@ import { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js
 import { asRecord, getField, hasUsableText } from "./cursor-record-utils.js";
 import { scrubPiToolDisplay, scrubSensitiveText } from "./cursor-sensitive-text.js";
 import { buildCursorPiToolDisplay, formatCursorToolTranscript, getCursorCreatePlanText, mergeCursorToolCalls } from "./cursor-tool-transcript.js";
+import { recordActiveCursorSdkCoordinatorEvent, recordActiveCursorSdkDisplayDecision } from "./cursor-sdk-event-debug.js";
 import { getString, getToolArgs, getToolName } from "./cursor-transcript-utils.js";
 
 function formatCursorToolName(toolCall: unknown): string {
@@ -215,7 +216,10 @@ export class CursorSdkTurnCoordinator {
 				toolCall: update.toolCall,
 				startedToolCall: this.startedToolCalls.get(update.callId),
 			});
-			if (resolution.action === "ignore-bridge") return;
+			if (resolution.action === "ignore-bridge") {
+				this.recordIgnoreBridgeDecision(resolution.identity, getToolName(update.toolCall), "delta");
+				return;
+			}
 			this.handleCompletedToolCall(resolution.toolCall, {
 				identity: resolution.identity,
 				source: resolution.source,
@@ -251,7 +255,10 @@ export class CursorSdkTurnCoordinator {
 			callId: stepId,
 			toolCall,
 		});
-		if (resolution.action === "ignore-bridge") return;
+		if (resolution.action === "ignore-bridge") {
+			this.recordIgnoreBridgeDecision(resolution.identity, getToolName(toolCall), "step");
+			return;
+		}
 		this.handleCompletedToolCall(resolution.toolCall, {
 			identity: resolution.identity,
 			source: resolution.source,
@@ -328,11 +335,37 @@ export class CursorSdkTurnCoordinator {
 
 		const transcript = scrubSensitiveText(formatCursorToolTranscript(toolCall, { cwd: this.cwd }), this.resolvedApiKey);
 		const display = buildCursorPiToolDisplay(toolCall, { cwd: this.cwd });
+		const toolName = display.toolName;
 		const fingerprint = this.getToolFingerprint({ toolName: display.toolName, args: display.args, result: display.result });
-		if (options.identity && this.completedToolIdentities.has(options.identity)) return;
+		if (options.identity && this.completedToolIdentities.has(options.identity)) {
+			this.recordDisplayDecision({
+				action: "skip-duplicate",
+				toolName,
+				identity: options.identity,
+				source: options.source,
+				reason: "identity-already-completed",
+			});
+			return;
+		}
 		if (options.source === "started") {
-			if (this.completedFallbackToolFingerprints.has(fingerprint)) return;
+			if (this.completedFallbackToolFingerprints.has(fingerprint)) {
+				this.recordDisplayDecision({
+					action: "skip-duplicate",
+					toolName,
+					identity: options.identity,
+					source: options.source,
+					reason: "fallback-fingerprint-already-completed",
+				});
+				return;
+			}
 		} else if (this.completedStartedToolFingerprints.has(fingerprint) || this.completedFallbackToolFingerprints.has(fingerprint)) {
+			this.recordDisplayDecision({
+				action: "skip-duplicate",
+				toolName,
+				identity: options.identity,
+				source: options.source,
+				reason: "fingerprint-already-completed",
+			});
 			return;
 		}
 		if (options.identity) this.completedToolIdentities.add(options.identity);
@@ -353,6 +386,15 @@ export class CursorSdkTurnCoordinator {
 			this.nativeToolReplayStarted = true;
 			const id = `${this.nativeReplayId}-tool-${++this.nativeToolDisplayCounter}`;
 			const scrubbedDisplay = scrubPiToolDisplay(display, this.resolvedApiKey);
+			this.recordDisplayDecision({
+				action: "queue_replay",
+				disposition,
+				toolName,
+				identity: options.identity,
+				source: options.source,
+				transcript,
+				replayToolId: id,
+			});
 			cursorLiveRuns.queueEvent(this.liveRun, {
 				type: "tool",
 				tool: { ...scrubbedDisplay, id },
@@ -364,7 +406,35 @@ export class CursorSdkTurnCoordinator {
 			disposition === "inactive_trace"
 				? formatInactiveCursorReplayTrace(scrubPiToolDisplay(display, this.resolvedApiKey))
 				: transcript || `Cursor tool: ${formatCursorToolName(toolCall)} completed`;
+		this.recordDisplayDecision({
+			action: "emit_trace",
+			disposition,
+			toolName,
+			identity: options.identity,
+			source: options.source,
+			transcript,
+			traceText,
+		});
 		this.emitCursorToolTrace(traceText);
+	}
+
+	private recordIgnoreBridgeDecision(
+		identity: string | undefined,
+		toolName: string,
+		source: "delta" | "step",
+	): void {
+		recordActiveCursorSdkDisplayDecision({
+			action: "ignore-bridge",
+			toolName,
+			identity,
+			source,
+		});
+	}
+
+	private recordDisplayDecision(
+		decision: Parameters<typeof recordActiveCursorSdkDisplayDecision>[0],
+	): void {
+		recordActiveCursorSdkDisplayDecision(decision);
 	}
 
 	private emitCursorToolTrace(text: string): void {
@@ -388,6 +458,7 @@ export class CursorSdkTurnCoordinator {
 
 	private emitCursorTaskProgress(label: string): void {
 		const progressText = `Cursor task: ${label}\n`;
+		recordActiveCursorSdkCoordinatorEvent("task_progress", { label, progressText, liveRun: this.liveRun !== undefined });
 		if (this.liveRun) {
 			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-delta", text: progressText });
 			return;

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -49,6 +49,12 @@ import {
 import { getEffectiveFastForModelId } from "./cursor-state.js";
 import { buildCursorModelSelection } from "./model-discovery.js";
 import { getCheckpointContextWindow, saveCachedContextWindow } from "./context-window-cache.js";
+import {
+	attachCursorSdkEventDebugPiStreamTap,
+	CursorSdkEventDebugSink,
+	recordActiveCursorSdkFinalPartial,
+	setActiveCursorSdkEventDebugSink,
+} from "./cursor-sdk-event-debug.js";
 import { CursorSdkTurnCoordinator } from "./cursor-provider-turn-coordinator.js";
 import { isCursorNativeToolDisplayRuntimeEnabled } from "./cursor-native-tool-display.js";
 import {
@@ -107,6 +113,8 @@ export function streamCursor(
 	options?: SimpleStreamOptions,
 ): AssistantMessageEventStream {
 	const stream = createAssistantMessageEventStream();
+	const sdkEventDebugRef: { current?: CursorSdkEventDebugSink } = {};
+	attachCursorSdkEventDebugPiStreamTap(stream, sdkEventDebugRef);
 
 	(async () => {
 		const partial = makeInitialMessage(model);
@@ -120,6 +128,8 @@ export function streamCursor(
 		let abortSignal: AbortSignal | undefined;
 		let abortListener: (() => void) | undefined;
 		let restoreCursorSdkOutputFilter: (() => void) | undefined;
+		let sdkEventDebug: CursorSdkEventDebugSink | undefined;
+		let deferSdkEventDebugFinalize = false;
 
 		try {
 			const throwIfAborted = (): void => {
@@ -129,7 +139,21 @@ export function streamCursor(
 			stream.push({ type: "start", partial });
 			throwIfAborted();
 
+			const cwd = getCursorSessionCwd();
+			sdkEventDebug = CursorSdkEventDebugSink.maybeCreate({
+				cwd,
+				modelId: model.id,
+				provider: model.provider,
+			});
+			sdkEventDebugRef.current = sdkEventDebug;
+			setActiveCursorSdkEventDebugSink(sdkEventDebug);
+			sdkEventDebug?.recordContextSnapshot(context);
+
 			if ((await drainExistingCursorLiveRunBeforeSend(stream, partial, model, context, options?.signal)) === "stream_ended") {
+				recordActiveCursorSdkFinalPartial(partial);
+				await sdkEventDebug?.finalize();
+				setActiveCursorSdkEventDebugSink(undefined);
+				sdkEventDebugRef.current = undefined;
 				stream.end();
 				return;
 			}
@@ -138,9 +162,6 @@ export function streamCursor(
 			if (!apiKey) throw new Error(MISSING_CURSOR_API_KEY_MESSAGE);
 			resolvedApiKey = apiKey;
 
-			// pi-ai Context/SimpleStreamOptions do not expose ExtensionContext.cwd; bridge via session_start
-			// until pi threads session cwd into streamSimple (cwd can change without a new session event).
-			const cwd = getCursorSessionCwd();
 			const fastEnabled = getEffectiveFastForModelId(model.id);
 			const selection = buildCursorModelSelection(model.id, options?.reasoning ?? "off", fastEnabled);
 			const settingSources = getEffectiveCursorSettingSources();
@@ -185,6 +206,23 @@ export function streamCursor(
 			const promptInputTokens = estimateCursorPromptInputTokens(prompt, promptOptions);
 			const useNativeToolReplay = isCursorNativeToolDisplayRuntimeEnabled();
 			const activeToolNames = getActiveContextToolNames(context);
+			sdkEventDebug?.recordProviderMeta({
+				model: {
+					id: model.id,
+					provider: model.provider,
+					api: model.api,
+					reasoning: options?.reasoning ?? "off",
+					fastEnabled,
+					selection,
+				},
+				settingSources: settingSources ?? null,
+				sendState: sessionAgentLease.sendState,
+				sendPlan,
+				promptOptions,
+				activeToolNames: activeToolNames ? [...activeToolNames] : [],
+				sessionAgentScopeKey,
+				bridgeRunId: bridgeRun?.id,
+			});
 			const nativeReplayId = createCursorNativeReplayId();
 			const textDeltas: string[] = [];
 			const useLiveRun = useNativeToolReplay || bridgeRun !== undefined;
@@ -230,13 +268,45 @@ export function streamCursor(
 			abortSignal?.addEventListener("abort", abortListener, { once: true });
 
 			throwIfAborted();
-			run = await agent.send(
-				{ text: prompt.text, images: prompt.images.length > 0 ? prompt.images : undefined },
-				{
-					onDelta: (args) => turnCoordinator.handleDelta(args.update),
-					onStep: (args) => turnCoordinator.handleStep(args.step),
+			sdkEventDebug?.recordSendMeta({
+				mode: sendPlan.mode,
+				reason: sendPlan.reason,
+				resetAgent: sendPlan.resetAgent,
+				bootstrap,
+				promptText: prompt.text,
+				imageCount: prompt.images.length,
+				useNativeToolReplay,
+				bridgeEnabled: bridgeRun !== undefined,
+				nativeReplayId,
+				promptInputTokens,
+			});
+			const sendPayload = {
+				text: prompt.text,
+				images: prompt.images.length > 0 ? prompt.images : undefined,
+			};
+			sdkEventDebug?.recordSendPayload(sendPayload);
+			sdkEventDebug?.recordProviderEvent("agent_send_start", sendPayload);
+			run = await agent.send(sendPayload, {
+				onDelta: (args) => {
+					sdkEventDebug?.recordOnDelta(args.update);
+					turnCoordinator.handleDelta(args.update);
 				},
-			);
+				onStep: (args) => {
+					sdkEventDebug?.recordOnStep(args.step);
+					turnCoordinator.handleStep(args.step);
+				},
+			});
+			sdkEventDebug?.recordRunMeta({
+				runId: run.id,
+				agentId: run.agentId,
+				status: run.status,
+			});
+			sdkEventDebug?.attachRunStream(run);
+			sdkEventDebug?.recordProviderEvent("agent_send_returned", {
+				runId: run.id,
+				agentId: run.agentId,
+				status: run.status,
+			});
 			if (liveRun) cursorLiveRuns.attachSdkRun(liveRun, run);
 			if (options?.signal?.aborted) {
 				await run.cancel().catch(() => {});
@@ -244,9 +314,13 @@ export function streamCursor(
 			}
 
 			if (liveRun) {
+				deferSdkEventDebugFinalize = true;
 				void run
 					.wait()
 					.then(async (result) => {
+						sdkEventDebug?.recordWaitResult(result);
+						await sdkEventDebug?.captureRunArtifacts(run);
+						await sdkEventDebug?.finalize();
 						if (liveRun.disposed) return;
 						turnCoordinator.discardIncompleteStartedToolCalls();
 						await cacheSdkContextWindow(liveRun.agent.agentId, model.id);
@@ -276,6 +350,10 @@ export function streamCursor(
 						}
 					})
 					.catch(async (error: unknown) => {
+						sdkEventDebug?.recordWaitResult({ status: "error", error: String(error) });
+						sdkEventDebug?.recordError("run_wait", error);
+						await sdkEventDebug?.captureRunArtifacts(run);
+						await sdkEventDebug?.finalize();
 						if (liveRun.disposed) return;
 						cursorLiveRuns.markError(liveRun, sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey));
 					});
@@ -291,11 +369,14 @@ export function streamCursor(
 					if (error instanceof CursorLiveRunAbortError) await cursorLiveRuns.release(liveRun);
 					throw error;
 				}
+				recordActiveCursorSdkFinalPartial(partial);
 				agent = null;
 				return;
 			}
 
 			const result = await run.wait();
+			sdkEventDebug?.recordWaitResult(result);
+			await sdkEventDebug?.captureRunArtifacts(run);
 			turnCoordinator.discardIncompleteStartedToolCalls();
 			await cacheSdkContextWindow(agent.agentId, model.id);
 
@@ -329,6 +410,7 @@ export function streamCursor(
 				stream.push({ type: "done", reason: "stop", message: partial });
 			}
 		} catch (error) {
+			sdkEventDebug?.recordError("provider_stream", error);
 			if (activeLiveRun && !activeLiveRun.disposed) await cursorLiveRuns.release(activeLiveRun);
 			else await abandonSessionCursorAgent(sessionAgentScopeKey);
 			if (error instanceof CursorLiveRunAbortError) {
@@ -343,6 +425,12 @@ export function streamCursor(
 				stream.push({ type: "error", reason: "error", error: partial });
 			}
 		} finally {
+			if (!deferSdkEventDebugFinalize) {
+				recordActiveCursorSdkFinalPartial(partial);
+				await sdkEventDebug?.finalize();
+			}
+			setActiveCursorSdkEventDebugSink(undefined);
+			sdkEventDebugRef.current = undefined;
 			restoreCursorSdkOutputFilter?.();
 
 			if (abortSignal && abortListener) {

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -52,8 +52,6 @@ import { getCheckpointContextWindow, saveCachedContextWindow } from "./context-w
 import {
 	attachCursorSdkEventDebugPiStreamTap,
 	CursorSdkEventDebugSink,
-	recordActiveCursorSdkFinalPartial,
-	setActiveCursorSdkEventDebugSink,
 } from "./cursor-sdk-event-debug.js";
 import { CursorSdkTurnCoordinator } from "./cursor-provider-turn-coordinator.js";
 import { isCursorNativeToolDisplayRuntimeEnabled } from "./cursor-native-tool-display.js";
@@ -146,13 +144,11 @@ export function streamCursor(
 				provider: model.provider,
 			});
 			sdkEventDebugRef.current = sdkEventDebug;
-			setActiveCursorSdkEventDebugSink(sdkEventDebug);
 			sdkEventDebug?.recordContextSnapshot(context);
 
-			if ((await drainExistingCursorLiveRunBeforeSend(stream, partial, model, context, options?.signal)) === "stream_ended") {
-				recordActiveCursorSdkFinalPartial(partial);
+			if ((await drainExistingCursorLiveRunBeforeSend(stream, partial, model, context, options?.signal, sdkEventDebug)) === "stream_ended") {
+				sdkEventDebug?.recordFinalPartial(partial);
 				await sdkEventDebug?.finalize();
-				setActiveCursorSdkEventDebugSink(undefined);
 				sdkEventDebugRef.current = undefined;
 				stream.end();
 				return;
@@ -173,6 +169,7 @@ export function streamCursor(
 				cwd,
 				modelSelection: selection,
 				settingSources,
+				debugRecorder: sdkEventDebug,
 				onBridgeToolRequest: (request: CursorPiBridgeToolRequest) => {
 					if (liveRunForBridgeQueue && !liveRunForBridgeQueue.disposed) {
 						cursorLiveRuns.queueEvent(liveRunForBridgeQueue, { type: "bridge-tool", request });
@@ -235,6 +232,7 @@ export function streamCursor(
 						sessionAgentScopeKey,
 						promptInputTokens,
 						textDeltas,
+						debugRecorder: sdkEventDebug,
 					})
 				: undefined;
 			if (liveRun) {
@@ -254,6 +252,7 @@ export function streamCursor(
 				activeToolNames,
 				nativeReplayId,
 				textDeltas,
+				debugRecorder: sdkEventDebug,
 			});
 
 			// Handle abort signal
@@ -315,12 +314,11 @@ export function streamCursor(
 
 			if (liveRun) {
 				deferSdkEventDebugFinalize = true;
-				void run
+				const waitCompletion = run
 					.wait()
 					.then(async (result) => {
 						sdkEventDebug?.recordWaitResult(result);
 						await sdkEventDebug?.captureRunArtifacts(run);
-						await sdkEventDebug?.finalize();
 						if (liveRun.disposed) return;
 						turnCoordinator.discardIncompleteStartedToolCalls();
 						await cacheSdkContextWindow(liveRun.agent.agentId, model.id);
@@ -353,7 +351,6 @@ export function streamCursor(
 						sdkEventDebug?.recordWaitResult({ status: "error", error: String(error) });
 						sdkEventDebug?.recordError("run_wait", error);
 						await sdkEventDebug?.captureRunArtifacts(run);
-						await sdkEventDebug?.finalize();
 						if (liveRun.disposed) return;
 						cursorLiveRuns.markError(liveRun, sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey));
 					});
@@ -363,13 +360,24 @@ export function streamCursor(
 						await cursorLiveRuns.waitForProgress(liveRun, options?.signal);
 						await settleCursorLiveToolBatch(liveRun);
 						turnCoordinator.closeTraceBlock();
-						await drainCursorLiveRunTurn(stream, partial, model, context, liveRun, 0, { mode: "emit", signal: options?.signal });
+						await drainCursorLiveRunTurn(stream, partial, model, context, liveRun, 0, {
+							mode: "emit",
+							signal: options?.signal,
+							debugRecorder: sdkEventDebug,
+						});
 					});
 				} catch (error) {
 					if (error instanceof CursorLiveRunAbortError) await cursorLiveRuns.release(liveRun);
 					throw error;
+				} finally {
+					sdkEventDebugRef.current = undefined;
+					void waitCompletion
+						.finally(async () => {
+							sdkEventDebug?.recordFinalPartial(partial);
+							await sdkEventDebug?.finalize();
+						})
+						.catch(() => {});
 				}
-				recordActiveCursorSdkFinalPartial(partial);
 				agent = null;
 				return;
 			}
@@ -426,10 +434,9 @@ export function streamCursor(
 			}
 		} finally {
 			if (!deferSdkEventDebugFinalize) {
-				recordActiveCursorSdkFinalPartial(partial);
+				sdkEventDebug?.recordFinalPartial(partial);
 				await sdkEventDebug?.finalize();
 			}
-			setActiveCursorSdkEventDebugSink(undefined);
 			sdkEventDebugRef.current = undefined;
 			restoreCursorSdkOutputFilter?.();
 

--- a/src/cursor-sdk-event-debug-constants.ts
+++ b/src/cursor-sdk-event-debug-constants.ts
@@ -1,0 +1,40 @@
+import { resolve } from "node:path";
+
+export const CURSOR_SDK_EVENT_DEBUG_ENV = "PI_CURSOR_SDK_EVENT_DEBUG";
+export const CURSOR_SDK_EVENT_DEBUG_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_DIR";
+export const CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR";
+export const CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_SESSION_DIR";
+export const CURSOR_SDK_EVENT_DEBUG_STDERR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_STDERR";
+export const CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX = "[pi-cursor-sdk:sdk-events]";
+
+export const SESSION_MANIFEST = "session.json";
+export const SESSION_PI_SESSION_SNAPSHOT = "pi-session.jsonl";
+
+export const ARTIFACTS = {
+	metadata: "metadata.json",
+	sendPayload: "send-payload.json",
+	contextSnapshot: "context-snapshot.json",
+	onDelta: "on-delta.jsonl",
+	onStep: "on-step.jsonl",
+	streamEvents: "stream-events.jsonl",
+	piStreamEvents: "pi-stream-events.jsonl",
+	providerEvents: "provider-events.jsonl",
+	liveRunEvents: "live-run-events.jsonl",
+	bridgeEvents: "bridge-events.jsonl",
+	bridgeRaw: "bridge-raw.jsonl",
+	displayDecisions: "display-decisions.jsonl",
+	coordinatorEvents: "coordinator-events.jsonl",
+	drainEvents: "drain-events.jsonl",
+	timeline: "timeline.jsonl",
+	piSessionSnapshot: "pi-session-snapshot.jsonl",
+	finalPartial: "final-partial.json",
+	errors: "errors.jsonl",
+	waitResult: "wait-result.json",
+	conversation: "conversation.json",
+	summary: "summary.json",
+} as const;
+
+export function resolveCursorSdkEventDebugBaseDir(cwd: string, env: Record<string, string | undefined> = process.env): string {
+	const raw = env[CURSOR_SDK_EVENT_DEBUG_DIR_ENV]?.trim();
+	return resolve(cwd, raw || ".debug/cursor-sdk-events");
+}

--- a/src/cursor-sdk-event-debug-session.ts
+++ b/src/cursor-sdk-event-debug-session.ts
@@ -75,6 +75,11 @@ function writeSessionManifest(sessionDir: string, manifest: CursorSdkEventDebugS
 	writeFileSync(join(sessionDir, SESSION_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 
+function maxTurnFromManifest(manifest: CursorSdkEventDebugSessionManifest | undefined): number {
+	if (!manifest || manifest.turns.length === 0) return 0;
+	return manifest.turns.reduce((max, entry) => Math.max(max, entry.turn), 0);
+}
+
 function resolveSessionDebugDir(
 	cwd: string,
 	env: Record<string, string | undefined>,
@@ -100,7 +105,8 @@ export function allocateCursorSdkEventDebugTurn(
 
 	let state = sessionDebugStates.get(scopeKey);
 	if (!state || state.sessionDir !== sessionDir) {
-		state = { sessionKey: scopeKey, sessionDir, turnCounter: 0 };
+		const existing = readSessionManifest(sessionDir);
+		state = { sessionKey: scopeKey, sessionDir, turnCounter: maxTurnFromManifest(existing) };
 		sessionDebugStates.set(scopeKey, state);
 	}
 
@@ -138,12 +144,12 @@ export function allocateCursorSdkEventDebugTurn(
 
 export function updateCursorSdkEventDebugSessionManifest(
 	sessionDir: string,
-	turn: number,
+	artifactDir: string,
 	summary: Record<string, unknown>,
 ): void {
 	const manifest = readSessionManifest(sessionDir);
 	if (!manifest) return;
-	const turnEntry = manifest.turns.find((entry) => entry.turn === turn);
+	const turnEntry = manifest.turns.find((entry) => entry.artifactDir === artifactDir);
 	if (!turnEntry) return;
 	turnEntry.finalizedAt = new Date().toISOString();
 	turnEntry.summary = summary;

--- a/src/cursor-sdk-event-debug-session.ts
+++ b/src/cursor-sdk-event-debug-session.ts
@@ -1,0 +1,157 @@
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import {
+	CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV,
+	CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV,
+	SESSION_MANIFEST,
+	resolveCursorSdkEventDebugBaseDir,
+} from "./cursor-sdk-event-debug-constants.js";
+import { getCursorSessionFile, getCursorSessionScopeKey } from "./cursor-session-scope.js";
+
+const ANONYMOUS_SESSION_SCOPE_KEY = "__anonymous__";
+
+interface CursorSdkEventDebugSessionState {
+	sessionKey: string;
+	sessionDir: string;
+	turnCounter: number;
+}
+
+interface CursorSdkEventDebugSessionManifest {
+	sessionKey: string;
+	sessionFile?: string;
+	sessionDir: string;
+	createdAt: string;
+	updatedAt: string;
+	turns: Array<{
+		turn: number;
+		artifactDir: string;
+		startedAt: string;
+		finalizedAt?: string;
+		summary?: Record<string, unknown>;
+	}>;
+}
+
+export interface CursorSdkEventDebugTurnAllocation {
+	artifactDir: string;
+	sessionDir?: string;
+	turn?: number;
+	sessionKey?: string;
+	pinnedRun: boolean;
+}
+
+const sessionDebugStates = new Map<string, CursorSdkEventDebugSessionState>();
+
+function sanitizePathSegment(value: string): string {
+	return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "session";
+}
+
+export function slugSessionKey(scopeKey: string): string {
+	if (scopeKey === ANONYMOUS_SESSION_SCOPE_KEY) {
+		return `anonymous-${process.pid}`;
+	}
+	const fileBase = sanitizePathSegment(basename(scopeKey).replace(/\.jsonl?$/i, "") || "session");
+	const hash = createHash("sha256").update(scopeKey).digest("hex").slice(0, 8);
+	return `${fileBase}-${hash}`;
+}
+
+function resolvePinnedRunArtifactDir(runDirOverride: string | undefined): string | undefined {
+	const trimmed = runDirOverride?.trim();
+	if (!trimmed) return undefined;
+	const dir = resolve(trimmed);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function readSessionManifest(sessionDir: string): CursorSdkEventDebugSessionManifest | undefined {
+	try {
+		return JSON.parse(readFileSync(join(sessionDir, SESSION_MANIFEST), "utf8")) as CursorSdkEventDebugSessionManifest;
+	} catch {
+		return undefined;
+	}
+}
+
+function writeSessionManifest(sessionDir: string, manifest: CursorSdkEventDebugSessionManifest): void {
+	writeFileSync(join(sessionDir, SESSION_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function resolveSessionDebugDir(
+	cwd: string,
+	env: Record<string, string | undefined>,
+	scopeKey: string,
+): string {
+	const pinned = env[CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV]?.trim();
+	if (pinned) return resolve(pinned);
+	return join(resolveCursorSdkEventDebugBaseDir(cwd, env), "sessions", slugSessionKey(scopeKey));
+}
+
+export function allocateCursorSdkEventDebugTurn(
+	cwd: string,
+	env: Record<string, string | undefined>,
+): CursorSdkEventDebugTurnAllocation {
+	const pinnedRunDir = resolvePinnedRunArtifactDir(env[CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV]);
+	if (pinnedRunDir) {
+		return { artifactDir: pinnedRunDir, pinnedRun: true };
+	}
+
+	const scopeKey = getCursorSessionScopeKey();
+	const sessionDir = resolveSessionDebugDir(cwd, env, scopeKey);
+	mkdirSync(sessionDir, { recursive: true });
+
+	let state = sessionDebugStates.get(scopeKey);
+	if (!state || state.sessionDir !== sessionDir) {
+		state = { sessionKey: scopeKey, sessionDir, turnCounter: 0 };
+		sessionDebugStates.set(scopeKey, state);
+	}
+
+	state.turnCounter += 1;
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const artifactDir = join(sessionDir, `turn-${String(state.turnCounter).padStart(3, "0")}-${stamp}`);
+	mkdirSync(artifactDir, { recursive: true });
+
+	const existing = readSessionManifest(sessionDir);
+	const manifest: CursorSdkEventDebugSessionManifest = existing ?? {
+		sessionKey: scopeKey,
+		sessionFile: getCursorSessionFile(),
+		sessionDir,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		turns: [],
+	};
+	manifest.sessionFile = getCursorSessionFile();
+	manifest.updatedAt = new Date().toISOString();
+	manifest.turns.push({
+		turn: state.turnCounter,
+		artifactDir,
+		startedAt: new Date().toISOString(),
+	});
+	writeSessionManifest(sessionDir, manifest);
+
+	return {
+		artifactDir,
+		sessionDir,
+		turn: state.turnCounter,
+		sessionKey: scopeKey,
+		pinnedRun: false,
+	};
+}
+
+export function updateCursorSdkEventDebugSessionManifest(
+	sessionDir: string,
+	turn: number,
+	summary: Record<string, unknown>,
+): void {
+	const manifest = readSessionManifest(sessionDir);
+	if (!manifest) return;
+	const turnEntry = manifest.turns.find((entry) => entry.turn === turn);
+	if (!turnEntry) return;
+	turnEntry.finalizedAt = new Date().toISOString();
+	turnEntry.summary = summary;
+	manifest.updatedAt = new Date().toISOString();
+	manifest.sessionFile = getCursorSessionFile();
+	writeSessionManifest(sessionDir, manifest);
+}
+
+export function resetCursorSdkEventDebugSessionStateForTests(): void {
+	sessionDebugStates.clear();
+}

--- a/src/cursor-sdk-event-debug.ts
+++ b/src/cursor-sdk-event-debug.ts
@@ -1,0 +1,669 @@
+import { appendFileSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { basename, join, resolve } from "node:path";
+import type { AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import type { InteractionUpdate } from "@cursor/sdk";
+import type { CursorPiToolBridgeDiagnosticEvent } from "./cursor-pi-tool-bridge-diagnostics.js";
+import { serializeCursorPiToolBridgeDiagnostic } from "./cursor-pi-tool-bridge-diagnostics.js";
+import type { CursorPiBridgeToolRequest } from "./cursor-pi-tool-bridge-types.js";
+import type { CursorLiveQueuedEvent } from "./cursor-live-run-coordinator.js";
+import { getCursorSessionFile, getCursorSessionScopeKey } from "./cursor-session-scope.js";
+import { parseEnvBoolean } from "./cursor-env-boolean.js";
+
+export const CURSOR_SDK_EVENT_DEBUG_ENV = "PI_CURSOR_SDK_EVENT_DEBUG";
+export const CURSOR_SDK_EVENT_DEBUG_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_DIR";
+export const CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR";
+export const CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_SESSION_DIR";
+export const CURSOR_SDK_EVENT_DEBUG_STDERR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_STDERR";
+export const CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX = "[pi-cursor-sdk:sdk-events]";
+
+const SESSION_MANIFEST = "session.json";
+const ANONYMOUS_SESSION_SCOPE_KEY = "__anonymous__";
+
+const ARTIFACTS = {
+	metadata: "metadata.json",
+	sendPayload: "send-payload.json",
+	contextSnapshot: "context-snapshot.json",
+	onDelta: "on-delta.jsonl",
+	onStep: "on-step.jsonl",
+	streamEvents: "stream-events.jsonl",
+	piStreamEvents: "pi-stream-events.jsonl",
+	providerEvents: "provider-events.jsonl",
+	liveRunEvents: "live-run-events.jsonl",
+	bridgeEvents: "bridge-events.jsonl",
+	bridgeRaw: "bridge-raw.jsonl",
+	displayDecisions: "display-decisions.jsonl",
+	coordinatorEvents: "coordinator-events.jsonl",
+	drainEvents: "drain-events.jsonl",
+	timeline: "timeline.jsonl",
+	piSessionSnapshot: "pi-session-snapshot.jsonl",
+	finalPartial: "final-partial.json",
+	errors: "errors.jsonl",
+	waitResult: "wait-result.json",
+	conversation: "conversation.json",
+	summary: "summary.json",
+} as const;
+
+const SESSION_PI_SESSION_SNAPSHOT = "pi-session.jsonl";
+
+export type CursorSdkDisplayDecisionAction = "skip-duplicate" | "queue_replay" | "emit_trace" | "ignore-bridge";
+
+export interface CursorSdkDisplayDecisionRecord {
+	action: CursorSdkDisplayDecisionAction;
+	disposition?: string;
+	toolName: string;
+	identity?: string;
+	source?: "started" | "fallback" | "delta" | "step";
+	transcript?: string;
+	traceText?: string;
+	replayToolId?: string;
+	reason?: string;
+}
+
+export interface CursorSdkEventDebugSinkOptions {
+	cwd: string;
+	modelId: string;
+	provider: string;
+	env?: Record<string, string | undefined>;
+}
+
+export interface CursorSdkEventDebugSendMeta {
+	mode: string;
+	reason: string;
+	resetAgent: boolean;
+	bootstrap: boolean;
+	promptText: string;
+	imageCount: number;
+	useNativeToolReplay: boolean;
+	bridgeEnabled: boolean;
+	nativeReplayId: string;
+	promptInputTokens: number;
+}
+
+export interface CursorSdkEventDebugRunMeta {
+	runId: string;
+	agentId: string;
+	status: string;
+}
+
+interface CursorSdkRunLike {
+	id: string;
+	agentId?: string;
+	status?: string;
+	stream?: () => AsyncIterable<unknown>;
+	wait?: () => Promise<unknown>;
+	supports?: (operation: never) => boolean;
+	unsupportedReason?: (operation: never) => string | undefined;
+	conversation?: () => Promise<unknown>;
+}
+
+interface CursorSdkEventDebugSessionState {
+	sessionKey: string;
+	sessionDir: string;
+	turnCounter: number;
+}
+
+interface CursorSdkEventDebugSessionManifest {
+	sessionKey: string;
+	sessionFile?: string;
+	sessionDir: string;
+	createdAt: string;
+	updatedAt: string;
+	turns: Array<{
+		turn: number;
+		artifactDir: string;
+		startedAt: string;
+		finalizedAt?: string;
+		summary?: Record<string, unknown>;
+	}>;
+}
+
+let activeCursorSdkEventDebugSink: CursorSdkEventDebugSink | undefined;
+const sessionDebugStates = new Map<string, CursorSdkEventDebugSessionState>();
+
+function eventType(value: unknown): string {
+	if (value && typeof value === "object") {
+		if ("type" in value && typeof value.type === "string") return value.type;
+		if ("event" in value && typeof value.event === "string") return value.event;
+		if ("kind" in value && typeof value.kind === "string") return value.kind;
+	}
+	return "unknown";
+}
+
+function sanitizePathSegment(value: string): string {
+	return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "session";
+}
+
+function slugSessionKey(scopeKey: string): string {
+	if (scopeKey === ANONYMOUS_SESSION_SCOPE_KEY) {
+		return `anonymous-${process.pid}`;
+	}
+	const fileBase = sanitizePathSegment(basename(scopeKey).replace(/\.jsonl?$/i, "") || "session");
+	const hash = createHash("sha256").update(scopeKey).digest("hex").slice(0, 8);
+	return `${fileBase}-${hash}`;
+}
+
+function resolvePinnedRunArtifactDir(runDirOverride: string | undefined): string | undefined {
+	const trimmed = runDirOverride?.trim();
+	if (!trimmed) return undefined;
+	const dir = resolve(trimmed);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+function readSessionManifest(sessionDir: string): CursorSdkEventDebugSessionManifest | undefined {
+	try {
+		return JSON.parse(readFileSync(join(sessionDir, SESSION_MANIFEST), "utf8")) as CursorSdkEventDebugSessionManifest;
+	} catch {
+		return undefined;
+	}
+}
+
+function writeSessionManifest(sessionDir: string, manifest: CursorSdkEventDebugSessionManifest): void {
+	writeFileSync(join(sessionDir, SESSION_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function resolveSessionDebugDir(
+	cwd: string,
+	env: Record<string, string | undefined>,
+	scopeKey: string,
+): string {
+	const pinned = env[CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV]?.trim();
+	if (pinned) return resolve(pinned);
+	return join(resolveCursorSdkEventDebugBaseDir(cwd, env), "sessions", slugSessionKey(scopeKey));
+}
+
+function allocateTurnArtifactDir(
+	cwd: string,
+	env: Record<string, string | undefined>,
+): { artifactDir: string; sessionDir?: string; turn?: number; sessionKey?: string; pinnedRun: boolean } {
+	const pinnedRunDir = resolvePinnedRunArtifactDir(env[CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV]);
+	if (pinnedRunDir) {
+		return { artifactDir: pinnedRunDir, pinnedRun: true };
+	}
+
+	const scopeKey = getCursorSessionScopeKey();
+	const sessionDir = resolveSessionDebugDir(cwd, env, scopeKey);
+	mkdirSync(sessionDir, { recursive: true });
+
+	let state = sessionDebugStates.get(scopeKey);
+	if (!state || state.sessionDir !== sessionDir) {
+		state = { sessionKey: scopeKey, sessionDir, turnCounter: 0 };
+		sessionDebugStates.set(scopeKey, state);
+	}
+
+	state.turnCounter += 1;
+	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+	const artifactDir = join(sessionDir, `turn-${String(state.turnCounter).padStart(3, "0")}-${stamp}`);
+	mkdirSync(artifactDir, { recursive: true });
+
+	const existing = readSessionManifest(sessionDir);
+	const manifest: CursorSdkEventDebugSessionManifest = existing ?? {
+		sessionKey: scopeKey,
+		sessionFile: getCursorSessionFile(),
+		sessionDir,
+		createdAt: new Date().toISOString(),
+		updatedAt: new Date().toISOString(),
+		turns: [],
+	};
+	manifest.sessionFile = getCursorSessionFile();
+	manifest.updatedAt = new Date().toISOString();
+	manifest.turns.push({
+		turn: state.turnCounter,
+		artifactDir,
+		startedAt: new Date().toISOString(),
+	});
+	writeSessionManifest(sessionDir, manifest);
+
+	return {
+		artifactDir,
+		sessionDir,
+		turn: state.turnCounter,
+		sessionKey: scopeKey,
+		pinnedRun: false,
+	};
+}
+
+function resolveCursorSdkEventDebugStderrEnabled(env: Record<string, string | undefined> = process.env): boolean {
+	return parseEnvBoolean(env[CURSOR_SDK_EVENT_DEBUG_STDERR_ENV], false);
+}
+
+export function resolveCursorSdkEventDebugEnabled(env: Record<string, string | undefined> = process.env): boolean {
+	return parseEnvBoolean(env[CURSOR_SDK_EVENT_DEBUG_ENV], false);
+}
+
+export function resolveCursorSdkEventDebugBaseDir(cwd: string, env: Record<string, string | undefined> = process.env): string {
+	const raw = env[CURSOR_SDK_EVENT_DEBUG_DIR_ENV]?.trim();
+	return resolve(cwd, raw || ".debug/cursor-sdk-events");
+}
+
+export function setActiveCursorSdkEventDebugSink(sink: CursorSdkEventDebugSink | undefined): void {
+	activeCursorSdkEventDebugSink = sink;
+}
+
+export function getActiveCursorSdkEventDebugSink(): CursorSdkEventDebugSink | undefined {
+	return activeCursorSdkEventDebugSink;
+}
+
+export function recordActiveCursorSdkLiveRunEvent(event: CursorLiveQueuedEvent): void {
+	activeCursorSdkEventDebugSink?.recordLiveRunEvent(event);
+}
+
+export function recordActiveCursorSdkBridgeDiagnostic(event: CursorPiToolBridgeDiagnosticEvent): void {
+	activeCursorSdkEventDebugSink?.recordBridgeDiagnostic(event);
+}
+
+export function recordActiveCursorSdkBridgeRaw(payload: {
+	kind: "queued" | "resolved" | "rejected";
+	request: CursorPiBridgeToolRequest;
+	result?: unknown;
+	error?: unknown;
+	rejectionKind?: string;
+}): void {
+	activeCursorSdkEventDebugSink?.recordBridgeRaw(payload);
+}
+
+export function recordActiveCursorSdkDisplayDecision(decision: CursorSdkDisplayDecisionRecord): void {
+	activeCursorSdkEventDebugSink?.recordDisplayDecision(decision);
+}
+
+export function recordActiveCursorSdkCoordinatorEvent(phase: string, payload: unknown): void {
+	activeCursorSdkEventDebugSink?.recordCoordinatorEvent(phase, payload);
+}
+
+export function recordActiveCursorSdkDrainEvent(phase: string, payload: unknown): void {
+	activeCursorSdkEventDebugSink?.recordDrainEvent(phase, payload);
+}
+
+export function recordActiveCursorSdkFinalPartial(partial: unknown): void {
+	activeCursorSdkEventDebugSink?.recordFinalPartial(partial);
+}
+
+export function attachCursorSdkEventDebugPiStreamTap(
+	stream: AssistantMessageEventStream,
+	sinkRef: { current?: CursorSdkEventDebugSink },
+): void {
+	if (!resolveCursorSdkEventDebugEnabled()) return;
+	const originalPush = stream.push.bind(stream);
+	stream.push = (event) => {
+		sinkRef.current?.recordPiStreamEvent(event);
+		return originalPush(event);
+	};
+}
+
+export class CursorSdkEventDebugSink {
+	readonly artifactDir: string;
+	readonly sessionDir?: string;
+	readonly turn?: number;
+	readonly sessionKey?: string;
+	readonly pinnedRun: boolean;
+	private readonly env: Record<string, string | undefined>;
+	private readonly startedAt = Date.now();
+	private readonly counts = {
+		onDelta: {} as Record<string, number>,
+		onStep: {} as Record<string, number>,
+		stream: {} as Record<string, number>,
+		piStream: {} as Record<string, number>,
+		provider: {} as Record<string, number>,
+		liveRun: {} as Record<string, number>,
+		bridge: {} as Record<string, number>,
+		bridgeRaw: {} as Record<string, number>,
+		displayDecisions: {} as Record<string, number>,
+		coordinator: {} as Record<string, number>,
+		drain: {} as Record<string, number>,
+		timeline: {} as Record<string, number>,
+		errors: 0,
+	};
+	private metadata: Record<string, unknown>;
+	private finalized = false;
+	private waitResultRecorded = false;
+	private streamCapturePromise: Promise<void> | undefined;
+	private readonly streamCaptureErrors: unknown[] = [];
+
+	static maybeCreate(options: CursorSdkEventDebugSinkOptions): CursorSdkEventDebugSink | undefined {
+		const env = options.env ?? process.env;
+		if (!resolveCursorSdkEventDebugEnabled(env)) return undefined;
+		const allocation = allocateTurnArtifactDir(options.cwd, env);
+		return new CursorSdkEventDebugSink(allocation, options, env);
+	}
+
+	private constructor(
+		allocation: {
+			artifactDir: string;
+			sessionDir?: string;
+			turn?: number;
+			sessionKey?: string;
+			pinnedRun: boolean;
+		},
+		options: CursorSdkEventDebugSinkOptions,
+		env: Record<string, string | undefined>,
+	) {
+		this.artifactDir = allocation.artifactDir;
+		this.sessionDir = allocation.sessionDir;
+		this.turn = allocation.turn;
+		this.sessionKey = allocation.sessionKey;
+		this.pinnedRun = allocation.pinnedRun;
+		this.env = env;
+		this.metadata = {
+			capturedAt: new Date().toISOString(),
+			modelId: options.modelId,
+			provider: options.provider,
+			cwd: options.cwd,
+			sessionDir: allocation.sessionDir,
+			sessionKey: allocation.sessionKey,
+			sessionFile: getCursorSessionFile(),
+			turn: allocation.turn,
+			pinnedRun: allocation.pinnedRun,
+			artifacts: ARTIFACTS,
+			warnings: [
+				"Raw artifact files may contain local paths, project text, tool args/results, or secrets from the workspace. Do not commit or share them.",
+			],
+		};
+		writeFileSync(join(this.artifactDir, ARTIFACTS.metadata), `${JSON.stringify(this.metadata, null, 2)}\n`);
+	}
+
+	recordProviderMeta(meta: Record<string, unknown>): void {
+		this.metadata = {
+			...this.metadata,
+			provider: meta,
+		};
+		writeFileSync(join(this.artifactDir, ARTIFACTS.metadata), `${JSON.stringify(this.metadata, null, 2)}\n`);
+	}
+
+	recordSendMeta(meta: CursorSdkEventDebugSendMeta): void {
+		this.metadata = {
+			...this.metadata,
+			send: meta,
+		};
+		writeFileSync(join(this.artifactDir, ARTIFACTS.metadata), `${JSON.stringify(this.metadata, null, 2)}\n`);
+	}
+
+	recordSendPayload(payload: unknown): void {
+		writeFileSync(join(this.artifactDir, ARTIFACTS.sendPayload), `${JSON.stringify(payload, null, 2)}\n`);
+	}
+
+	recordContextSnapshot(context: unknown): void {
+		writeFileSync(join(this.artifactDir, ARTIFACTS.contextSnapshot), `${JSON.stringify(context, null, 2)}\n`);
+	}
+
+	recordRunMeta(meta: CursorSdkEventDebugRunMeta): void {
+		this.metadata = {
+			...this.metadata,
+			run: meta,
+		};
+		writeFileSync(join(this.artifactDir, ARTIFACTS.metadata), `${JSON.stringify(this.metadata, null, 2)}\n`);
+	}
+
+	recordOnDelta(update: InteractionUpdate): void {
+		this.appendJsonl(ARTIFACTS.onDelta, "update", update, this.counts.onDelta);
+	}
+
+	recordOnStep(step: unknown): void {
+		this.appendJsonl(ARTIFACTS.onStep, "step", step, this.counts.onStep);
+	}
+
+	recordStreamEvent(event: unknown): void {
+		this.appendJsonl(ARTIFACTS.streamEvents, "event", event, this.counts.stream);
+	}
+
+	recordPiStreamEvent(event: unknown): void {
+		this.appendJsonl(ARTIFACTS.piStreamEvents, "event", event, this.counts.piStream);
+	}
+
+	recordProviderEvent(phase: string, payload: unknown): void {
+		this.appendProviderJsonl(phase, payload);
+	}
+
+	recordLiveRunEvent(event: CursorLiveQueuedEvent): void {
+		this.appendJsonl(ARTIFACTS.liveRunEvents, "event", event, this.counts.liveRun);
+	}
+
+	recordBridgeDiagnostic(event: CursorPiToolBridgeDiagnosticEvent): void {
+		const serialized = serializeCursorPiToolBridgeDiagnostic(event);
+		this.appendJsonl(ARTIFACTS.bridgeEvents, "event", serialized, this.counts.bridge, String(serialized.event));
+	}
+
+	recordBridgeRaw(payload: {
+		kind: "queued" | "resolved" | "rejected";
+		request: CursorPiBridgeToolRequest;
+		result?: unknown;
+		error?: unknown;
+		rejectionKind?: string;
+	}): void {
+		this.appendJsonl(ARTIFACTS.bridgeRaw, "bridgeRaw", payload, this.counts.bridgeRaw, payload.kind);
+	}
+
+	recordDisplayDecision(decision: CursorSdkDisplayDecisionRecord): void {
+		this.appendJsonl(ARTIFACTS.displayDecisions, "decision", decision, this.counts.displayDecisions, decision.action);
+	}
+
+	recordCoordinatorEvent(phase: string, payload: unknown): void {
+		this.appendCoordinatorJsonl(phase, payload);
+	}
+
+	recordDrainEvent(phase: string, payload: unknown): void {
+		this.appendDrainJsonl(phase, payload);
+	}
+
+	recordFinalPartial(partial: unknown): void {
+		writeFileSync(join(this.artifactDir, ARTIFACTS.finalPartial), `${JSON.stringify(partial, null, 2)}\n`);
+		this.recordTimeline("finalPartial", "snapshot", partial);
+	}
+
+	recordError(label: string, error: unknown): void {
+		this.counts.errors += 1;
+		const payload = {
+			label,
+			message: error instanceof Error ? error.message : String(error),
+			stack: error instanceof Error ? error.stack : undefined,
+			value: error,
+		};
+		this.appendJsonl(ARTIFACTS.errors, "error", payload, { [label]: 1 }, label);
+	}
+
+	attachRunStream(run: unknown): void {
+		const sdkRun = run as CursorSdkRunLike;
+		if (typeof sdkRun.stream !== "function") {
+			this.recordProviderEvent("run_stream_unavailable", { runId: sdkRun.id });
+			return;
+		}
+		this.streamCapturePromise = (async () => {
+			try {
+				for await (const event of sdkRun.stream!()) {
+					this.recordStreamEvent(event);
+				}
+			} catch (error) {
+				this.streamCaptureErrors.push(error);
+				this.recordError("run_stream", error);
+			}
+		})();
+	}
+
+	async captureRunArtifacts(run: unknown): Promise<void> {
+		const sdkRun = run as CursorSdkRunLike & {
+			supports?: (operation: string) => boolean;
+			unsupportedReason?: (operation: string) => string | undefined;
+		};
+		if (this.streamCapturePromise) {
+			await this.streamCapturePromise.catch(() => undefined);
+		}
+		if (typeof sdkRun.conversation === "function" && sdkRun.supports?.("conversation")) {
+			try {
+				const conversation = await sdkRun.conversation();
+				writeFileSync(join(this.artifactDir, ARTIFACTS.conversation), `${JSON.stringify(conversation, null, 2)}\n`);
+				this.recordProviderEvent("conversation_captured", { supported: true });
+			} catch (error) {
+				this.recordError("conversation", error);
+			}
+		} else {
+			writeFileSync(
+				join(this.artifactDir, ARTIFACTS.conversation),
+				`${JSON.stringify(
+					{
+						skipped: true,
+						reason: sdkRun.unsupportedReason?.("conversation") ?? "conversation unsupported",
+					},
+					null,
+					2,
+				)}\n`,
+			);
+		}
+	}
+
+	recordWaitResult(result: unknown): void {
+		if (this.waitResultRecorded) return;
+		this.waitResultRecorded = true;
+		writeFileSync(join(this.artifactDir, ARTIFACTS.waitResult), `${JSON.stringify(result, null, 2)}\n`);
+	}
+
+	private capturePiSessionSnapshot(): { copied: boolean; sessionFile?: string; reason?: string } {
+		const sessionFile = getCursorSessionFile();
+		if (!sessionFile) {
+			return { copied: false, reason: "session file unknown" };
+		}
+		try {
+			copyFileSync(sessionFile, join(this.artifactDir, ARTIFACTS.piSessionSnapshot));
+			if (this.sessionDir) {
+				copyFileSync(sessionFile, join(this.sessionDir, SESSION_PI_SESSION_SNAPSHOT));
+			}
+			this.recordTimeline("piSession", "snapshot", { sessionFile, artifact: ARTIFACTS.piSessionSnapshot });
+			return { copied: true, sessionFile };
+		} catch (error) {
+			this.recordError("pi_session_snapshot", error);
+			return {
+				copied: false,
+				sessionFile,
+				reason: error instanceof Error ? error.message : String(error),
+			};
+		}
+	}
+
+	private updateSessionManifest(summary: Record<string, unknown>): void {
+		if (this.pinnedRun || !this.sessionDir || this.turn === undefined) return;
+		const manifest = readSessionManifest(this.sessionDir);
+		if (!manifest) return;
+		const turnEntry = manifest.turns.find((entry) => entry.turn === this.turn);
+		if (!turnEntry) return;
+		turnEntry.finalizedAt = new Date().toISOString();
+		turnEntry.summary = summary;
+		manifest.updatedAt = new Date().toISOString();
+		manifest.sessionFile = getCursorSessionFile();
+		writeSessionManifest(this.sessionDir, manifest);
+	}
+
+	async finalize(): Promise<void> {
+		if (this.finalized) return;
+		this.finalized = true;
+		if (this.streamCapturePromise) {
+			await this.streamCapturePromise.catch(() => undefined);
+		}
+		const piSessionSnapshot = this.capturePiSessionSnapshot();
+		const summary = {
+			artifactDir: this.artifactDir,
+			sessionDir: this.sessionDir,
+			sessionKey: this.sessionKey,
+			sessionFile: getCursorSessionFile(),
+			turn: this.turn,
+			elapsedMs: Date.now() - this.startedAt,
+			counts: {
+				onDelta: { ...this.counts.onDelta },
+				onStep: { ...this.counts.onStep },
+				stream: { ...this.counts.stream },
+				piStream: { ...this.counts.piStream },
+				provider: { ...this.counts.provider },
+				liveRun: { ...this.counts.liveRun },
+				bridge: { ...this.counts.bridge },
+				bridgeRaw: { ...this.counts.bridgeRaw },
+				displayDecisions: { ...this.counts.displayDecisions },
+				coordinator: { ...this.counts.coordinator },
+				drain: { ...this.counts.drain },
+				timeline: { ...this.counts.timeline },
+				errors: this.counts.errors,
+			},
+			piSessionSnapshot,
+			artifacts: Object.fromEntries(
+				Object.entries(ARTIFACTS).map(([key, name]) => [key, join(this.artifactDir, name)]),
+			),
+			waitResultRecorded: this.waitResultRecorded,
+			streamCaptureErrors: this.streamCaptureErrors.map((error) =>
+				error instanceof Error ? error.message : String(error),
+			),
+		};
+		writeFileSync(join(this.artifactDir, ARTIFACTS.summary), `${JSON.stringify(summary, null, 2)}\n`);
+		this.updateSessionManifest(summary);
+		if (resolveCursorSdkEventDebugStderrEnabled(this.env)) {
+			process.stderr.write(`${CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX} ${JSON.stringify(summary)}\n`);
+		}
+	}
+
+	private appendProviderJsonl(phase: string, payload: unknown): void {
+		const elapsedMs = Date.now() - this.startedAt;
+		const record = { ts: new Date().toISOString(), elapsedMs, turn: this.turn, phase, payload };
+		appendFileSync(join(this.artifactDir, ARTIFACTS.providerEvents), `${JSON.stringify(record)}\n`);
+		this.counts.provider[phase] = (this.counts.provider[phase] ?? 0) + 1;
+		this.recordTimeline("provider", phase, payload);
+	}
+
+	private appendCoordinatorJsonl(phase: string, payload: unknown): void {
+		const elapsedMs = Date.now() - this.startedAt;
+		const record = { ts: new Date().toISOString(), elapsedMs, turn: this.turn, phase, payload };
+		appendFileSync(join(this.artifactDir, ARTIFACTS.coordinatorEvents), `${JSON.stringify(record)}\n`);
+		this.counts.coordinator[phase] = (this.counts.coordinator[phase] ?? 0) + 1;
+		this.recordTimeline("coordinator", phase, payload);
+	}
+
+	private appendDrainJsonl(phase: string, payload: unknown): void {
+		const elapsedMs = Date.now() - this.startedAt;
+		const record = { ts: new Date().toISOString(), elapsedMs, turn: this.turn, phase, payload };
+		appendFileSync(join(this.artifactDir, ARTIFACTS.drainEvents), `${JSON.stringify(record)}\n`);
+		this.counts.drain[phase] = (this.counts.drain[phase] ?? 0) + 1;
+		this.recordTimeline("drain", phase, payload);
+	}
+
+	private recordTimeline(layer: string, kind: string, payload: unknown): void {
+		const elapsedMs = Date.now() - this.startedAt;
+		const record = {
+			ts: new Date().toISOString(),
+			elapsedMs,
+			turn: this.turn,
+			layer,
+			kind,
+			payload,
+		};
+		appendFileSync(join(this.artifactDir, ARTIFACTS.timeline), `${JSON.stringify(record)}\n`);
+		const timelineKey = `${layer}:${kind}`;
+		this.counts.timeline[timelineKey] = (this.counts.timeline[timelineKey] ?? 0) + 1;
+	}
+
+	private appendJsonl(
+		fileName: string,
+		recordKey: string,
+		value: unknown,
+		counts: Record<string, number>,
+		countKey?: string,
+	): void {
+		const elapsedMs = Date.now() - this.startedAt;
+		const record = {
+			ts: new Date().toISOString(),
+			elapsedMs,
+			turn: this.turn,
+			[recordKey]: value,
+		};
+		appendFileSync(join(this.artifactDir, fileName), `${JSON.stringify(record)}\n`);
+		const type = countKey ?? eventType(value);
+		counts[type] = (counts[type] ?? 0) + 1;
+		const layer = fileName.replace(/\.jsonl$/, "");
+		this.recordTimeline(layer, type, value);
+	}
+}
+
+export function resetCursorSdkEventDebugSessionStateForTests(): void {
+	sessionDebugStates.clear();
+}
+
+export const __testUtils = {
+	ARTIFACTS,
+	SESSION_MANIFEST,
+	slugSessionKey,
+	resetSessionDebugState: resetCursorSdkEventDebugSessionStateForTests,
+};

--- a/src/cursor-sdk-event-debug.ts
+++ b/src/cursor-sdk-event-debug.ts
@@ -1,50 +1,38 @@
-import { appendFileSync, copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { createHash } from "node:crypto";
-import { basename, join, resolve } from "node:path";
+import { copyFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import type { AssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { InteractionUpdate } from "@cursor/sdk";
 import type { CursorPiToolBridgeDiagnosticEvent } from "./cursor-pi-tool-bridge-diagnostics.js";
 import { serializeCursorPiToolBridgeDiagnostic } from "./cursor-pi-tool-bridge-diagnostics.js";
 import type { CursorPiBridgeToolRequest } from "./cursor-pi-tool-bridge-types.js";
 import type { CursorLiveQueuedEvent } from "./cursor-live-run-coordinator.js";
-import { getCursorSessionFile, getCursorSessionScopeKey } from "./cursor-session-scope.js";
+import { getCursorSessionFile } from "./cursor-session-scope.js";
 import { parseEnvBoolean } from "./cursor-env-boolean.js";
+import {
+	ARTIFACTS,
+	CURSOR_SDK_EVENT_DEBUG_ENV,
+	CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX,
+	CURSOR_SDK_EVENT_DEBUG_STDERR_ENV,
+	SESSION_MANIFEST,
+	SESSION_PI_SESSION_SNAPSHOT,
+} from "./cursor-sdk-event-debug-constants.js";
+import {
+	allocateCursorSdkEventDebugTurn,
+	resetCursorSdkEventDebugSessionStateForTests,
+	slugSessionKey,
+	updateCursorSdkEventDebugSessionManifest,
+	type CursorSdkEventDebugTurnAllocation,
+} from "./cursor-sdk-event-debug-session.js";
 
-export const CURSOR_SDK_EVENT_DEBUG_ENV = "PI_CURSOR_SDK_EVENT_DEBUG";
-export const CURSOR_SDK_EVENT_DEBUG_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_DIR";
-export const CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR";
-export const CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_SESSION_DIR";
-export const CURSOR_SDK_EVENT_DEBUG_STDERR_ENV = "PI_CURSOR_SDK_EVENT_DEBUG_STDERR";
-export const CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX = "[pi-cursor-sdk:sdk-events]";
-
-const SESSION_MANIFEST = "session.json";
-const ANONYMOUS_SESSION_SCOPE_KEY = "__anonymous__";
-
-const ARTIFACTS = {
-	metadata: "metadata.json",
-	sendPayload: "send-payload.json",
-	contextSnapshot: "context-snapshot.json",
-	onDelta: "on-delta.jsonl",
-	onStep: "on-step.jsonl",
-	streamEvents: "stream-events.jsonl",
-	piStreamEvents: "pi-stream-events.jsonl",
-	providerEvents: "provider-events.jsonl",
-	liveRunEvents: "live-run-events.jsonl",
-	bridgeEvents: "bridge-events.jsonl",
-	bridgeRaw: "bridge-raw.jsonl",
-	displayDecisions: "display-decisions.jsonl",
-	coordinatorEvents: "coordinator-events.jsonl",
-	drainEvents: "drain-events.jsonl",
-	timeline: "timeline.jsonl",
-	piSessionSnapshot: "pi-session-snapshot.jsonl",
-	finalPartial: "final-partial.json",
-	errors: "errors.jsonl",
-	waitResult: "wait-result.json",
-	conversation: "conversation.json",
-	summary: "summary.json",
-} as const;
-
-const SESSION_PI_SESSION_SNAPSHOT = "pi-session.jsonl";
+export {
+	CURSOR_SDK_EVENT_DEBUG_DIR_ENV,
+	CURSOR_SDK_EVENT_DEBUG_ENV,
+	CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX,
+	CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV,
+	CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV,
+	CURSOR_SDK_EVENT_DEBUG_STDERR_ENV,
+	resolveCursorSdkEventDebugBaseDir,
+} from "./cursor-sdk-event-debug-constants.js";
 
 export type CursorSdkDisplayDecisionAction = "skip-duplicate" | "queue_replay" | "emit_trace" | "ignore-bridge";
 
@@ -97,30 +85,6 @@ interface CursorSdkRunLike {
 	conversation?: () => Promise<unknown>;
 }
 
-interface CursorSdkEventDebugSessionState {
-	sessionKey: string;
-	sessionDir: string;
-	turnCounter: number;
-}
-
-interface CursorSdkEventDebugSessionManifest {
-	sessionKey: string;
-	sessionFile?: string;
-	sessionDir: string;
-	createdAt: string;
-	updatedAt: string;
-	turns: Array<{
-		turn: number;
-		artifactDir: string;
-		startedAt: string;
-		finalizedAt?: string;
-		summary?: Record<string, unknown>;
-	}>;
-}
-
-let activeCursorSdkEventDebugSink: CursorSdkEventDebugSink | undefined;
-const sessionDebugStates = new Map<string, CursorSdkEventDebugSessionState>();
-
 function eventType(value: unknown): string {
 	if (value && typeof value === "object") {
 		if ("type" in value && typeof value.type === "string") return value.type;
@@ -128,100 +92,6 @@ function eventType(value: unknown): string {
 		if ("kind" in value && typeof value.kind === "string") return value.kind;
 	}
 	return "unknown";
-}
-
-function sanitizePathSegment(value: string): string {
-	return value.replace(/[^a-zA-Z0-9._-]+/g, "-").replace(/^-+|-+$/g, "") || "session";
-}
-
-function slugSessionKey(scopeKey: string): string {
-	if (scopeKey === ANONYMOUS_SESSION_SCOPE_KEY) {
-		return `anonymous-${process.pid}`;
-	}
-	const fileBase = sanitizePathSegment(basename(scopeKey).replace(/\.jsonl?$/i, "") || "session");
-	const hash = createHash("sha256").update(scopeKey).digest("hex").slice(0, 8);
-	return `${fileBase}-${hash}`;
-}
-
-function resolvePinnedRunArtifactDir(runDirOverride: string | undefined): string | undefined {
-	const trimmed = runDirOverride?.trim();
-	if (!trimmed) return undefined;
-	const dir = resolve(trimmed);
-	mkdirSync(dir, { recursive: true });
-	return dir;
-}
-
-function readSessionManifest(sessionDir: string): CursorSdkEventDebugSessionManifest | undefined {
-	try {
-		return JSON.parse(readFileSync(join(sessionDir, SESSION_MANIFEST), "utf8")) as CursorSdkEventDebugSessionManifest;
-	} catch {
-		return undefined;
-	}
-}
-
-function writeSessionManifest(sessionDir: string, manifest: CursorSdkEventDebugSessionManifest): void {
-	writeFileSync(join(sessionDir, SESSION_MANIFEST), `${JSON.stringify(manifest, null, 2)}\n`);
-}
-
-function resolveSessionDebugDir(
-	cwd: string,
-	env: Record<string, string | undefined>,
-	scopeKey: string,
-): string {
-	const pinned = env[CURSOR_SDK_EVENT_DEBUG_SESSION_DIR_ENV]?.trim();
-	if (pinned) return resolve(pinned);
-	return join(resolveCursorSdkEventDebugBaseDir(cwd, env), "sessions", slugSessionKey(scopeKey));
-}
-
-function allocateTurnArtifactDir(
-	cwd: string,
-	env: Record<string, string | undefined>,
-): { artifactDir: string; sessionDir?: string; turn?: number; sessionKey?: string; pinnedRun: boolean } {
-	const pinnedRunDir = resolvePinnedRunArtifactDir(env[CURSOR_SDK_EVENT_DEBUG_RUN_DIR_ENV]);
-	if (pinnedRunDir) {
-		return { artifactDir: pinnedRunDir, pinnedRun: true };
-	}
-
-	const scopeKey = getCursorSessionScopeKey();
-	const sessionDir = resolveSessionDebugDir(cwd, env, scopeKey);
-	mkdirSync(sessionDir, { recursive: true });
-
-	let state = sessionDebugStates.get(scopeKey);
-	if (!state || state.sessionDir !== sessionDir) {
-		state = { sessionKey: scopeKey, sessionDir, turnCounter: 0 };
-		sessionDebugStates.set(scopeKey, state);
-	}
-
-	state.turnCounter += 1;
-	const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-	const artifactDir = join(sessionDir, `turn-${String(state.turnCounter).padStart(3, "0")}-${stamp}`);
-	mkdirSync(artifactDir, { recursive: true });
-
-	const existing = readSessionManifest(sessionDir);
-	const manifest: CursorSdkEventDebugSessionManifest = existing ?? {
-		sessionKey: scopeKey,
-		sessionFile: getCursorSessionFile(),
-		sessionDir,
-		createdAt: new Date().toISOString(),
-		updatedAt: new Date().toISOString(),
-		turns: [],
-	};
-	manifest.sessionFile = getCursorSessionFile();
-	manifest.updatedAt = new Date().toISOString();
-	manifest.turns.push({
-		turn: state.turnCounter,
-		artifactDir,
-		startedAt: new Date().toISOString(),
-	});
-	writeSessionManifest(sessionDir, manifest);
-
-	return {
-		artifactDir,
-		sessionDir,
-		turn: state.turnCounter,
-		sessionKey: scopeKey,
-		pinnedRun: false,
-	};
 }
 
 function resolveCursorSdkEventDebugStderrEnabled(env: Record<string, string | undefined> = process.env): boolean {
@@ -232,51 +102,21 @@ export function resolveCursorSdkEventDebugEnabled(env: Record<string, string | u
 	return parseEnvBoolean(env[CURSOR_SDK_EVENT_DEBUG_ENV], false);
 }
 
-export function resolveCursorSdkEventDebugBaseDir(cwd: string, env: Record<string, string | undefined> = process.env): string {
-	const raw = env[CURSOR_SDK_EVENT_DEBUG_DIR_ENV]?.trim();
-	return resolve(cwd, raw || ".debug/cursor-sdk-events");
-}
-
-export function setActiveCursorSdkEventDebugSink(sink: CursorSdkEventDebugSink | undefined): void {
-	activeCursorSdkEventDebugSink = sink;
-}
-
-export function getActiveCursorSdkEventDebugSink(): CursorSdkEventDebugSink | undefined {
-	return activeCursorSdkEventDebugSink;
-}
-
-export function recordActiveCursorSdkLiveRunEvent(event: CursorLiveQueuedEvent): void {
-	activeCursorSdkEventDebugSink?.recordLiveRunEvent(event);
-}
-
-export function recordActiveCursorSdkBridgeDiagnostic(event: CursorPiToolBridgeDiagnosticEvent): void {
-	activeCursorSdkEventDebugSink?.recordBridgeDiagnostic(event);
-}
-
-export function recordActiveCursorSdkBridgeRaw(payload: {
-	kind: "queued" | "resolved" | "rejected";
-	request: CursorPiBridgeToolRequest;
-	result?: unknown;
-	error?: unknown;
-	rejectionKind?: string;
-}): void {
-	activeCursorSdkEventDebugSink?.recordBridgeRaw(payload);
-}
-
-export function recordActiveCursorSdkDisplayDecision(decision: CursorSdkDisplayDecisionRecord): void {
-	activeCursorSdkEventDebugSink?.recordDisplayDecision(decision);
-}
-
-export function recordActiveCursorSdkCoordinatorEvent(phase: string, payload: unknown): void {
-	activeCursorSdkEventDebugSink?.recordCoordinatorEvent(phase, payload);
-}
-
-export function recordActiveCursorSdkDrainEvent(phase: string, payload: unknown): void {
-	activeCursorSdkEventDebugSink?.recordDrainEvent(phase, payload);
-}
-
-export function recordActiveCursorSdkFinalPartial(partial: unknown): void {
-	activeCursorSdkEventDebugSink?.recordFinalPartial(partial);
+export interface CursorSdkEventDebugRecorder {
+	recordLiveRunEvent(event: CursorLiveQueuedEvent): void;
+	recordBridgeDiagnostic(event: CursorPiToolBridgeDiagnosticEvent): void;
+	recordBridgeRaw(payload: {
+		kind: "queued" | "resolved" | "rejected";
+		request: CursorPiBridgeToolRequest;
+		result?: unknown;
+		error?: unknown;
+		rejectionKind?: string;
+	}): void;
+	recordDisplayDecision(decision: CursorSdkDisplayDecisionRecord): void;
+	recordCoordinatorEvent(phase: string, payload: unknown): void;
+	recordDrainEvent(phase: string, payload: unknown): void;
+	recordFinalPartial(partial: unknown): void;
+	finalize(): Promise<void>;
 }
 
 export function attachCursorSdkEventDebugPiStreamTap(
@@ -315,7 +155,9 @@ export class CursorSdkEventDebugSink {
 		errors: 0,
 	};
 	private metadata: Record<string, unknown>;
+	private readonly jsonlBuffers = new Map<string, unknown[]>();
 	private finalized = false;
+	private finalizationPromise: Promise<void> | undefined;
 	private waitResultRecorded = false;
 	private streamCapturePromise: Promise<void> | undefined;
 	private readonly streamCaptureErrors: unknown[] = [];
@@ -323,18 +165,12 @@ export class CursorSdkEventDebugSink {
 	static maybeCreate(options: CursorSdkEventDebugSinkOptions): CursorSdkEventDebugSink | undefined {
 		const env = options.env ?? process.env;
 		if (!resolveCursorSdkEventDebugEnabled(env)) return undefined;
-		const allocation = allocateTurnArtifactDir(options.cwd, env);
+		const allocation = allocateCursorSdkEventDebugTurn(options.cwd, env);
 		return new CursorSdkEventDebugSink(allocation, options, env);
 	}
 
 	private constructor(
-		allocation: {
-			artifactDir: string;
-			sessionDir?: string;
-			turn?: number;
-			sessionKey?: string;
-			pinnedRun: boolean;
-		},
+		allocation: CursorSdkEventDebugTurnAllocation,
 		options: CursorSdkEventDebugSinkOptions,
 		env: Record<string, string | undefined>,
 	) {
@@ -365,7 +201,7 @@ export class CursorSdkEventDebugSink {
 	recordProviderMeta(meta: Record<string, unknown>): void {
 		this.metadata = {
 			...this.metadata,
-			provider: meta,
+			providerMeta: meta,
 		};
 		writeFileSync(join(this.artifactDir, ARTIFACTS.metadata), `${JSON.stringify(this.metadata, null, 2)}\n`);
 	}
@@ -540,20 +376,16 @@ export class CursorSdkEventDebugSink {
 
 	private updateSessionManifest(summary: Record<string, unknown>): void {
 		if (this.pinnedRun || !this.sessionDir || this.turn === undefined) return;
-		const manifest = readSessionManifest(this.sessionDir);
-		if (!manifest) return;
-		const turnEntry = manifest.turns.find((entry) => entry.turn === this.turn);
-		if (!turnEntry) return;
-		turnEntry.finalizedAt = new Date().toISOString();
-		turnEntry.summary = summary;
-		manifest.updatedAt = new Date().toISOString();
-		manifest.sessionFile = getCursorSessionFile();
-		writeSessionManifest(this.sessionDir, manifest);
+		updateCursorSdkEventDebugSessionManifest(this.sessionDir, this.turn, summary);
 	}
 
 	async finalize(): Promise<void> {
+		this.finalizationPromise ??= this.finalizeOnce();
+		await this.finalizationPromise;
+	}
+
+	private async finalizeOnce(): Promise<void> {
 		if (this.finalized) return;
-		this.finalized = true;
 		if (this.streamCapturePromise) {
 			await this.streamCapturePromise.catch(() => undefined);
 		}
@@ -589,17 +421,19 @@ export class CursorSdkEventDebugSink {
 				error instanceof Error ? error.message : String(error),
 			),
 		};
+		this.flushJsonlBuffers();
 		writeFileSync(join(this.artifactDir, ARTIFACTS.summary), `${JSON.stringify(summary, null, 2)}\n`);
 		this.updateSessionManifest(summary);
 		if (resolveCursorSdkEventDebugStderrEnabled(this.env)) {
 			process.stderr.write(`${CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX} ${JSON.stringify(summary)}\n`);
 		}
+		this.finalized = true;
 	}
 
 	private appendProviderJsonl(phase: string, payload: unknown): void {
 		const elapsedMs = Date.now() - this.startedAt;
 		const record = { ts: new Date().toISOString(), elapsedMs, turn: this.turn, phase, payload };
-		appendFileSync(join(this.artifactDir, ARTIFACTS.providerEvents), `${JSON.stringify(record)}\n`);
+		this.bufferJsonl(ARTIFACTS.providerEvents, record);
 		this.counts.provider[phase] = (this.counts.provider[phase] ?? 0) + 1;
 		this.recordTimeline("provider", phase, payload);
 	}
@@ -607,7 +441,7 @@ export class CursorSdkEventDebugSink {
 	private appendCoordinatorJsonl(phase: string, payload: unknown): void {
 		const elapsedMs = Date.now() - this.startedAt;
 		const record = { ts: new Date().toISOString(), elapsedMs, turn: this.turn, phase, payload };
-		appendFileSync(join(this.artifactDir, ARTIFACTS.coordinatorEvents), `${JSON.stringify(record)}\n`);
+		this.bufferJsonl(ARTIFACTS.coordinatorEvents, record);
 		this.counts.coordinator[phase] = (this.counts.coordinator[phase] ?? 0) + 1;
 		this.recordTimeline("coordinator", phase, payload);
 	}
@@ -615,7 +449,7 @@ export class CursorSdkEventDebugSink {
 	private appendDrainJsonl(phase: string, payload: unknown): void {
 		const elapsedMs = Date.now() - this.startedAt;
 		const record = { ts: new Date().toISOString(), elapsedMs, turn: this.turn, phase, payload };
-		appendFileSync(join(this.artifactDir, ARTIFACTS.drainEvents), `${JSON.stringify(record)}\n`);
+		this.bufferJsonl(ARTIFACTS.drainEvents, record);
 		this.counts.drain[phase] = (this.counts.drain[phase] ?? 0) + 1;
 		this.recordTimeline("drain", phase, payload);
 	}
@@ -630,7 +464,7 @@ export class CursorSdkEventDebugSink {
 			kind,
 			payload,
 		};
-		appendFileSync(join(this.artifactDir, ARTIFACTS.timeline), `${JSON.stringify(record)}\n`);
+		this.bufferJsonl(ARTIFACTS.timeline, record);
 		const timelineKey = `${layer}:${kind}`;
 		this.counts.timeline[timelineKey] = (this.counts.timeline[timelineKey] ?? 0) + 1;
 	}
@@ -649,16 +483,27 @@ export class CursorSdkEventDebugSink {
 			turn: this.turn,
 			[recordKey]: value,
 		};
-		appendFileSync(join(this.artifactDir, fileName), `${JSON.stringify(record)}\n`);
+		this.bufferJsonl(fileName, record);
 		const type = countKey ?? eventType(value);
 		counts[type] = (counts[type] ?? 0) + 1;
 		const layer = fileName.replace(/\.jsonl$/, "");
 		this.recordTimeline(layer, type, value);
 	}
-}
 
-export function resetCursorSdkEventDebugSessionStateForTests(): void {
-	sessionDebugStates.clear();
+	private bufferJsonl(fileName: string, record: unknown): void {
+		if (this.finalized) return;
+		const records = this.jsonlBuffers.get(fileName) ?? [];
+		records.push(record);
+		this.jsonlBuffers.set(fileName, records);
+	}
+
+	private flushJsonlBuffers(): void {
+		for (const [fileName, records] of this.jsonlBuffers) {
+			const lines = records.map((record) => `${JSON.stringify(record)}\n`).join("");
+			writeFileSync(join(this.artifactDir, fileName), lines, { flag: "a" });
+		}
+		this.jsonlBuffers.clear();
+	}
 }
 
 export const __testUtils = {

--- a/src/cursor-sdk-event-debug.ts
+++ b/src/cursor-sdk-event-debug.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AssistantMessageEventStream } from "@earendil-works/pi-ai";
 import type { InteractionUpdate } from "@cursor/sdk";
@@ -98,6 +98,18 @@ function resolveCursorSdkEventDebugStderrEnabled(env: Record<string, string | un
 	return parseEnvBoolean(env[CURSOR_SDK_EVENT_DEBUG_STDERR_ENV], false);
 }
 
+function snapshotCursorSdkEventDebugRecord(record: unknown): unknown {
+	try {
+		return structuredClone(record);
+	} catch {
+		try {
+			return JSON.parse(JSON.stringify(record));
+		} catch {
+			return record;
+		}
+	}
+}
+
 export function resolveCursorSdkEventDebugEnabled(env: Record<string, string | undefined> = process.env): boolean {
 	return parseEnvBoolean(env[CURSOR_SDK_EVENT_DEBUG_ENV], false);
 }
@@ -195,6 +207,7 @@ export class CursorSdkEventDebugSink {
 				"Raw artifact files may contain local paths, project text, tool args/results, or secrets from the workspace. Do not commit or share them.",
 			],
 		};
+		this.clearKnownArtifactFiles();
 		writeFileSync(join(this.artifactDir, ARTIFACTS.metadata), `${JSON.stringify(this.metadata, null, 2)}\n`);
 	}
 
@@ -376,7 +389,17 @@ export class CursorSdkEventDebugSink {
 
 	private updateSessionManifest(summary: Record<string, unknown>): void {
 		if (this.pinnedRun || !this.sessionDir || this.turn === undefined) return;
-		updateCursorSdkEventDebugSessionManifest(this.sessionDir, this.turn, summary);
+		updateCursorSdkEventDebugSessionManifest(this.sessionDir, this.artifactDir, summary);
+	}
+
+	private clearKnownArtifactFiles(): void {
+		for (const fileName of Object.values(ARTIFACTS)) {
+			try {
+				unlinkSync(join(this.artifactDir, fileName));
+			} catch {
+				// Ignore missing prior artifacts when reusing a pinned run directory.
+			}
+		}
 	}
 
 	async finalize(): Promise<void> {
@@ -493,14 +516,14 @@ export class CursorSdkEventDebugSink {
 	private bufferJsonl(fileName: string, record: unknown): void {
 		if (this.finalized) return;
 		const records = this.jsonlBuffers.get(fileName) ?? [];
-		records.push(record);
+		records.push(snapshotCursorSdkEventDebugRecord(record));
 		this.jsonlBuffers.set(fileName, records);
 	}
 
 	private flushJsonlBuffers(): void {
 		for (const [fileName, records] of this.jsonlBuffers) {
 			const lines = records.map((record) => `${JSON.stringify(record)}\n`).join("");
-			writeFileSync(join(this.artifactDir, fileName), lines, { flag: "a" });
+			writeFileSync(join(this.artifactDir, fileName), lines);
 		}
 		this.jsonlBuffers.clear();
 	}

--- a/src/cursor-session-agent.ts
+++ b/src/cursor-session-agent.ts
@@ -16,6 +16,7 @@ import {
 } from "./cursor-pi-tool-bridge.js";
 import { computeCursorContextFingerprint } from "./context.js";
 import { getCursorSessionScopeKey, onCursorSessionScopeKeyChange } from "./cursor-session-scope.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
 
 export interface SessionCursorAgentSendState {
 	bootstrapped: boolean;
@@ -75,6 +76,7 @@ interface SessionCursorAgentCreateParams {
 	modelSelection: ModelSelection;
 	settingSources?: SettingSource[];
 	onBridgeToolRequest?: (request: CursorPiBridgeToolRequest) => void;
+	debugRecorder?: CursorSdkEventDebugRecorder;
 	createAgent?: typeof Agent.create;
 }
 
@@ -174,6 +176,7 @@ function leaseFromEntry(
 	created: boolean,
 ): SessionCursorAgentLease {
 	bindBridgeToolRequest(entry, params.onBridgeToolRequest);
+	entry.bridgeRun?.setDebugRecorder(params.debugRecorder);
 	return {
 		scopeKey,
 		agent: entry.agent!,
@@ -193,6 +196,7 @@ async function createSessionAgentEntry(
 	if (registeredBridge) {
 		bridgeRun = await registeredBridge.createRun({
 			onToolRequest: params.onBridgeToolRequest,
+			debugRecorder: params.debugRecorder,
 		});
 		if (!bridgeRun.enabled || !bridgeRun.mcpServers) {
 			await bridgeRun.dispose();

--- a/test/cursor-provider-stream-trace.test.ts
+++ b/test/cursor-provider-stream-trace.test.ts
@@ -32,6 +32,7 @@ import {
 import { streamCursor, __testUtils as cursorProviderTestUtils } from "../src/cursor-provider.js";
 import { __testUtils as contextWindowCacheTestUtils } from "../src/context-window-cache.js";
 import { __testUtils as modelDiscoveryTestUtils } from "../src/model-discovery.js";
+import { __testUtils as sdkEventDebugTestUtils } from "../src/cursor-sdk-event-debug.js";
 import type { Context } from "@earendil-works/pi-ai";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -97,6 +98,242 @@ it("detects trailing user messages only after tool results", () => {
 
 		const done = getDoneEvent(events);
 		expect(done).toBeDefined();
+	});
+
+	it("captures provider debug artifacts through streamCursor when enabled", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-provider-debug-"));
+		const previousDebug = process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+		const previousRunDir = process.env.PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR;
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG = "1";
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR = artifactDir;
+
+		try {
+			const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+				opts.onDelta({ update: { type: "text-delta", text: "debugged" } });
+				return {
+					id: "run-debug",
+					agentId: "agent-debug",
+					status: "finished",
+					wait: vi.fn().mockResolvedValue({ id: "run-debug", status: "finished" }),
+					cancel: vi.fn(),
+					supports: () => false,
+					unsupportedReason: () => "conversation unsupported",
+					stream: async function* () {
+						yield { type: "assistant", message: { content: [{ type: "text", text: "debugged" }] } };
+					},
+				};
+			});
+			mockedCreate.mockResolvedValue({
+				send: mockSend,
+				[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+			});
+
+			await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+
+			expect(readFileSync(join(artifactDir, "on-delta.jsonl"), "utf8")).toContain('"text-delta"');
+			expect(readFileSync(join(artifactDir, "pi-stream-events.jsonl"), "utf8")).toContain('"text_delta"');
+			expect(readFileSync(join(artifactDir, "stream-events.jsonl"), "utf8")).toContain('"assistant"');
+			expect(JSON.parse(readFileSync(join(artifactDir, "summary.json"), "utf8"))).toMatchObject({
+				artifactDir,
+				waitResultRecorded: true,
+			});
+		} finally {
+			if (previousDebug === undefined) delete process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+			else process.env.PI_CURSOR_SDK_EVENT_DEBUG = previousDebug;
+			if (previousRunDir === undefined) delete process.env.PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR;
+			else process.env.PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR = previousRunDir;
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
+	it("records continuation drain artifacts on the next turn debug sink", async () => {
+		const previousNativeDisplay = process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY;
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		const registeredTools: RegisteredTool[] = [];
+		await registerNativeToolDisplayForTest(registeredTools);
+
+		const baseDir = mkdtempSync(join(tmpdir(), "pi-cursor-provider-debug-continuation-"));
+		const sessionFile = join(baseDir, "session.jsonl");
+		const eventsDir = join(baseDir, "events");
+		const previousDebug = process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+		const previousDebugDir = process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR;
+		const { __testUtils: scopeTestUtils } = await import("../src/cursor-session-scope.js");
+
+		sdkEventDebugTestUtils.resetSessionDebugState();
+		scopeTestUtils.set(baseDir, sessionFile);
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG = "1";
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR = eventsDir;
+
+		let resolveRun: (result: { id: string; status: "finished"; result: string }) => void = () => {};
+		const runWait = vi.fn(
+			() =>
+				new Promise<{ id: string; status: "finished"; result: string }>((resolve) => {
+					resolveRun = resolve;
+				}),
+		);
+		let firstOnDelta: CursorDeltaHandler | undefined;
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+			firstOnDelta = opts.onDelta;
+			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "bash", args: { command: "git status" } }, callId: "c1" } });
+			opts.onDelta({
+				update: {
+					type: "tool-call-completed",
+					toolCall: {
+						name: "bash",
+						result: { status: "success", value: { stdout: "clean", stderr: "", exitCode: 0 } },
+					},
+					callId: "c1",
+				},
+			});
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "running",
+				wait: runWait,
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		try {
+			const firstEvents = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+			expect(getDoneEvent(firstEvents).reason).toBe("toolUse");
+
+			firstOnDelta?.({ update: { type: "text-delta", text: "Late scoped text." } });
+			const secondEventsPromise = collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+			await Promise.resolve();
+			resolveRun({ id: "run-1", status: "finished", result: "Late scoped final." });
+			await secondEventsPromise;
+
+			const sessionSlug = sdkEventDebugTestUtils.slugSessionKey(sessionFile);
+			const manifest = JSON.parse(
+				readFileSync(join(eventsDir, "sessions", sessionSlug, sdkEventDebugTestUtils.SESSION_MANIFEST), "utf8"),
+			);
+			expect(manifest.turns).toHaveLength(2);
+
+			const parseDrainPhases = (artifactDir: string): string[] =>
+				readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.drainEvents), "utf8")
+					.trim()
+					.split("\n")
+					.filter(Boolean)
+					.map((line) => JSON.parse(line).phase as string);
+
+			expect(parseDrainPhases(manifest.turns[0].artifactDir)).toContain("turn_end");
+			expect(parseDrainPhases(manifest.turns[1].artifactDir)).toEqual(
+				expect.arrayContaining(["pre_send_start", "turn_start", "turn_end", "pre_send_end"]),
+			);
+		} finally {
+			sdkEventDebugTestUtils.resetSessionDebugState();
+			scopeTestUtils.reset();
+			if (previousDebug === undefined) delete process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+			else process.env.PI_CURSOR_SDK_EVENT_DEBUG = previousDebug;
+			if (previousDebugDir === undefined) delete process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR;
+			else process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR = previousDebugDir;
+			if (previousNativeDisplay === undefined) delete process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY;
+			else process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = previousNativeDisplay;
+			rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("records turn_end and pre_send_end when aborting during live-run progress wait", async () => {
+		const previousNativeDisplay = process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY;
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		const registeredTools: RegisteredTool[] = [];
+		await registerNativeToolDisplayForTest(registeredTools);
+
+		const baseDir = mkdtempSync(join(tmpdir(), "pi-cursor-provider-debug-abort-"));
+		const sessionFile = join(baseDir, "session.jsonl");
+		const eventsDir = join(baseDir, "events");
+		const previousDebug = process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+		const previousDebugDir = process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR;
+		const { __testUtils: scopeTestUtils } = await import("../src/cursor-session-scope.js");
+
+		sdkEventDebugTestUtils.resetSessionDebugState();
+		scopeTestUtils.set(baseDir, sessionFile);
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG = "1";
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR = eventsDir;
+
+		const controller = new AbortController();
+		let firstOnDelta: CursorDeltaHandler | undefined;
+		const runWait = vi.fn(() => new Promise<{ id: string; status: "finished"; result: string }>(() => {}));
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+			firstOnDelta = opts.onDelta;
+			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "bash", args: { command: "git status" } }, callId: "c1" } });
+			opts.onDelta({
+				update: {
+					type: "tool-call-completed",
+					toolCall: {
+						name: "bash",
+						result: { status: "success", value: { stdout: "clean", stderr: "", exitCode: 0 } },
+					},
+					callId: "c1",
+				},
+			});
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "running",
+				wait: runWait,
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const parseDrainEvents = (artifactDir: string): Array<{ phase: string; payload?: { outcome?: string; reason?: string } }> =>
+			readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.drainEvents), "utf8")
+				.trim()
+				.split("\n")
+				.filter(Boolean)
+				.map((line) => JSON.parse(line));
+
+		try {
+			const firstEvents = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+			expect(getDoneEvent(firstEvents).reason).toBe("toolUse");
+
+			firstOnDelta?.({ update: { type: "text-delta", text: "Late scoped text." } });
+			const secondEventsPromise = collectEvents(
+				streamCursor(makeModel(), makeContext(), { apiKey: "test-key", signal: controller.signal }),
+			);
+			await Promise.resolve();
+			controller.abort();
+			const secondEvents = await secondEventsPromise;
+			expect(getErrorEvent(secondEvents).reason).toBe("aborted");
+
+			const sessionSlug = sdkEventDebugTestUtils.slugSessionKey(sessionFile);
+			const manifest = JSON.parse(
+				readFileSync(join(eventsDir, "sessions", sessionSlug, sdkEventDebugTestUtils.SESSION_MANIFEST), "utf8"),
+			);
+			expect(manifest.turns).toHaveLength(2);
+
+			const drainEvents = parseDrainEvents(manifest.turns[1].artifactDir);
+			expect(drainEvents.map((event) => event.phase)).toEqual(
+				expect.arrayContaining(["pre_send_start", "turn_start", "turn_end", "pre_send_end"]),
+			);
+			expect(drainEvents.find((event) => event.phase === "turn_end")?.payload).toMatchObject({ outcome: "aborted", reason: "signal_aborted" });
+			expect(drainEvents.find((event) => event.phase === "pre_send_end")?.payload).toMatchObject({ outcome: "aborted", reason: "signal_aborted" });
+		} finally {
+			sdkEventDebugTestUtils.resetSessionDebugState();
+			scopeTestUtils.reset();
+			if (previousDebug === undefined) delete process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+			else process.env.PI_CURSOR_SDK_EVENT_DEBUG = previousDebug;
+			if (previousDebugDir === undefined) delete process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR;
+			else process.env.PI_CURSOR_SDK_EVENT_DEBUG_DIR = previousDebugDir;
+			if (previousNativeDisplay === undefined) delete process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY;
+			else process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = previousNativeDisplay;
+			rmSync(baseDir, { recursive: true, force: true });
+		}
 	});
 
 	it("emits createPlan args as final visible text when native replay is unavailable", async () => {

--- a/test/cursor-sdk-event-debug.test.ts
+++ b/test/cursor-sdk-event-debug.test.ts
@@ -108,6 +108,46 @@ describe("cursor sdk event debug sink", () => {
 		}
 	});
 
+	it("snapshots buffered pi stream and timeline records before later mutations", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-snapshot-"));
+
+		try {
+			const sink = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env: {
+					PI_CURSOR_SDK_EVENT_DEBUG: "1",
+					PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+				},
+			});
+			const partial = { role: "assistant" as const, content: [{ type: "text" as const, text: "before" }] };
+			const event = { type: "text_delta", delta: "before", partial };
+
+			sink?.recordPiStreamEvent(event);
+			event.delta = "after";
+			partial.content[0] = { type: "text", text: "after" };
+			await sink?.finalize();
+
+			const [piStreamEvent] = readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.piStreamEvents), "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+			expect(piStreamEvent.event.delta).toBe("before");
+			expect(piStreamEvent.event.partial.content[0].text).toBe("before");
+
+			const timelineEvents = readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.timeline), "utf8")
+				.trim()
+				.split("\n")
+				.map((line) => JSON.parse(line));
+			const piStreamTimelineEvent = timelineEvents.find((event) => event.layer === "pi-stream-events");
+			expect(piStreamTimelineEvent.payload.delta).toBe("before");
+			expect(piStreamTimelineEvent.payload.partial.content[0].text).toBe("before");
+		} finally {
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
 	it("can opt in to stderr summary output", async () => {
 		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-"));
 		const stderrLines: string[] = [];
@@ -201,6 +241,136 @@ describe("cursor sdk event debug session grouping", () => {
 			expect(sink?.pinnedRun).toBe(true);
 			expect(sink?.sessionDir).toBeUndefined();
 			expect(sink?.turn).toBeUndefined();
+		} finally {
+			sdkEventDebugTestUtils.resetSessionDebugState();
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
+	it("continues turn numbering after process restart with an existing session manifest", async () => {
+		const baseDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-resume-"));
+		const sessionFile = join(baseDir, "my-session.jsonl");
+		const { __testUtils: scopeTestUtils } = await import("../src/cursor-session-scope.js");
+
+		sdkEventDebugTestUtils.resetSessionDebugState();
+		scopeTestUtils.set(baseDir, sessionFile);
+
+		try {
+			const env = {
+				PI_CURSOR_SDK_EVENT_DEBUG: "1",
+				PI_CURSOR_SDK_EVENT_DEBUG_DIR: join(baseDir, "events"),
+			};
+			const sink1 = CursorSdkEventDebugSink.maybeCreate({
+				cwd: baseDir,
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env,
+			});
+			sink1?.recordSendMeta({
+				mode: "bootstrap",
+				reason: "initial",
+				resetAgent: false,
+				bootstrap: true,
+				promptText: "turn-one",
+				imageCount: 0,
+				useNativeToolReplay: true,
+				bridgeEnabled: false,
+				nativeReplayId: "replay-1",
+				promptInputTokens: 12,
+			});
+			await sink1?.finalize();
+
+			sdkEventDebugTestUtils.resetSessionDebugState();
+
+			const sink2 = CursorSdkEventDebugSink.maybeCreate({
+				cwd: baseDir,
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env,
+			});
+			sink2?.recordSendMeta({
+				mode: "incremental",
+				reason: "follow-up",
+				resetAgent: false,
+				bootstrap: false,
+				promptText: "turn-two",
+				imageCount: 0,
+				useNativeToolReplay: true,
+				bridgeEnabled: false,
+				nativeReplayId: "replay-2",
+				promptInputTokens: 8,
+			});
+			await sink2?.finalize();
+
+			expect(sink1?.turn).toBe(1);
+			expect(sink2?.turn).toBe(2);
+			expect(sink1?.artifactDir).not.toBe(sink2?.artifactDir);
+
+			const manifest = JSON.parse(
+				readFileSync(join(sink1!.sessionDir!, sdkEventDebugTestUtils.SESSION_MANIFEST), "utf8"),
+			);
+			expect(manifest.turns).toHaveLength(2);
+			expect(manifest.turns[0]).toMatchObject({
+				turn: 1,
+				artifactDir: sink1?.artifactDir,
+				summary: { turn: 1, artifactDir: sink1?.artifactDir },
+			});
+			expect(manifest.turns[1]).toMatchObject({
+				turn: 2,
+				artifactDir: sink2?.artifactDir,
+				summary: { turn: 2, artifactDir: sink2?.artifactDir },
+			});
+			const turnOneMetadata = JSON.parse(
+				readFileSync(join(sink1!.artifactDir, sdkEventDebugTestUtils.ARTIFACTS.metadata), "utf8"),
+			);
+			const turnTwoMetadata = JSON.parse(
+				readFileSync(join(sink2!.artifactDir, sdkEventDebugTestUtils.ARTIFACTS.metadata), "utf8"),
+			);
+			expect(turnOneMetadata.send.promptText).toBe("turn-one");
+			expect(turnTwoMetadata.send.promptText).toBe("turn-two");
+		} finally {
+			sdkEventDebugTestUtils.resetSessionDebugState();
+			scopeTestUtils.reset();
+			rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("clears stale artifacts when reusing a pinned run directory", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-reuse-"));
+		sdkEventDebugTestUtils.resetSessionDebugState();
+
+		try {
+			const env = {
+				PI_CURSOR_SDK_EVENT_DEBUG: "1",
+				PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+			};
+			const sink1 = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env,
+			});
+			sink1?.recordPiStreamEvent({ type: "text_delta", delta: "first-run" });
+			await sink1?.finalize();
+			expect(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.piStreamEvents), "utf8")).toContain(
+				"first-run",
+			);
+
+			const sink2 = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env,
+			});
+			sink2?.recordPiStreamEvent({ type: "text_delta", delta: "second-run" });
+			await sink2?.finalize();
+
+			const piStreamEvents = readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.piStreamEvents), "utf8");
+			expect(piStreamEvents).toContain("second-run");
+			expect(piStreamEvents).not.toContain("first-run");
+			expect(JSON.parse(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.summary), "utf8"))).toMatchObject({
+				counts: { piStream: { text_delta: 1 } },
+			});
 		} finally {
 			sdkEventDebugTestUtils.resetSessionDebugState();
 			rmSync(artifactDir, { recursive: true, force: true });

--- a/test/cursor-sdk-event-debug.test.ts
+++ b/test/cursor-sdk-event-debug.test.ts
@@ -1,0 +1,224 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX,
+	CursorSdkEventDebugSink,
+	resolveCursorSdkEventDebugBaseDir,
+	resolveCursorSdkEventDebugEnabled,
+	__testUtils as sdkEventDebugTestUtils,
+} from "../src/cursor-sdk-event-debug.js";
+import { parseDebugProviderEventsArgs } from "../scripts/debug-provider-events.mjs";
+
+describe("cursor sdk event debug sink", () => {
+	it("is disabled by default", () => {
+		expect(resolveCursorSdkEventDebugEnabled({})).toBe(false);
+		expect(resolveCursorSdkEventDebugEnabled({ PI_CURSOR_SDK_EVENT_DEBUG: "1" })).toBe(true);
+	});
+
+	it("defaults artifact base dir to .debug/cursor-sdk-events", () => {
+		expect(resolveCursorSdkEventDebugBaseDir("/repo", {})).toBe("/repo/.debug/cursor-sdk-events");
+		expect(resolveCursorSdkEventDebugBaseDir("/repo", { PI_CURSOR_SDK_EVENT_DEBUG_DIR: "tmp/events" })).toBe(
+			"/repo/tmp/events",
+		);
+	});
+
+	it("records raw payloads to disk without stderr by default", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-"));
+		const stderrLines: string[] = [];
+		const originalWrite = process.stderr.write.bind(process.stderr);
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrLines.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			const sink = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env: {
+					PI_CURSOR_SDK_EVENT_DEBUG: "1",
+					PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+				},
+			});
+			expect(sink?.artifactDir).toBe(artifactDir);
+			sink?.recordSendMeta({
+				mode: "bootstrap",
+				reason: "initial",
+				resetAgent: false,
+				bootstrap: true,
+				promptText: "hello",
+				imageCount: 0,
+				useNativeToolReplay: true,
+				bridgeEnabled: false,
+				nativeReplayId: "replay-1",
+				promptInputTokens: 12,
+			});
+			sink?.recordSendPayload({ text: "hello" });
+			sink?.recordPiStreamEvent({ type: "text_delta", delta: "Hi" });
+			sink?.recordOnDelta({ type: "text-delta", text: "Hi" });
+			sink?.recordOnStep({ type: "toolCall", message: { type: "read" } });
+			sink?.recordRunMeta({ runId: "run-1", agentId: "agent-1", status: "running" });
+			sink?.recordBridgeDiagnostic({
+				event: "run_created",
+				runId: "run-1",
+				enabled: true,
+				exposedToolCount: 1,
+				pendingCount: 0,
+			});
+			sink?.recordDisplayDecision({
+				action: "queue_replay",
+				disposition: "queue_replay",
+				toolName: "grep",
+				replayToolId: "cursor-replay-1-tool-1",
+			});
+			sink?.recordCoordinatorEvent("task_progress", { label: "searching" });
+			sink?.recordDrainEvent("turn_end", { outcome: "tool_use" });
+			sink?.recordFinalPartial({ role: "assistant", stopReason: "toolUse" });
+			sink?.recordWaitResult({ status: "finished", result: "Hi" });
+			await sink?.finalize();
+
+			const metadata = JSON.parse(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.metadata), "utf8"));
+			expect(metadata.send.promptText).toBe("hello");
+			expect(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.onDelta), "utf8")).toContain('"text-delta"');
+			expect(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.onStep), "utf8")).toContain('"toolCall"');
+			expect(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.piStreamEvents), "utf8")).toContain(
+				'"text_delta"',
+			);
+			expect(JSON.parse(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.waitResult), "utf8"))).toMatchObject({
+				status: "finished",
+			});
+			expect(JSON.parse(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.summary), "utf8"))).toMatchObject({
+				artifactDir,
+				counts: {
+					bridge: { run_created: 1 },
+					displayDecisions: { queue_replay: 1 },
+					coordinator: { task_progress: 1 },
+					drain: { turn_end: 1 },
+				},
+			});
+			expect(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.timeline), "utf8")).toContain('"layer":"display-decisions"');
+			expect(readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.finalPartial), "utf8")).toContain('"toolUse"');
+			expect(stderrLines.some((line) => line.includes(CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX))).toBe(false);
+		} finally {
+			process.stderr.write = originalWrite;
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
+	it("can opt in to stderr summary output", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-"));
+		const stderrLines: string[] = [];
+		const originalWrite = process.stderr.write.bind(process.stderr);
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrLines.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			const sink = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env: {
+					PI_CURSOR_SDK_EVENT_DEBUG: "1",
+					PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+					PI_CURSOR_SDK_EVENT_DEBUG_STDERR: "1",
+				},
+			});
+			await sink?.finalize();
+			expect(stderrLines.some((line) => line.includes(CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX))).toBe(true);
+		} finally {
+			process.stderr.write = originalWrite;
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("cursor sdk event debug session grouping", () => {
+	it("groups multiple turns under one pi session directory", async () => {
+		const baseDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-session-"));
+		const sessionFile = join(baseDir, "my-session.jsonl");
+		const { __testUtils: scopeTestUtils } = await import("../src/cursor-session-scope.js");
+
+		sdkEventDebugTestUtils.resetSessionDebugState();
+		scopeTestUtils.set(baseDir, sessionFile);
+
+		try {
+			const env = {
+				PI_CURSOR_SDK_EVENT_DEBUG: "1",
+				PI_CURSOR_SDK_EVENT_DEBUG_DIR: join(baseDir, "events"),
+			};
+			const sink1 = CursorSdkEventDebugSink.maybeCreate({
+				cwd: baseDir,
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env,
+			});
+			await sink1?.finalize();
+			const sink2 = CursorSdkEventDebugSink.maybeCreate({
+				cwd: baseDir,
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env,
+			});
+			await sink2?.finalize();
+
+			expect(sink1?.turn).toBe(1);
+			expect(sink2?.turn).toBe(2);
+			expect(sink1?.sessionDir).toBe(sink2?.sessionDir);
+			expect(sink1?.artifactDir).not.toBe(sink2?.artifactDir);
+
+			const manifest = JSON.parse(
+				readFileSync(join(sink1!.sessionDir!, sdkEventDebugTestUtils.SESSION_MANIFEST), "utf8"),
+			);
+			expect(manifest.turns).toHaveLength(2);
+			expect(manifest.sessionFile).toBe(sessionFile);
+			expect(manifest.turns[0].summary?.turn).toBe(1);
+			expect(manifest.turns[1].summary?.turn).toBe(2);
+		} finally {
+			sdkEventDebugTestUtils.resetSessionDebugState();
+			scopeTestUtils.reset();
+			rmSync(baseDir, { recursive: true, force: true });
+		}
+	});
+
+	it("keeps pinned run dirs isolated from session grouping", () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-event-debug-pinned-"));
+		sdkEventDebugTestUtils.resetSessionDebugState();
+		try {
+			const sink = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env: {
+					PI_CURSOR_SDK_EVENT_DEBUG: "1",
+					PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+				},
+			});
+			expect(sink?.pinnedRun).toBe(true);
+			expect(sink?.sessionDir).toBeUndefined();
+			expect(sink?.turn).toBeUndefined();
+		} finally {
+			sdkEventDebugTestUtils.resetSessionDebugState();
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("debug-provider-events maintainer probe", () => {
+	it("parses args and prompt file overrides", () => {
+		expect(
+			parseDebugProviderEventsArgs(["--cwd", "/tmp/work", "--model", "cursor/composer-2.5", "--prompt", "hello"], {
+				CURSOR_API_KEY: "key",
+			}),
+		).toMatchObject({
+			cwd: "/tmp/work",
+			model: "cursor/composer-2.5",
+			prompt: "hello",
+			apiKey: "key",
+		});
+	});
+});

--- a/test/smoke-tooling.test.ts
+++ b/test/smoke-tooling.test.ts
@@ -12,12 +12,14 @@ describe("smoke tooling package checks", () => {
 		expect(run(process.execPath, ["--check", "scripts/steering-rpc-smoke.mjs"]).status).toBe(0);
 		expect(run(process.execPath, ["--check", "scripts/validate-smoke-jsonl.mjs"]).status).toBe(0);
 		expect(run(process.execPath, ["--check", "scripts/debug-sdk-events.mjs"]).status).toBe(0);
+		expect(run(process.execPath, ["--check", "scripts/debug-provider-events.mjs"]).status).toBe(0);
 
 		const liveHelp = run("scripts/tmux-live-smoke.sh", ["--help"]);
 		const isolatedHelp = run("scripts/isolated-cursor-smoke.sh", ["--help"]);
 		const steeringHelp = run(process.execPath, ["scripts/steering-rpc-smoke.mjs", "--help"]);
 		const jsonlHelp = run(process.execPath, ["scripts/validate-smoke-jsonl.mjs", "--help"]);
 		const sdkEventsHelp = run(process.execPath, ["scripts/debug-sdk-events.mjs", "--help"]);
+		const providerEventsHelp = run(process.execPath, ["scripts/debug-provider-events.mjs", "--help"]);
 
 		expect(liveHelp.status).toBe(0);
 		expect(liveHelp.stdout).toContain("retry-empty-output");
@@ -30,6 +32,8 @@ describe("smoke tooling package checks", () => {
 		expect(jsonlHelp.stdout).toContain("--replay-errors");
 		expect(sdkEventsHelp.status).toBe(0);
 		expect(sdkEventsHelp.stdout).toContain("Capture timestamped Cursor SDK event timelines");
+		expect(providerEventsHelp.status).toBe(0);
+		expect(providerEventsHelp.stdout).toContain("Capture raw Cursor SDK onDelta/onStep payloads through pi's provider path");
 	});
 
 	it("packages smoke scripts and avoids reusing the v0.1.16 tarball version", () => {
@@ -46,6 +50,7 @@ describe("smoke tooling package checks", () => {
 		expect(paths.has("scripts/steering-rpc-smoke.mjs")).toBe(true);
 		expect(paths.has("scripts/validate-smoke-jsonl.mjs")).toBe(true);
 		expect(paths.has("scripts/debug-sdk-events.mjs")).toBe(true);
+		expect(paths.has("scripts/debug-provider-events.mjs")).toBe(true);
 		expect(paths.has("CHANGELOG.md")).toBe(true);
 		expect(paths.has("README.md")).toBe(true);
 		expect([...paths].some((path) => path.startsWith("dist/") || path.startsWith("coverage/") || path.startsWith(".pi/") || path.includes("smoke-dir"))).toBe(false);


### PR DESCRIPTION
## Summary
- Add opt-in `PI_CURSOR_SDK_EVENT_DEBUG=1` capture through pi's Cursor provider, writing gitignored artifacts under `.debug/cursor-sdk-events/` without stderr noise by default.
- Record the full investigation stack: SDK callbacks, provider lifecycle, live-run queue/drain, bridge diagnostics/raw calls, display routing decisions, pi stream events, merged timeline, final partial, and pi session JSONL snapshots grouped by multi-turn session.
- Add `npm run debug:provider-events` maintainer script plus docs/tests for one-shot repros outside the interactive TUI.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm pack --dry-run`
- [x] Live smoke with `PI_CURSOR_SDK_EVENT_DEBUG=1 npm run smoke:live` from detached PR worktree with isolated `HOME`; artifact layout verified under `.debug/cursor-sdk-events` (`/tmp/pi-cursor-sdk-live-smoke-pr56-debug-20260525T101912`)


Made with [Cursor](https://cursor.com)
