### PR TITLE
fix: label collapsed read replay when only local preview is available

### DIFF
--- a/src/cursor-native-tool-display-replay.ts
+++ b/src/cursor-native-tool-display-replay.ts
@@ -4,6 +4,7 @@ import { getLanguageFromPath, highlightCode, type ToolDefinition } from "@earend
 import { Image, Text, type Component } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { resolveCursorEditDiff } from "./cursor-edit-diff.js";
+import { LOCAL_READ_PREVIEW_NOTICE, isLocalReadPreviewContent } from "./cursor-transcript-utils.js";
 import {
 	CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
 	getCursorReplayDisplayLabel,
@@ -443,6 +444,27 @@ export function renderCursorReplayResult(
 	if (details?.cursorToolName === "generateImage") return renderCursorGenerateImageResult(result, options, theme, context, isError);
 	if (details?.title) return renderExpandableCursorReplayResult(details.title, result, options, theme, context, isError);
 	return new Text(text || theme.fg("success", "Cursor tool result replayed"), 0, 0);
+}
+
+export function renderNativeLookingCursorReadReplayResult(
+	result: Parameters<CursorReplayRenderResult>[0],
+	options: Parameters<CursorReplayRenderResult>[1],
+	theme: Parameters<CursorReplayRenderResult>[2],
+	context: Parameters<CursorReplayRenderResult>[3],
+	renderBase: () => Component | undefined,
+): Component {
+	const base = renderBase?.() ?? new Text("", 0, 0);
+	if (!(base instanceof Text)) return base;
+	const readArgs = context.args as Record<string, unknown> | undefined;
+	const replayDetails = result.details as Record<string, unknown> | undefined;
+	const usesLocalPreview =
+		readArgs?.localReadPreview === true ||
+		replayDetails?.localReadPreview === true ||
+		isLocalReadPreviewContent(firstContentText(result));
+	if (usesLocalPreview && !options.expanded && !context.isError) {
+		base.setText(`\n${theme.fg("warning", LOCAL_READ_PREVIEW_NOTICE)}`);
+	}
+	return base;
 }
 
 export function createCursorReplayOnlyToolDefinition(toolName: CursorReplayToolName): ToolDefinition<typeof cursorReplayToolSchema, unknown> {

--- a/src/cursor-native-tool-display-replay.ts
+++ b/src/cursor-native-tool-display-replay.ts
@@ -454,7 +454,6 @@ export function renderNativeLookingCursorReadReplayResult(
 	renderBase: () => Component | undefined,
 ): Component {
 	const base = renderBase?.() ?? new Text("", 0, 0);
-	if (!(base instanceof Text)) return base;
 	const readArgs = context.args as Record<string, unknown> | undefined;
 	const replayDetails = result.details as Record<string, unknown> | undefined;
 	const usesLocalPreview =
@@ -462,7 +461,12 @@ export function renderNativeLookingCursorReadReplayResult(
 		replayDetails?.localReadPreview === true ||
 		isLocalReadPreviewContent(firstContentText(result));
 	if (usesLocalPreview && !options.expanded && !context.isError) {
-		base.setText(`\n${theme.fg("warning", LOCAL_READ_PREVIEW_NOTICE)}`);
+		const noticeText = `\n${theme.fg("warning", LOCAL_READ_PREVIEW_NOTICE)}`;
+		if (base instanceof Text) {
+			base.setText(noticeText);
+			return base;
+		}
+		return new Text(noticeText, 0, 0);
 	}
 	return base;
 }

--- a/src/cursor-native-tool-display-tools.ts
+++ b/src/cursor-native-tool-display-tools.ts
@@ -21,6 +21,7 @@ import {
 	createCursorReplayOnlyToolDefinition,
 	renderCursorReplayResult,
 	renderNativeLookingCursorFileMutationCall,
+	renderNativeLookingCursorReadReplayResult,
 } from "./cursor-native-tool-display-replay.js";
 import {
 	consumeCursorNativeToolDisplay,
@@ -65,6 +66,16 @@ export function wrapNativeCursorTool<TParams extends TSchema, TDetails, TState>(
 			return getCurrentDefinition().execute(toolCallId, params, signal, onUpdate, ctx);
 		},
 		renderCall(args, theme, context) {
+			if (definition.name === "read" && isCursorReplayToolCallId(context.toolCallId)) {
+				const currentRenderCall = getCurrentDefinition().renderCall;
+				const rendered = currentRenderCall ? currentRenderCall(args, theme, context) : new Text("", 0, 0);
+				const text = rendered instanceof Text ? rendered : new Text("", 0, 0);
+				if ((args as Record<string, unknown>).localReadPreview === true && !context.expanded) {
+					const current = text.render(120).join("\n");
+					text.setText(`${current}${theme.fg("muted", " · local file preview")}`);
+				}
+				return text;
+			}
 			if (isCursorFileMutationToolName(definition.name) && isCursorReplayToolCallId(context.toolCallId)) {
 				return renderNativeLookingCursorFileMutationCall(definition.name, args as Record<string, unknown>, theme, context.isPartial);
 			}
@@ -75,6 +86,11 @@ export function wrapNativeCursorTool<TParams extends TSchema, TDetails, TState>(
 			const details = asCursorReplayToolDetails(result.details);
 			if (isCursorFileMutationToolName(definition.name) && details?.cursorToolName === definition.name) {
 				return renderCursorReplayResult(result, options, theme, context, context.isError);
+			}
+			if (definition.name === "read" && isCursorReplayToolCallId(context.toolCallId)) {
+				return renderNativeLookingCursorReadReplayResult(result, options, theme, context, () =>
+					getCurrentDefinition().renderResult?.(result, options, theme, context),
+				);
 			}
 			const currentRenderResult = getCurrentDefinition().renderResult;
 			return currentRenderResult ? currentRenderResult(result, options, theme, context) : new Text("", 0, 0);

--- a/src/cursor-native-tool-display-tools.ts
+++ b/src/cursor-native-tool-display-tools.ts
@@ -69,12 +69,16 @@ export function wrapNativeCursorTool<TParams extends TSchema, TDetails, TState>(
 			if (definition.name === "read" && isCursorReplayToolCallId(context.toolCallId)) {
 				const currentRenderCall = getCurrentDefinition().renderCall;
 				const rendered = currentRenderCall ? currentRenderCall(args, theme, context) : new Text("", 0, 0);
-				const text = rendered instanceof Text ? rendered : new Text("", 0, 0);
 				if ((args as Record<string, unknown>).localReadPreview === true && !context.expanded) {
-					const current = text.render(120).join("\n");
-					text.setText(`${current}${theme.fg("muted", " · local file preview")}`);
+					const baseText = rendered.render(120).join("\n").trimEnd();
+					const labeled = `${baseText}${theme.fg("muted", " · local file preview")}`;
+					if (rendered instanceof Text) {
+						rendered.setText(labeled);
+						return rendered;
+					}
+					return new Text(labeled, 0, 0);
 				}
-				return text;
+				return rendered;
 			}
 			if (isCursorFileMutationToolName(definition.name) && isCursorReplayToolCallId(context.toolCallId)) {
 				return renderNativeLookingCursorFileMutationCall(definition.name, args as Record<string, unknown>, theme, context.isPartial);

--- a/src/cursor-transcript-tool-formatters.ts
+++ b/src/cursor-transcript-tool-formatters.ts
@@ -27,6 +27,21 @@ import {
 	type TranscriptOptions,
 } from "./cursor-transcript-utils.js";
 
+export function usesLocalReadPreview(args: Record<string, unknown>, result: NormalizedResult, options: TranscriptOptions): boolean {
+	if (result.status === "error") return false;
+	const value = asRecord(result.value);
+	const resultContent = getString(value, "content");
+	if (resultContent && resultContent.length > 0) return false;
+	const rawPath = typeof args.path === "string" ? args.path : undefined;
+	if (!rawPath) return false;
+	const readOptions = {
+		...options,
+		maxChars: options.maxChars ?? DEFAULT_READ_TRANSCRIPT_CHARS,
+		maxLines: options.maxLines ?? DEFAULT_READ_TRANSCRIPT_LINES,
+	};
+	return readFilePreview(rawPath, readOptions) !== undefined;
+}
+
 function getReadContent(args: Record<string, unknown>, result: NormalizedResult, options: TranscriptOptions): string {
 	const rawPath = typeof args.path === "string" ? args.path : undefined;
 	const readOptions = {
@@ -57,9 +72,17 @@ export function formatRead(args: Record<string, unknown>, result: NormalizedResu
 	return joinSections(`read ${path}`, limitText(getReadContent(args, result, options), readOptions, totalLines));
 }
 
-export function buildReadDisplayArgs(args: Record<string, unknown>, options: TranscriptOptions): Record<string, unknown> {
+export function buildReadDisplayArgs(
+	args: Record<string, unknown>,
+	options: TranscriptOptions,
+	result?: NormalizedResult,
+): Record<string, unknown> {
 	const rawPath = typeof args.path === "string" ? args.path : undefined;
-	return rawPath ? { ...args, path: formatDisplayPath(rawPath, options.cwd) } : args;
+	const displayArgs = rawPath ? { ...args, path: formatDisplayPath(rawPath, options.cwd) } : args;
+	if (result && usesLocalReadPreview(args, result, options)) {
+		return { ...displayArgs, localReadPreview: true };
+	}
+	return displayArgs;
 }
 
 function buildPathDisplayArgs(args: Record<string, unknown>, options: TranscriptOptions): Record<string, unknown> {

--- a/src/cursor-transcript-tool-specs.ts
+++ b/src/cursor-transcript-tool-specs.ts
@@ -61,6 +61,7 @@ import {
 	summarizeSemSearch,
 	summarizeTask,
 	summarizeTodos,
+	usesLocalReadPreview,
 } from "./cursor-transcript-tool-formatters.js";
 
 export interface ToolDisplayContext {
@@ -242,10 +243,14 @@ const TOOL_DISPLAY_SPECS: Record<string, ToolDisplaySpec> = {
 		formatTranscript: ({ args, result, options }) => formatRead(args, result, options),
 		buildPiToolDisplay: ({ args, result, options }) => {
 			const isError = result.status === "error";
+			const usesLocalPreview = !isError && usesLocalReadPreview(args, result, options);
 			return {
 				toolName: "read",
-				args: buildReadDisplayArgs(args, options),
-				result: textToolResult(isError ? formatError(result.error) : formatNativeReadDisplayContent(args, result, options)),
+				args: buildReadDisplayArgs(args, options, result),
+				result: textToolResult(
+					isError ? formatError(result.error) : formatNativeReadDisplayContent(args, result, options),
+					usesLocalPreview ? { localReadPreview: true } : undefined,
+				),
 				isError,
 			};
 		},

--- a/src/cursor-transcript-utils.ts
+++ b/src/cursor-transcript-utils.ts
@@ -43,6 +43,10 @@ export const DEFAULT_NATIVE_READ_DISPLAY_LINES = 20;
 export const LOCAL_READ_PREVIEW_NOTICE =
 	"[local file preview at transcript time; Cursor read result content was unavailable]";
 
+export function isLocalReadPreviewContent(text: string): boolean {
+	return text.startsWith(LOCAL_READ_PREVIEW_NOTICE);
+}
+
 export function getString(record: Record<string, unknown> | undefined, key: string): string | undefined {
 	const value = record?.[key];
 	return typeof value === "string" ? value : undefined;

--- a/test/cursor-native-tool-display-replay.test.ts
+++ b/test/cursor-native-tool-display-replay.test.ts
@@ -4,8 +4,11 @@ import {
 	CURSOR_REPLAY_PREVIEW_MAX_LINE_CHARS,
 	formatCursorReplayDiff,
 	formatCursorReplayFilePreview,
+	renderNativeLookingCursorReadReplayResult,
 	type CursorReplayRenderTheme,
 } from "../src/cursor-native-tool-display-replay.js";
+import { LOCAL_READ_PREVIEW_NOTICE } from "../src/cursor-transcript-utils.js";
+import { Text } from "@earendil-works/pi-tui";
 
 const theme = {
 	fg: (_name: string, value: string) => value,
@@ -38,5 +41,24 @@ describe("cursor native replay rendering", () => {
 
 		expect(rendered).toContain("more diff lines hidden");
 		expect(rendered).not.toContain("full diff");
+	});
+
+	it("shows local read preview disclaimer in collapsed native read replay results", () => {
+		const result = {
+			content: [{ type: "text" as const, text: `${LOCAL_READ_PREVIEW_NOTICE}\n# Local preview\n` }],
+			details: { localReadPreview: true },
+		};
+		const rendered = renderNativeLookingCursorReadReplayResult(
+			result,
+			{ expanded: false, isPartial: false },
+			theme,
+			{ isError: false, args: { path: "README.md", localReadPreview: true } },
+			() => new Text("", 0, 0),
+		)
+			.render(120)
+			.join("\n");
+
+		expect(rendered).toContain(LOCAL_READ_PREVIEW_NOTICE);
+		expect(rendered).not.toContain("# Local preview");
 	});
 });

--- a/test/cursor-tool-transcript.test.ts
+++ b/test/cursor-tool-transcript.test.ts
@@ -809,6 +809,8 @@ describe("formatCursorToolTranscript", () => {
 				{ cwd: dir },
 			);
 
+			expect(display.args).toMatchObject({ localReadPreview: true });
+			expect(display.result.details).toMatchObject({ localReadPreview: true });
 			expect(display.result.content[0].text).toContain(
 				"[local file preview at transcript time; Cursor read result content was unavailable]",
 			);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -603,6 +603,62 @@ describe("extension factory", () => {
 		});
 	});
 
+	it("labels collapsed native read replay cards when only local preview content is available", async () => {
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		mockedDiscover.mockResolvedValueOnce([]);
+		const dir = mkdtempSync(join(tmpdir(), "pi-cursor-read-preview-replay-"));
+		try {
+			writeFileSync(join(dir, "README.md"), "# Local preview body\n");
+			const pi = createMockPi();
+			await extensionFactory(pi);
+			await runSessionStartHandlers(pi, { cwd: dir });
+
+			const notice = "[local file preview at transcript time; Cursor read result content was unavailable]";
+			recordCursorNativeToolDisplay({
+				id: "cursor-replay-1-1-tool-1",
+				toolName: "read",
+				args: { path: "README.md", localReadPreview: true },
+				result: {
+					content: [{ type: "text", text: `${notice}\n# Local preview body\n` }],
+					details: { localReadPreview: true },
+				},
+				isError: false,
+			});
+
+			const readTool = pi._tools.find((tool) => tool.name === "read");
+			const theme = {
+				fg: (style: string, text: string) => (style === "warning" || style === "muted" ? `<${style}>${text}</${style}>` : text),
+				bold: (text: string) => text,
+			} as never;
+			const replayContext = {
+				isError: false,
+				toolCallId: "cursor-replay-1-1-tool-1",
+				args: { path: "README.md", localReadPreview: true },
+				expanded: false,
+			} as never;
+			const options = { expanded: false, isPartial: false } as never;
+
+			const callRendered = readTool.renderCall?.({ path: "README.md", localReadPreview: true }, theme, replayContext)?.render(120).join("\n") ?? "";
+			const resultRendered =
+				readTool.renderResult?.(
+					{
+						content: [{ type: "text", text: `${notice}\n# Local preview body\n` }],
+						details: { localReadPreview: true },
+					},
+					options,
+					theme,
+					replayContext,
+				)?.render(120).join("\n") ?? "";
+
+			expect(callRendered).toContain("read README.md");
+			expect(callRendered).toContain("local file preview");
+			expect(resultRendered).toContain(notice);
+			expect(resultRendered).not.toContain("# Local preview body");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
 	it("renders Cursor generateImage replay results with a visible path and image fallback", async () => {
 		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
 		mockedDiscover.mockResolvedValueOnce([]);


### PR DESCRIPTION
## Summary
- Detect when Cursor read replay uses a local transcript-time file preview instead of Cursor-reported content
- Mark read replay display args/details with `localReadPreview` and show the existing disclaimer in collapsed native read cards (call suffix + result notice)
- Expanded replay continues to prefix content with `LOCAL_READ_PREVIEW_NOTICE`; safety/path rules unchanged

Fixes #51

## Test plan
- [x] `npm test` (390 tests)
- [x] `npm run typecheck`
- [x] Unit test: empty Cursor read + local preview path → collapsed/expanded output includes preview disclaimer
- [ ] Live smoke not run (display-only replay labeling change; no provider/runtime behavior change)


Made with [Cursor](https://cursor.com)