### PR TITLE
Harden replay fallbacks and debug discarded SDK tool calls (#52)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-session-send-policy.ts` owns session send planning (`bootstrap` vs `incremental`), periodic agent rebootstrap threshold, and prompt mode selection.
 - `src/cursor-provider-live-run-drain.ts` owns live-run drain/replay mirroring, pre-send continuation, and native replay turn emission.
 - `src/cursor-provider-turn-coordinator.ts` owns SDK delta/step handling, tool completion routing, and trace/native-replay emission during a turn.
-- `src/cursor-sdk-event-debug.ts` owns opt-in provider event artifact capture for Cursor SDK callbacks, stream events, replay/drain/bridge decisions, final partials, and summaries under `.debug/cursor-sdk-events/`.
+- `src/cursor-sdk-event-debug.ts` owns opt-in provider event artifact capture for Cursor SDK callbacks, stream events, replay/drain/bridge decisions, final partials, and summaries under `.debug/cursor-sdk-events/`, including discarded incomplete started tool calls when `PI_CURSOR_SDK_EVENT_DEBUG=1`.
 - `src/cursor-sdk-event-debug-constants.ts` owns debug artifact/env names and default artifact base-dir resolution.
 - `src/cursor-sdk-event-debug-session.ts` owns debug session grouping, turn artifact directory allocation, and session manifest updates.
 - `src/cursor-agents-context.ts` owns Cursor-model suppression of pi `<project_context>` / `AGENTS.md` duplication and `PI_CURSOR_PRESERVE_PI_AGENTS_MD`.

--- a/docs/cursor-testing-lessons.md
+++ b/docs/cursor-testing-lessons.md
@@ -274,7 +274,7 @@ Artifacts under `--out` (default `.debug/cursor-sdk-events/<timestamp>/` under `
 - `bridge-events.jsonl` — bridge lifecycle/request diagnostics (file-only; no stderr unless bridge debug is also enabled)
 - `bridge-raw.jsonl` — raw bridged MCP args/results
 - `display-decisions.jsonl` — per-tool native replay routing (`queue_replay`, `emit_trace`, `inactive_trace`, dedupe skips, bridge ignores) with transcript/trace text
-- `coordinator-events.jsonl` — turn-coordinator side effects (task progress labels, etc.)
+- `coordinator-events.jsonl` — turn-coordinator side effects (task progress labels, discarded incomplete started tool calls, etc.)
 - `drain-events.jsonl` — live-run pre-send drain and per-turn drain lifecycle (`turn_start`, `turn_end`, inactive replay traces, native display registration)
 - `timeline.jsonl` — merged cross-layer timeline (one grep-friendly stream for the whole turn)
 - `pi-session-snapshot.jsonl` — copy of pi session JSONL at turn finalize (session dir also gets latest `pi-session.jsonl`)
@@ -310,6 +310,18 @@ Optional env:
 - `PI_CURSOR_SDK_EVENT_DEBUG_STDERR=1` — also print the summary line to stderr (off by default so the pi TUI stays normal)
 
 Capture is file-only by default: no stderr markers, and bridge diagnostics during SDK event debug go to `bridge-events.jsonl` instead of `[pi-cursor-sdk:bridge]` unless you separately set `PI_CURSOR_PI_TOOL_BRIDGE_DEBUG=1`. Raw payloads stay on disk and may contain secrets — do not commit or share them.
+
+### Discarded incomplete SDK tool calls
+
+When Cursor emits `tool-call-started` without a matching completion/step result, the provider discards the leftover started call at run end without synthetic replay errors. Default UX stays unchanged.
+
+With `PI_CURSOR_SDK_EVENT_DEBUG=1`, each discarded started call is recorded in `coordinator-events.jsonl` under phase `discarded-incomplete-started-tool-call` with:
+
+- normalized SDK tool name
+- scrubbed call-id hash (raw call IDs are not written)
+- reason `no-completion-at-run-end`
+
+Stderr output for these records requires `PI_CURSOR_SDK_EVENT_DEBUG_STDERR=1`. This complements the standalone `npm run debug:sdk-events` probe by interpreting a specific provider discard path during normal pi runs.
 
 ## Related docs and scripts
 

--- a/src/cursor-provider-turn-coordinator.ts
+++ b/src/cursor-provider-turn-coordinator.ts
@@ -9,8 +9,11 @@ import { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js
 import { asRecord, getField, hasUsableText } from "./cursor-record-utils.js";
 import { scrubPiToolDisplay, scrubSensitiveText } from "./cursor-sensitive-text.js";
 import { buildCursorPiToolDisplay, formatCursorToolTranscript, getCursorCreatePlanText, mergeCursorToolCalls } from "./cursor-tool-transcript.js";
-import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
-import { getString, getToolArgs, getToolName } from "./cursor-transcript-utils.js";
+import {
+	recordDiscardedIncompleteStartedToolCall,
+	type CursorSdkEventDebugRecorder,
+} from "./cursor-sdk-event-debug.js";
+import { getString, getToolArgs, getToolName, normalizeToolName } from "./cursor-transcript-utils.js";
 
 function formatCursorToolName(toolCall: unknown): string {
 	return truncateCursorDisplayLine(getToolName(toolCall), 80) || "unknown";
@@ -156,6 +159,13 @@ export class CursorSdkTurnCoordinator {
 	}
 
 	discardIncompleteStartedToolCalls(): void {
+		for (const [callId, toolCall] of this.startedToolCalls) {
+			if (typeof callId !== "string") continue;
+			recordDiscardedIncompleteStartedToolCall(this.debugRecorder, process.env, {
+				toolName: normalizeToolName(getToolName(toolCall)),
+				callId,
+			});
+		}
 		this.startedToolCalls.clear();
 		this.bridgeStartedToolCallIds.clear();
 		this.activeShellCallIds.clear();

--- a/src/cursor-sdk-event-debug.ts
+++ b/src/cursor-sdk-event-debug.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { copyFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { AssistantMessageEventStream } from "@earendil-works/pi-ai";
@@ -129,6 +130,49 @@ export interface CursorSdkEventDebugRecorder {
 	recordDrainEvent(phase: string, payload: unknown): void;
 	recordFinalPartial(partial: unknown): void;
 	finalize(): Promise<void>;
+}
+
+export const DISCARDED_INCOMPLETE_TOOL_CALL_REASON = "no-completion-at-run-end";
+
+export function hashCursorSdkCallId(callId: string): string {
+	return createHash("sha256").update(callId).digest("hex").slice(0, 8);
+}
+
+export interface DiscardedIncompleteStartedToolCallRecord {
+	event: "discarded-incomplete-started-tool-call";
+	toolName: string;
+	callIdHash: string;
+	reason: typeof DISCARDED_INCOMPLETE_TOOL_CALL_REASON;
+}
+
+export function serializeDiscardedIncompleteStartedToolCall(record: {
+	toolName: string;
+	callId: string;
+	reason?: typeof DISCARDED_INCOMPLETE_TOOL_CALL_REASON;
+}): DiscardedIncompleteStartedToolCallRecord {
+	return {
+		event: "discarded-incomplete-started-tool-call",
+		toolName: record.toolName,
+		callIdHash: hashCursorSdkCallId(record.callId),
+		reason: record.reason ?? DISCARDED_INCOMPLETE_TOOL_CALL_REASON,
+	};
+}
+
+export function recordDiscardedIncompleteStartedToolCall(
+	recorder: CursorSdkEventDebugRecorder | undefined,
+	env: Record<string, string | undefined>,
+	record: { toolName: string; callId: string; reason?: typeof DISCARDED_INCOMPLETE_TOOL_CALL_REASON },
+): void {
+	if (!recorder && !resolveCursorSdkEventDebugEnabled(env)) return;
+	try {
+		const payload = serializeDiscardedIncompleteStartedToolCall(record);
+		recorder?.recordCoordinatorEvent("discarded-incomplete-started-tool-call", payload);
+		if (resolveCursorSdkEventDebugStderrEnabled(env) && resolveCursorSdkEventDebugEnabled(env)) {
+			process.stderr.write(`${CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX} ${JSON.stringify(payload)}\n`);
+		}
+	} catch {
+		// Debug logging must never affect provider execution.
+	}
 }
 
 export function attachCursorSdkEventDebugPiStreamTap(

--- a/src/cursor-transcript-tool-formatters.ts
+++ b/src/cursor-transcript-tool-formatters.ts
@@ -805,9 +805,60 @@ export function formatMcp(args: Record<string, unknown>, result: NormalizedResul
 	return joinSections(toolName, limitText(body, options));
 }
 
+const UNKNOWN_TOOL_FALLBACK_MAX_ARGS = 8;
+const UNKNOWN_TOOL_FALLBACK_MAX_CHARS = 240;
+const UNKNOWN_TOOL_FALLBACK_MAX_LINES = 6;
+
+function summarizeUnknownToolArgValue(value: unknown): string {
+	if (typeof value === "string") return truncateArg(value);
+	if (typeof value === "number" || typeof value === "boolean") return String(value);
+	if (Array.isArray(value)) {
+		const preview = value.slice(0, 3).map((entry) => summarizeUnknownToolArgValue(entry)).join(", ");
+		const omitted = value.length - Math.min(value.length, 3);
+		return omitted > 0 ? `[${preview}, +${omitted} more]` : `[${preview}]`;
+	}
+	return truncateArg(stringifyUnknown(value).replace(/\s+/g, " "));
+}
+
+function summarizeUnknownToolArgs(args: Record<string, unknown>): string {
+	const entries = Object.entries(args).slice(0, UNKNOWN_TOOL_FALLBACK_MAX_ARGS);
+	if (entries.length === 0) return "";
+	const parts = entries.map(([key, value]) => `${key}=${summarizeUnknownToolArgValue(value)}`);
+	const omitted = Object.keys(args).length - entries.length;
+	const body = parts.join(", ");
+	return omitted > 0 ? `${body} (+${omitted} more)` : body;
+}
+
+function summarizeUnknownToolResult(value: unknown, options: TranscriptOptions): string {
+	const text = stringifyUnknown(value).trim();
+	if (!text) return "";
+	return limitText(text.replace(/\s+/g, " "), {
+		...options,
+		maxChars: options.maxChars ?? UNKNOWN_TOOL_FALLBACK_MAX_CHARS,
+		maxLines: options.maxLines ?? UNKNOWN_TOOL_FALLBACK_MAX_LINES,
+	});
+}
+
+function summarizeUnknownToolError(error: unknown, options: TranscriptOptions): string {
+	const text = formatError(error).trim();
+	if (!text) return "Error";
+	return limitText(text, {
+		...options,
+		maxChars: options.maxChars ?? UNKNOWN_TOOL_FALLBACK_MAX_CHARS,
+		maxLines: options.maxLines ?? UNKNOWN_TOOL_FALLBACK_MAX_LINES,
+	});
+}
+
 export function formatFallback(name: string, args: Record<string, unknown>, result: NormalizedResult, options: TranscriptOptions): string {
 	const header = name === "unknown" ? "Cursor tool" : name;
-	if (result.status === "error") return joinSections(header, formatError(result.error));
-	const argsText = Object.keys(args).length > 0 ? `${stringifyUnknown(args)}\n\n` : "";
-	return joinSections(header, limitText(`${argsText}${stringifyUnknown(result.value)}`.trim(), options));
+	if (result.status === "error") {
+		const argsSummary = summarizeUnknownToolArgs(args);
+		const errorSummary = summarizeUnknownToolError(result.error, options);
+		const body = [argsSummary, errorSummary].filter(Boolean).join("\n\n");
+		return joinSections(header, body ? limitText(body, options) : undefined);
+	}
+	const argsSummary = summarizeUnknownToolArgs(args);
+	const resultSummary = summarizeUnknownToolResult(result.value, options);
+	const body = [argsSummary, resultSummary].filter(Boolean).join("\n\n");
+	return joinSections(header, body ? limitText(body, options) : undefined);
 }

--- a/src/cursor-transcript-tool-specs.ts
+++ b/src/cursor-transcript-tool-specs.ts
@@ -154,14 +154,22 @@ function buildActivityReplayDisplay(cursorToolName: string, spec: ToolDisplaySpe
 }
 
 function buildGenericPiToolDisplay(context: ToolDisplayContext): CursorPiToolDisplay {
-	const { name, args, result, options } = context;
-	const isError = result.status === "error";
-	return {
-		toolName: name,
-		args,
-		result: textToolResult(isError ? formatError(result.error) : limitText(stringifyUnknown(result.value), options)),
-		isError,
-	};
+	const { rawName, name, args, result, options } = context;
+	const displayName = rawName.trim() || name;
+	const activityTitle = getCursorReplayDisplayLabel(CURSOR_REPLAY_ACTIVITY_TOOL_NAME);
+	const activitySummary = truncateArg(displayName === "unknown" ? "tool" : displayName);
+	const activityArgs = buildCursorActivityDisplayArgs({ cursorToolName: activitySummary }, activityTitle, activitySummary);
+	const contentText = formatFallback(name, args, result, options);
+	const summary =
+		result.status === "error"
+			? undefined
+			: firstNonEmptyLine(contentText) ?? activitySummary;
+	return buildReplaySummaryDisplay(CURSOR_REPLAY_ACTIVITY_TOOL_NAME, activityArgs, result, contentText, {
+		cursorToolName: name,
+		title: activityTitle,
+		summary,
+		expandedText: contentText,
+	});
 }
 
 function buildEditPiToolDisplay(context: ToolDisplayContext): CursorPiToolDisplay {

--- a/src/cursor-transcript-tool-specs.ts
+++ b/src/cursor-transcript-tool-specs.ts
@@ -114,13 +114,13 @@ function buildReplaySummaryDisplay(
 	details: Record<string, unknown>,
 ): CursorPiToolDisplay {
 	const isError = result.status === "error";
-	const summary = isError ? formatError(result.error) : firstNonEmptyLine(contentText);
+	const summary = isError ? details.summary : (details.summary ?? firstNonEmptyLine(contentText));
 	return {
 		toolName,
 		args,
 		result: textToolResult(contentText, {
 			...details,
-			summary: details.summary ?? summary,
+			summary,
 			expandedText: details.expandedText ?? contentText,
 		}),
 		isError,

--- a/test/cursor-native-replay-stress.test.ts
+++ b/test/cursor-native-replay-stress.test.ts
@@ -40,6 +40,34 @@ function mockFinishedGrepSend() {
 	});
 }
 
+function mockFinishedTaskSend() {
+	return vi.fn(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+		opts.onDelta({
+			update: {
+				type: "tool-call-completed",
+				toolCall: {
+					name: "task",
+					args: { description: "Verify plan-strip resync" },
+					result: {
+						status: "success",
+						value: { result: { success: { command: "echo ok", stdout: "ok\n" } } },
+					},
+				},
+				callId: "task-1",
+			},
+		});
+		return {
+			id: "run-1",
+			agentId: "agent-1",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "done" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		};
+	});
+}
+
 describe("native replay stress", () => {
 	beforeEach(async () => {
 		cursorProviderTestUtils.setCursorNativeReplayIdleDisposeMs(0);
@@ -62,6 +90,25 @@ describe("native replay stress", () => {
 		mockedCreate.mockResolvedValue({
 			agentId: "agent-1",
 			send: mockFinishedGrepSend(),
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const context = makeContext();
+		context.tools = pi.getActiveTools().map((name) => ({ name, description: name, parameters: Type.Object({}) }));
+		const events = await collectEvents(streamCursor(CURSOR_MODEL, context, { apiKey: "test-key" }));
+		expect(hasEventType(events, "toolcall_start")).toBe(true);
+	});
+
+	it("plan strip then turn_start resync replays neutral task activity when context.tools match active tools", async () => {
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		const pi = await createNativeToolDisplayPiForTest();
+		pi.setActiveTools(["read", "bash", "edit", "write"]);
+		await pi.runEventHandlers("turn_start", { model: CURSOR_MODEL });
+		expect(pi.getActiveTools()).toContain("cursor");
+
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockFinishedTaskSend(),
 			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
 		});
 

--- a/test/cursor-provider-stream-trace.test.ts
+++ b/test/cursor-provider-stream-trace.test.ts
@@ -570,6 +570,41 @@ it("detects trailing user messages only after tool results", () => {
 		expect(hasEventType(events, "toolcall_start")).toBe(false);
 	});
 
+	it("records discarded incomplete started tool calls to coordinator-events.jsonl when PI_CURSOR_SDK_EVENT_DEBUG is enabled", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-provider-discarded-debug-"));
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG = "1";
+		process.env.PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR = artifactDir;
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "read", args: { path: "README.md" } }, callId: "c1" } });
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "done" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		try {
+			await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+			const coordinatorEvents = readFileSync(join(artifactDir, "coordinator-events.jsonl"), "utf8");
+			expect(coordinatorEvents).toContain("discarded-incomplete-started-tool-call");
+			expect(coordinatorEvents).toContain('"toolName":"read"');
+			expect(coordinatorEvents).toContain('"reason":"no-completion-at-run-end"');
+			expect(coordinatorEvents).not.toContain("c1");
+		} finally {
+			delete process.env.PI_CURSOR_SDK_EVENT_DEBUG;
+			delete process.env.PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR;
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
 	it("still surfaces explicit completed Cursor tool errors", async () => {
 		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
 			opts.onDelta({ update: { type: "tool-call-started", toolCall: { name: "shell", args: { command: "cat missing.txt" } }, callId: "c1" } });

--- a/test/cursor-sdk-event-debug.test.ts
+++ b/test/cursor-sdk-event-debug.test.ts
@@ -1,12 +1,18 @@
 import { mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+	CURSOR_SDK_EVENT_DEBUG_ENV,
 	CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX,
+	CURSOR_SDK_EVENT_DEBUG_STDERR_ENV,
+	DISCARDED_INCOMPLETE_TOOL_CALL_REASON,
 	CursorSdkEventDebugSink,
+	hashCursorSdkCallId,
+	recordDiscardedIncompleteStartedToolCall,
 	resolveCursorSdkEventDebugBaseDir,
 	resolveCursorSdkEventDebugEnabled,
+	serializeDiscardedIncompleteStartedToolCall,
 	__testUtils as sdkEventDebugTestUtils,
 } from "../src/cursor-sdk-event-debug.js";
 import { parseDebugProviderEventsArgs } from "../scripts/debug-provider-events.mjs";
@@ -374,6 +380,91 @@ describe("cursor sdk event debug session grouping", () => {
 		} finally {
 			sdkEventDebugTestUtils.resetSessionDebugState();
 			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("discarded incomplete started tool calls", () => {
+	it("hashes call ids without exposing raw values", () => {
+		expect(hashCursorSdkCallId("secret-call-id-123")).toMatch(/^[a-f0-9]{8}$/);
+		expect(hashCursorSdkCallId("secret-call-id-123")).toBe(hashCursorSdkCallId("secret-call-id-123"));
+		expect(hashCursorSdkCallId("secret-call-id-123")).not.toBe("secret-call-id-123");
+	});
+
+	it("serializes discarded incomplete started tool calls with bounded fields", () => {
+		expect(
+			serializeDiscardedIncompleteStartedToolCall({
+				toolName: "read",
+				callId: "call-abc",
+			}),
+		).toEqual({
+			event: "discarded-incomplete-started-tool-call",
+			toolName: "read",
+			callIdHash: hashCursorSdkCallId("call-abc"),
+			reason: DISCARDED_INCOMPLETE_TOOL_CALL_REASON,
+		});
+	});
+
+	it("records discarded incomplete started tool calls to coordinator-events.jsonl without stderr by default", async () => {
+		const artifactDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-discarded-debug-"));
+		const stderrLines: string[] = [];
+		const originalWrite = process.stderr.write.bind(process.stderr);
+		process.stderr.write = ((chunk: string | Uint8Array) => {
+			stderrLines.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+			return true;
+		}) as typeof process.stderr.write;
+
+		try {
+			const sink = CursorSdkEventDebugSink.maybeCreate({
+				cwd: "/repo",
+				modelId: "composer-2.5",
+				provider: "cursor",
+				env: {
+					PI_CURSOR_SDK_EVENT_DEBUG: "1",
+					PI_CURSOR_SDK_EVENT_DEBUG_RUN_DIR: artifactDir,
+				},
+			});
+			recordDiscardedIncompleteStartedToolCall(
+				sink,
+				{ [CURSOR_SDK_EVENT_DEBUG_ENV]: "1" },
+				{ toolName: "read", callId: "call-abc" },
+			);
+			await sink?.finalize();
+
+			const coordinatorEvents = readFileSync(join(artifactDir, sdkEventDebugTestUtils.ARTIFACTS.coordinatorEvents), "utf8");
+			expect(coordinatorEvents).toContain('"phase":"discarded-incomplete-started-tool-call"');
+			expect(coordinatorEvents).toContain('"toolName":"read"');
+			expect(coordinatorEvents).toContain(`"callIdHash":"${hashCursorSdkCallId("call-abc")}"`);
+			expect(coordinatorEvents).toContain(`"reason":"${DISCARDED_INCOMPLETE_TOOL_CALL_REASON}"`);
+			expect(coordinatorEvents).not.toContain("call-abc");
+			expect(stderrLines.some((line) => line.includes("discarded-incomplete-started-tool-call"))).toBe(false);
+		} finally {
+			process.stderr.write = originalWrite;
+			rmSync(artifactDir, { recursive: true, force: true });
+		}
+	});
+
+	it("can opt in to stderr output for discarded incomplete started tool calls", () => {
+		const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+		try {
+			recordDiscardedIncompleteStartedToolCall(undefined, {}, { toolName: "read", callId: "call-abc" });
+			expect(stderr).not.toHaveBeenCalled();
+
+			recordDiscardedIncompleteStartedToolCall(
+				undefined,
+				{ [CURSOR_SDK_EVENT_DEBUG_ENV]: "1", [CURSOR_SDK_EVENT_DEBUG_STDERR_ENV]: "1" },
+				{ toolName: "read", callId: "call-abc" },
+			);
+			expect(stderr).toHaveBeenCalledOnce();
+			const line = String(stderr.mock.calls[0]?.[0]);
+			expect(line.startsWith(`${CURSOR_SDK_EVENT_DEBUG_LOG_PREFIX} `)).toBe(true);
+			expect(line).toContain('"event":"discarded-incomplete-started-tool-call"');
+			expect(line).toContain('"toolName":"read"');
+			expect(line).toContain(`"callIdHash":"${hashCursorSdkCallId("call-abc")}"`);
+			expect(line).toContain(`"reason":"${DISCARDED_INCOMPLETE_TOOL_CALL_REASON}"`);
+			expect(line).not.toContain("call-abc");
+		} finally {
+			stderr.mockRestore();
 		}
 	});
 });

--- a/test/cursor-tool-transcript.test.ts
+++ b/test/cursor-tool-transcript.test.ts
@@ -877,4 +877,79 @@ describe("formatCursorToolTranscript", () => {
 		expect(transcript).toContain("line 0\nline 1\nline 2");
 		expect(transcript).toContain("17 more lines");
 	});
+
+	it("bounds unknown future Cursor tool completions with neutral activity cards", () => {
+		const largePayload = "x".repeat(5000);
+		const toolCall = {
+			name: "futureSemSearchWidget",
+			args: {
+				query: largePayload,
+				...Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`field-${index}`, `value-${index}`])),
+			},
+			result: {
+				status: "success",
+				value: { matches: Array.from({ length: 40 }, (_, index) => ({ path: `src/file-${index}.ts`, score: index })) },
+			},
+		};
+
+		const transcript = formatCursorToolTranscript(toolCall);
+		expect(transcript.startsWith("futureSemSearchWidget\n\n")).toBe(true);
+		expect(transcript).toContain("query=");
+		expect(transcript).toContain("(+5 more)");
+		expect(transcript.length).toBeLessThan(1200);
+		expect(transcript).not.toContain(largePayload);
+
+		const display = buildCursorPiToolDisplay(toolCall);
+		expect(display).toMatchObject({
+			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
+			args: {
+				cursorToolName: "futureSemSearchWidget",
+				activityTitle: "Cursor activity",
+				activitySummary: "futureSemSearchWidget",
+			},
+			result: {
+				details: {
+					cursorToolName: "futureSemSearchWidget",
+					title: "Cursor activity",
+				},
+			},
+			isError: false,
+		});
+		expect(display.result.content[0].text.length).toBeLessThan(1200);
+	});
+
+	it("bounds unknown future Cursor tool error completions with neutral activity cards", () => {
+		const largeError = { message: "x".repeat(5000), details: Object.fromEntries(Array.from({ length: 20 }, (_, index) => [`field-${index}`, "y".repeat(200)])) };
+		const toolCall = {
+			name: "futureBrokenWidget",
+			args: {
+				query: "x".repeat(5000),
+				...Object.fromEntries(Array.from({ length: 12 }, (_, index) => [`field-${index}`, `value-${index}`])),
+			},
+			result: {
+				status: "error",
+				error: largeError,
+			},
+		};
+
+		const transcript = formatCursorToolTranscript(toolCall);
+		expect(transcript.startsWith("futureBrokenWidget\n\n")).toBe(true);
+		expect(transcript).toContain("query=");
+		expect(transcript).toContain("Error:");
+		expect(transcript.length).toBeLessThan(1200);
+		expect(transcript).not.toContain("x".repeat(500));
+
+		const display = buildCursorPiToolDisplay(toolCall);
+		expect(display).toMatchObject({
+			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
+			args: {
+				cursorToolName: "futureBrokenWidget",
+				activityTitle: "Cursor activity",
+				activitySummary: "futureBrokenWidget",
+			},
+			isError: true,
+		});
+		expect(display.result.content[0].text.length).toBeLessThan(1200);
+		expect(display.result.content[0].text).not.toContain("x".repeat(500));
+	});
 });

--- a/test/cursor-tool-transcript.test.ts
+++ b/test/cursor-tool-transcript.test.ts
@@ -951,5 +951,7 @@ describe("formatCursorToolTranscript", () => {
 		});
 		expect(display.result.content[0].text.length).toBeLessThan(1200);
 		expect(display.result.content[0].text).not.toContain("x".repeat(500));
+		expect(display.result.details?.summary).toBeUndefined();
+		expect(JSON.stringify(display.result.details ?? {})).not.toContain("x".repeat(500));
 	});
 });


### PR DESCRIPTION
## Summary
- Bound unknown/future SDK tool transcript and neutral activity replay cards for both success and error completions instead of dumping full JSON args/results.
- Log discarded incomplete started tool calls through main's canonical `PI_CURSOR_SDK_EVENT_DEBUG` sink (`coordinator-events.jsonl` via `debugRecorder`); stderr requires `PI_CURSOR_SDK_EVENT_DEBUG_STDERR=1`.
- Extended plan-strip resync regression coverage for neutral task activity replay and documented the resync + discard debug contract in `docs/cursor-testing-lessons.md`.

Rebased onto `main` after #55 (provider errors) and #56 (provider SDK event debug capture). This PR is scoped to #52-only replay hardening and discard debug hooks on top of the merged debug infrastructure.

## Test plan
- [x] npm test
- [x] npm run typecheck
- [x] npm pack --dry-run
- [ ] Live smoke not run in this worker session (provider/runtime change; maintainer should run pre-merge smoke per AGENTS.md)

Closes #52