### PR TITLE
Surface scrubbed Cursor SDK failure and abort reasons in pi TUI (#55)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/index.ts` registers the pi extension, provider, fallback warnings, Cursor fast controls, native replay wrappers, question tool, and pi tool bridge hooks.
 - `src/model-discovery.ts` discovers Cursor models, builds pi model metadata, stores per-model metadata, and defines fallback models.
 - `src/cursor-provider.ts` streams through local `@cursor/sdk` agents, injects local MCP bridge config, resumes live bridge runs, and sanitizes Cursor SDK errors.
+- `src/cursor-provider-errors.ts` owns scrubbed Cursor SDK run failure detail, abort reason formatting, and provider error sanitization.
 - `src/cursor-session-agent.ts` owns session-scoped SDK agent pooling, send-state commits, and lifecycle invalidation on compaction/tree/shutdown.
 - `src/cursor-session-send-policy.ts` owns session send planning (`bootstrap` vs `incremental`), periodic agent rebootstrap threshold, and prompt mode selection.
 - `src/cursor-provider-live-run-drain.ts` owns live-run drain/replay mirroring, pre-send continuation, and native replay turn emission.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,10 @@ Actual Cursor runs still need a key from `/login`, `CURSOR_API_KEY`, or `--api-k
 
 You may be seeing fallback startup models or a missing/invalid key. In interactive pi, run `/login`, choose `Use an API key`, choose `Cursor`, paste the key, then run `/cursor-refresh-models`.
 
+When a Cursor run fails after auth is configured, pi now surfaces scrubbed provider detail instead of only `Cursor SDK run failed`. Generic SDK failures include safe run metadata such as model id, a short run id prefix, and duration when available. Check the red toast or assistant error message for that detail before retrying.
+
+Aborted runs now include a likely cause when determinable, for example `Cancelled: prompt interrupted.` for user cancel or `Cancelled: Cursor SDK run was cancelled.` for SDK-side cancellation.
+
 You can also restart pi with a key in the same shell or launcher that starts pi:
 
 ```bash

--- a/scripts/lib/cursor-probe-utils.mjs
+++ b/scripts/lib/cursor-probe-utils.mjs
@@ -16,17 +16,37 @@ export function resolveCursorSettingSources(raw) {
 		.filter(Boolean);
 }
 
+const BRIDGE_ENDPOINT_ROOT = "/cursor-pi-tool-bridge";
+const BRIDGE_ENDPOINT_TOKEN_PATTERN = "[^/\\s\"'<>]+";
+const BRIDGE_LOOPBACK_HOST_PATTERN = "127\\.0\\.0\\.1(?::\\d+)?";
+const BRIDGE_ENDPOINT_PATH_PATTERN = `${escapeRegExp(BRIDGE_ENDPOINT_ROOT)}/${BRIDGE_ENDPOINT_TOKEN_PATTERN}/mcp`;
+
+function scrubBridgeEndpointMaterial(text) {
+	return text
+		.replace(
+			new RegExp(`https?://${BRIDGE_LOOPBACK_HOST_PATTERN}${BRIDGE_ENDPOINT_PATH_PATTERN}`, "gi"),
+			"[redacted-bridge-endpoint]",
+		)
+		.replace(
+			new RegExp(`${BRIDGE_LOOPBACK_HOST_PATTERN}${BRIDGE_ENDPOINT_PATH_PATTERN}`, "gi"),
+			"[redacted-bridge-endpoint]",
+		)
+		.replace(new RegExp(BRIDGE_ENDPOINT_PATH_PATTERN, "gi"), "[redacted-bridge-endpoint]");
+}
+
 export function scrubSensitiveText(text, apiKey) {
 	let scrubbed = text;
 	const trimmedKey = apiKey?.trim();
 	if (trimmedKey) {
 		scrubbed = scrubbed.replace(new RegExp(escapeRegExp(trimmedKey), "g"), "[redacted]");
 	}
-	return scrubbed
-		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
-		.replace(/((?:^|[\s,{])cookie["']?\s*[:=]\s*["']?)[^\n]+/gi, "$1[redacted]")
-		.replace(
-			/((?:authorization|api[_-]?key|apiKey|token|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)[^"'\s,;}]+/gi,
-			"$1[redacted]",
-		);
+	return scrubBridgeEndpointMaterial(
+		scrubbed
+			.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+			.replace(/((?:^|[\s,{])cookie["']?\s*[:=]\s*["']?)[^\n]+/gi, "$1[redacted]")
+			.replace(
+				/((?:authorization|api[_-]?key|apiKey|token|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)[^"'\s,;}]+/gi,
+				"$1[redacted]",
+			),
+	);
 }

--- a/src/cursor-live-run-coordinator.ts
+++ b/src/cursor-live-run-coordinator.ts
@@ -46,6 +46,7 @@ export interface CursorLiveRun {
 	cancelled: boolean;
 	disposed: boolean;
 	errorMessage?: string;
+	abortMessage?: string;
 	chainUserInputAfterCompletion: boolean;
 }
 
@@ -70,7 +71,7 @@ export interface CursorLiveRunCoordinator {
 	start(params: CursorLiveRunCreateParams): CursorLiveRun;
 	attachSdkRun(run: CursorLiveRun, sdkRun: CursorLiveSdkRun): void;
 	markFinished(run: CursorLiveRun, finalText: string): void;
-	markCancelled(run: CursorLiveRun): void;
+	markCancelled(run: CursorLiveRun, abortMessage?: string): void;
 	markError(run: CursorLiveRun, errorMessage: string): void;
 	queueEvent(run: CursorLiveRun, event: CursorLiveQueuedEvent): void;
 	peekEvent(run: CursorLiveRun): CursorLiveQueuedEvent | undefined;
@@ -294,9 +295,10 @@ export function createCursorLiveRunCoordinator(deps: CursorLiveRunCoordinatorDep
 			coordinator.requestIdleDispose(run);
 		},
 
-		markCancelled(run): void {
+		markCancelled(run, abortMessage): void {
 			if (run.disposed) return;
 			run.cancelled = true;
+			run.abortMessage = abortMessage;
 			run.done = true;
 			notifyProgress(run);
 			coordinator.requestIdleDispose(run);

--- a/src/cursor-provider-errors.ts
+++ b/src/cursor-provider-errors.ts
@@ -1,0 +1,85 @@
+import type { RunResult } from "@cursor/sdk";
+import { scrubSensitiveText } from "./cursor-sensitive-text.js";
+
+export const MISSING_CURSOR_API_KEY_MESSAGE =
+	"Cursor SDK runs require a Cursor API key. Run /login -> Use an API key -> Cursor, set CURSOR_API_KEY before starting pi, or restart pi with --api-key.";
+const GENERIC_CURSOR_SDK_ERROR_MESSAGE =
+	"Cursor SDK request failed. The API key may be missing, invalid, or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
+const AUTH_CURSOR_SDK_ERROR_MESSAGE =
+	"Cursor SDK request failed because the API key may be invalid or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
+
+const GENERIC_CURSOR_RUN_FAILURE_TEXT = "cursor sdk run failed";
+
+export type CursorSdkRunFailureSource = Pick<RunResult, "id" | "status" | "durationMs" | "model" | "result">;
+
+function isGenericErrorMessage(message: string): boolean {
+	const normalized = message.trim().toLowerCase();
+	return normalized === "" || normalized === "error" || normalized === "unknown error";
+}
+
+function isKnownGenericRunFailureText(message: string): boolean {
+	const normalized = message.trim().toLowerCase();
+	return normalized === "" || normalized === GENERIC_CURSOR_RUN_FAILURE_TEXT || isGenericErrorMessage(normalized);
+}
+
+function isLikelyAuthError(message: string): boolean {
+	return /\b(unauthorized|unauthorised|forbidden|invalid api key|invalid key|authentication|auth|401|403)\b/i.test(message);
+}
+
+function shortRunId(runId: string): string {
+	const trimmed = runId.trim();
+	if (trimmed.length <= 12) return trimmed;
+	return `${trimmed.slice(0, 8)}…`;
+}
+
+export function formatCursorSdkRunFailureDetail(result: CursorSdkRunFailureSource, runResult?: string): string {
+	const fromWait = result.result?.trim();
+	if (fromWait && !isKnownGenericRunFailureText(fromWait)) {
+		return fromWait;
+	}
+	const fromRun = runResult?.trim();
+	if (fromRun && !isKnownGenericRunFailureText(fromRun)) {
+		return fromRun;
+	}
+
+	const parts = ["Cursor SDK run failed"];
+	if (result.model?.id) parts.push(`model ${result.model.id}`);
+	parts.push(`run ${shortRunId(result.id)}`);
+	if (typeof result.durationMs === "number") parts.push(`${result.durationMs}ms`);
+	return parts.join(" · ");
+}
+
+export type CursorSdkAbortCause = "user_interrupt" | "sdk_cancelled" | "live_run_disposed" | "unknown";
+
+export function formatCursorSdkAbortMessage(cause: CursorSdkAbortCause): string {
+	switch (cause) {
+		case "user_interrupt":
+			return "Cancelled: prompt interrupted.";
+		case "sdk_cancelled":
+			return "Cancelled: Cursor SDK run was cancelled.";
+		case "live_run_disposed":
+			return "Cancelled: Cursor SDK live run ended before completion.";
+		case "unknown":
+			return "Cancelled: Cursor SDK run aborted.";
+	}
+}
+
+export function resolveCursorSdkAbortCause(options: {
+	signalAborted?: boolean;
+	sdkStatusCancelled?: boolean;
+	liveRunDisposed?: boolean;
+}): CursorSdkAbortCause {
+	if (options.signalAborted) return "user_interrupt";
+	if (options.sdkStatusCancelled) return "sdk_cancelled";
+	if (options.liveRunDisposed) return "live_run_disposed";
+	return "unknown";
+}
+
+export function sanitizeCursorProviderError(error: unknown, apiKey?: string): string {
+	const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+	if (message === MISSING_CURSOR_API_KEY_MESSAGE) return MISSING_CURSOR_API_KEY_MESSAGE;
+	const scrubbed = scrubSensitiveText(message, apiKey).trim();
+	if (isGenericErrorMessage(scrubbed)) return GENERIC_CURSOR_SDK_ERROR_MESSAGE;
+	if (isLikelyAuthError(scrubbed)) return AUTH_CURSOR_SDK_ERROR_MESSAGE;
+	return scrubbed || GENERIC_CURSOR_SDK_ERROR_MESSAGE;
+}

--- a/src/cursor-provider-live-run-drain.ts
+++ b/src/cursor-provider-live-run-drain.ts
@@ -23,6 +23,7 @@ import { resetSessionCursorAgent } from "./cursor-session-agent.js";
 import { applyCursorApproximateUsage } from "./cursor-usage-accounting.js";
 import { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js";
 import { hasUsableText } from "./cursor-record-utils.js";
+import { formatCursorSdkAbortMessage, resolveCursorSdkAbortCause } from "./cursor-provider-errors.js";
 import { formatInactiveCursorReplayTrace } from "./cursor-native-replay-trace.js";
 import { partitionNativeToolsByActiveContext } from "./cursor-native-replay-routing.js";
 
@@ -308,11 +309,15 @@ export async function drainCursorLiveRunTurn(
 
 		if (run.disposed) {
 			partial.stopReason = "aborted";
+			partial.errorMessage = formatCursorSdkAbortMessage(
+				resolveCursorSdkAbortCause({ liveRunDisposed: true }),
+			);
 			stream.push({ type: "error", reason: "aborted", error: partial });
 			return "aborted";
 		}
 		if (run.cancelled) {
 			partial.stopReason = "aborted";
+			if (run.abortMessage) partial.errorMessage = run.abortMessage;
 			stream.push({ type: "error", reason: "aborted", error: partial });
 			await cursorLiveRuns.release(run);
 			return "aborted";

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -51,6 +51,15 @@ import { buildCursorModelSelection } from "./model-discovery.js";
 import { getCheckpointContextWindow, saveCachedContextWindow } from "./context-window-cache.js";
 import { CursorSdkTurnCoordinator } from "./cursor-provider-turn-coordinator.js";
 import { isCursorNativeToolDisplayRuntimeEnabled } from "./cursor-native-tool-display.js";
+import {
+	formatCursorSdkAbortMessage,
+	formatCursorSdkRunFailureDetail,
+	MISSING_CURSOR_API_KEY_MESSAGE,
+	resolveCursorSdkAbortCause,
+	sanitizeCursorProviderError,
+} from "./cursor-provider-errors.js";
+import { getEffectiveCursorSettingSources } from "./cursor-setting-sources.js";
+import { hasUsableText } from "./cursor-record-utils.js";
 
 function makeInitialMessage(model: Model<Api>): AssistantMessage {
 	return {
@@ -73,39 +82,12 @@ function makeInitialMessage(model: Model<Api>): AssistantMessage {
 }
 
 const CURSOR_API_KEY_ENV_VAR = "CURSOR_API_KEY";
-const MISSING_API_KEY_MESSAGE =
-	"Cursor SDK runs require a Cursor API key. Run /login -> Use an API key -> Cursor, set CURSOR_API_KEY before starting pi, or restart pi with --api-key.";
-const GENERIC_CURSOR_SDK_ERROR_MESSAGE =
-	"Cursor SDK request failed. The API key may be missing, invalid, or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
-const AUTH_CURSOR_SDK_ERROR_MESSAGE =
-	"Cursor SDK request failed because the API key may be invalid or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
-import { getEffectiveCursorSettingSources } from "./cursor-setting-sources.js";
-import { scrubSensitiveText } from "./cursor-sensitive-text.js";
-import { hasUsableText } from "./cursor-record-utils.js";
-
-function isGenericErrorMessage(message: string): boolean {
-	const normalized = message.trim().toLowerCase();
-	return normalized === "" || normalized === "error" || normalized === "unknown error";
-}
-
-function isLikelyAuthError(message: string): boolean {
-	return /\b(unauthorized|unauthorised|forbidden|invalid api key|invalid key|authentication|auth|401|403)\b/i.test(message);
-}
 
 function resolveCursorApiKey(apiKey?: string): string | undefined {
 	const trimmed = apiKey?.trim();
 	if (!trimmed) return undefined;
 	if (trimmed === CURSOR_API_KEY_ENV_VAR) return process.env.CURSOR_API_KEY?.trim();
 	return trimmed;
-}
-
-function sanitizeError(error: unknown, apiKey?: string): string {
-	const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
-	if (message === MISSING_API_KEY_MESSAGE) return MISSING_API_KEY_MESSAGE;
-	const scrubbed = scrubSensitiveText(message, apiKey).trim();
-	if (isGenericErrorMessage(scrubbed)) return GENERIC_CURSOR_SDK_ERROR_MESSAGE;
-	if (isLikelyAuthError(scrubbed)) return AUTH_CURSOR_SDK_ERROR_MESSAGE;
-	return scrubbed || GENERIC_CURSOR_SDK_ERROR_MESSAGE;
 }
 
 async function cacheSdkContextWindow(agentId: string, modelId: string): Promise<void> {
@@ -153,7 +135,7 @@ export function streamCursor(
 			}
 
 			const apiKey = resolveCursorApiKey(options?.apiKey);
-			if (!apiKey) throw new Error(MISSING_API_KEY_MESSAGE);
+			if (!apiKey) throw new Error(MISSING_CURSOR_API_KEY_MESSAGE);
 			resolvedApiKey = apiKey;
 
 			// pi-ai Context/SimpleStreamOptions do not expose ExtensionContext.cwd; bridge via session_start
@@ -276,14 +258,26 @@ export function streamCursor(
 								selectCursorFinalText(result.result, liveRun.textDeltas, liveRun.emittedText, turnCoordinator.planTextCandidate),
 							);
 						} else if (result.status === "cancelled" || options?.signal?.aborted) {
-							cursorLiveRuns.markCancelled(liveRun);
+							cursorLiveRuns.markCancelled(
+								liveRun,
+								formatCursorSdkAbortMessage(
+									resolveCursorSdkAbortCause({
+										signalAborted: options?.signal?.aborted,
+										sdkStatusCancelled: result.status === "cancelled",
+									}),
+								),
+							);
 						} else {
-							cursorLiveRuns.markError(liveRun, sanitizeError(result.result ?? "Cursor SDK run failed", resolvedApiKey ?? options?.apiKey));
+							const failureDetail = formatCursorSdkRunFailureDetail(result, run?.result);
+							cursorLiveRuns.markError(
+								liveRun,
+								sanitizeCursorProviderError(failureDetail, resolvedApiKey ?? options?.apiKey),
+							);
 						}
 					})
 					.catch(async (error: unknown) => {
 						if (liveRun.disposed) return;
-						cursorLiveRuns.markError(liveRun, sanitizeError(error, resolvedApiKey ?? options?.apiKey));
+						cursorLiveRuns.markError(liveRun, sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey));
 					});
 
 				try {
@@ -312,11 +306,18 @@ export function streamCursor(
 			if (result.status === "cancelled") {
 				await abandonSessionCursorAgent(sessionAgentScopeKey);
 				partial.stopReason = "aborted";
+				partial.errorMessage = formatCursorSdkAbortMessage(
+					resolveCursorSdkAbortCause({
+						signalAborted: options?.signal?.aborted,
+						sdkStatusCancelled: true,
+					}),
+				);
 				stream.push({ type: "error", reason: "aborted", error: partial });
 			} else if (result.status === "error") {
 				await abandonSessionCursorAgent(sessionAgentScopeKey);
 				partial.stopReason = "error";
-				partial.errorMessage = sanitizeError(result.result ?? "Cursor SDK run failed", resolvedApiKey ?? options?.apiKey);
+				const failureDetail = formatCursorSdkRunFailureDetail(result, run.result);
+				partial.errorMessage = sanitizeCursorProviderError(failureDetail, resolvedApiKey ?? options?.apiKey);
 				stream.push({ type: "error", reason: "error", error: partial });
 			} else {
 				commitSessionAgentSend(sessionAgentScopeKey, context, bootstrap);
@@ -332,10 +333,13 @@ export function streamCursor(
 			else await abandonSessionCursorAgent(sessionAgentScopeKey);
 			if (error instanceof CursorLiveRunAbortError) {
 				partial.stopReason = "aborted";
+				partial.errorMessage = formatCursorSdkAbortMessage(
+					resolveCursorSdkAbortCause({ signalAborted: options?.signal?.aborted }),
+				);
 				stream.push({ type: "error", reason: "aborted", error: partial });
 			} else {
 				partial.stopReason = "error";
-				partial.errorMessage = sanitizeError(error, resolvedApiKey ?? options?.apiKey);
+				partial.errorMessage = sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey);
 				stream.push({ type: "error", reason: "error", error: partial });
 			}
 		} finally {

--- a/src/cursor-sensitive-text.ts
+++ b/src/cursor-sensitive-text.ts
@@ -4,19 +4,39 @@ function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
+const BRIDGE_ENDPOINT_ROOT = "/cursor-pi-tool-bridge";
+const BRIDGE_ENDPOINT_TOKEN_PATTERN = "[^/\\s\"'<>]+";
+const BRIDGE_LOOPBACK_HOST_PATTERN = "127\\.0\\.0\\.1(?::\\d+)?";
+const BRIDGE_ENDPOINT_PATH_PATTERN = `${escapeRegExp(BRIDGE_ENDPOINT_ROOT)}/${BRIDGE_ENDPOINT_TOKEN_PATTERN}/mcp`;
+
+function scrubBridgeEndpointMaterial(text: string): string {
+	return text
+		.replace(
+			new RegExp(`https?://${BRIDGE_LOOPBACK_HOST_PATTERN}${BRIDGE_ENDPOINT_PATH_PATTERN}`, "gi"),
+			"[redacted-bridge-endpoint]",
+		)
+		.replace(
+			new RegExp(`${BRIDGE_LOOPBACK_HOST_PATTERN}${BRIDGE_ENDPOINT_PATH_PATTERN}`, "gi"),
+			"[redacted-bridge-endpoint]",
+		)
+		.replace(new RegExp(BRIDGE_ENDPOINT_PATH_PATTERN, "gi"), "[redacted-bridge-endpoint]");
+}
+
 export function scrubSensitiveText(text: string, apiKey?: string): string {
 	let scrubbed = text;
 	const trimmedKey = apiKey?.trim();
 	if (trimmedKey) {
 		scrubbed = scrubbed.replace(new RegExp(escapeRegExp(trimmedKey), "g"), "[redacted]");
 	}
-	return scrubbed
-		.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
-		.replace(/((?:^|[\s,{])cookie["']?\s*[:=]\s*["']?)[^\n]+/gi, "$1[redacted]")
-		.replace(
-			/((?:authorization|api[_-]?key|apiKey|token|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)[^"'\s,;}]+/gi,
-			"$1[redacted]",
-		);
+	return scrubBridgeEndpointMaterial(
+		scrubbed
+			.replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [redacted]")
+			.replace(/((?:^|[\s,{])cookie["']?\s*[:=]\s*["']?)[^\n]+/gi, "$1[redacted]")
+			.replace(
+				/((?:authorization|api[_-]?key|apiKey|token|session(?:[_-]?id)?)["']?\s*[:=]\s*["']?)[^"'\s,;}]+/gi,
+				"$1[redacted]",
+			),
+	);
 }
 
 function scrubDisplayValue(value: unknown, apiKey?: string): unknown {

--- a/test/cursor-provider-bridge-mcp.test.ts
+++ b/test/cursor-provider-bridge-mcp.test.ts
@@ -44,14 +44,20 @@ import { join } from "node:path";
 describe("streamCursor bridge MCP", () => {
 	beforeEach(resetCursorProviderTestState);
 
-it("surfaces live-run wait error status as a provider error", async () => {
+	it("surfaces empty live-run error status with run metadata", async () => {
 		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
 			opts.onDelta({ update: { type: "text-delta", text: "partial" } });
 			return {
-				id: "run-1",
+				id: "run-abc123456789",
 				agentId: "agent-1",
 				status: "error",
-				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "error", result: "Cursor SDK run failed" }),
+				wait: vi.fn().mockResolvedValue({
+					id: "run-abc123456789",
+					status: "error",
+					result: "Cursor SDK run failed",
+					durationMs: 900,
+					model: { id: "composer-2.5" },
+				}),
 				cancel: vi.fn(),
 				supports: () => true,
 				unsupportedReason: () => undefined,
@@ -67,7 +73,36 @@ it("surfaces live-run wait error status as a provider error", async () => {
 		const error = getErrorEvent(events);
 
 		expect(error.reason).toBe("error");
-		expect(error.error.errorMessage).toContain("Cursor SDK run failed");
+		expect(error.error.errorMessage).toContain("model composer-2.5");
+		expect(error.error.errorMessage).toContain("900ms");
+		expect(error.error.errorMessage).not.toBe("Cursor SDK run failed");
+		expect(hasEventType(events, "done")).toBe(false);
+	});
+
+	it("surfaces live-run wait error status as a provider error", async () => {
+		const mockSend = vi.fn().mockImplementation(async (_msg: unknown, opts: { onDelta: CursorDeltaHandler }) => {
+			opts.onDelta({ update: { type: "text-delta", text: "partial" } });
+			return {
+				id: "run-1",
+				agentId: "agent-1",
+				status: "error",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "error", result: "MCP tool call timed out after 60s" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			};
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const events = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+		const error = getErrorEvent(events);
+
+		expect(error.reason).toBe("error");
+		expect(error.error.errorMessage).toContain("MCP tool call timed out after 60s");
 		expect(hasEventType(events, "done")).toBe(false);
 	});
 

--- a/test/cursor-provider-errors.test.ts
+++ b/test/cursor-provider-errors.test.ts
@@ -57,6 +57,21 @@ describe("cursor-provider-errors", () => {
 		expect(message).toContain("Cursor SDK run failed");
 	});
 
+	it("scrubs bridge endpoint material from non-generic SDK run failure detail", () => {
+		const endpointToken = "secret-endpoint-token-provider";
+		const sdkDetail = formatCursorSdkRunFailureDetail({
+			id: "run-bridge-leak",
+			status: "error",
+			result: `MCP request failed for http://127.0.0.1:4321/cursor-pi-tool-bridge/${endpointToken}/mcp`,
+		});
+		const message = sanitizeCursorProviderError(sdkDetail, "test-key");
+
+		expect(message).toContain("MCP request failed for [redacted-bridge-endpoint]");
+		expect(message).not.toContain(endpointToken);
+		expect(message).not.toContain("127.0.0.1");
+		expect(message).not.toContain("/cursor-pi-tool-bridge/");
+	});
+
 	it("formats abort causes deterministically", () => {
 		expect(formatCursorSdkAbortMessage(resolveCursorSdkAbortCause({ signalAborted: true }))).toBe(
 			"Cancelled: prompt interrupted.",

--- a/test/cursor-provider-errors.test.ts
+++ b/test/cursor-provider-errors.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+	formatCursorSdkAbortMessage,
+	formatCursorSdkRunFailureDetail,
+	resolveCursorSdkAbortCause,
+	sanitizeCursorProviderError,
+} from "../src/cursor-provider-errors.js";
+
+describe("cursor-provider-errors", () => {
+	it("builds run metadata when SDK result text is the generic failure string", () => {
+		const detail = formatCursorSdkRunFailureDetail({
+			id: "run-abc123456789",
+			status: "error",
+			result: "Cursor SDK run failed",
+			model: { id: "composer-2.5" },
+			durationMs: 1200,
+		});
+
+		expect(detail).toContain("model composer-2.5");
+		expect(detail).toContain("run run-abc1…");
+		expect(detail).toContain("1200ms");
+		expect(detail).not.toBe("Cursor SDK run failed");
+	});
+
+	it("prefers non-generic SDK result text", () => {
+		const detail = formatCursorSdkRunFailureDetail({
+			id: "run-1",
+			status: "error",
+			result: "MCP tool call timed out after 60s",
+		});
+
+		expect(detail).toBe("MCP tool call timed out after 60s");
+	});
+
+	it("falls back to run.result when wait result text is generic", () => {
+		const detail = formatCursorSdkRunFailureDetail(
+			{ id: "run-2", status: "error", result: "Cursor SDK run failed" },
+			"ConnectError: read ETIMEDOUT",
+		);
+
+		expect(detail).toBe("ConnectError: read ETIMEDOUT");
+	});
+
+	it("scrubs secrets and maps generic startup errors to actionable auth guidance", () => {
+		expect(sanitizeCursorProviderError(new Error("Error"), "test-key")).toContain("Cursor SDK request failed");
+		expect(sanitizeCursorProviderError(new Error("Unauthorized Bearer secret-key"), "secret-key")).toContain(
+			"invalid or unauthorized",
+		);
+		expect(sanitizeCursorProviderError(new Error("Bearer secret-key"), "secret-key")).not.toContain("secret-key");
+	});
+
+	it("preserves scrubbed run failure metadata in provider errors", () => {
+		const detail = formatCursorSdkRunFailureDetail({ id: "run-3", status: "error" });
+		const message = sanitizeCursorProviderError(detail, "test-key");
+
+		expect(message).toContain("run run-3");
+		expect(message).toContain("Cursor SDK run failed");
+	});
+
+	it("formats abort causes deterministically", () => {
+		expect(formatCursorSdkAbortMessage(resolveCursorSdkAbortCause({ signalAborted: true }))).toBe(
+			"Cancelled: prompt interrupted.",
+		);
+		expect(formatCursorSdkAbortMessage(resolveCursorSdkAbortCause({ sdkStatusCancelled: true }))).toBe(
+			"Cancelled: Cursor SDK run was cancelled.",
+		);
+		expect(formatCursorSdkAbortMessage(resolveCursorSdkAbortCause({ liveRunDisposed: true }))).toBe(
+			"Cancelled: Cursor SDK live run ended before completion.",
+		);
+	});
+});

--- a/test/cursor-provider-stream-auth.test.ts
+++ b/test/cursor-provider-stream-auth.test.ts
@@ -60,6 +60,7 @@ it("aborts after agent creation without sending a prompt when already cancelled"
 
 		expect(error.reason).toBe("aborted");
 		expect(error.error.stopReason).toBe("aborted");
+		expect(error.error.errorMessage).toBe("Cancelled: prompt interrupted.");
 		expect(mockSend).not.toHaveBeenCalled();
 		expect(mockDispose).toHaveBeenCalledTimes(1);
 	});

--- a/test/cursor-sensitive-text.test.ts
+++ b/test/cursor-sensitive-text.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { scrubPiToolDisplay, scrubSensitiveText } from "../src/cursor-sensitive-text.js";
+
+describe("cursor-sensitive-text", () => {
+	it("redacts loopback bridge MCP endpoint URLs", () => {
+		const endpointToken = "secret-endpoint-token-abc123";
+		const fullUrl = `http://127.0.0.1:54321/cursor-pi-tool-bridge/${endpointToken}/mcp`;
+		const scrubbed = scrubSensitiveText(`MCP connect failed: ${fullUrl}`);
+
+		expect(scrubbed).toBe("MCP connect failed: [redacted-bridge-endpoint]");
+		expect(scrubbed).not.toContain(endpointToken);
+		expect(scrubbed).not.toContain("127.0.0.1");
+		expect(scrubbed).not.toContain("/cursor-pi-tool-bridge/");
+	});
+
+	it("redacts bridge endpoint paths without a host", () => {
+		const endpointToken = "secret-endpoint-token-path";
+		const path = `/cursor-pi-tool-bridge/${endpointToken}/mcp`;
+		const scrubbed = scrubSensitiveText(`route not found: ${path}`);
+
+		expect(scrubbed).toBe("route not found: [redacted-bridge-endpoint]");
+		expect(scrubbed).not.toContain(endpointToken);
+	});
+
+	it("redacts host-only bridge endpoint references", () => {
+		const endpointToken = "secret-endpoint-token-host";
+		const hostPath = `127.0.0.1:8080/cursor-pi-tool-bridge/${endpointToken}/mcp`;
+		const scrubbed = scrubSensitiveText(`fetch failed for ${hostPath}`);
+
+		expect(scrubbed).toBe("fetch failed for [redacted-bridge-endpoint]");
+		expect(scrubbed).not.toContain(endpointToken);
+	});
+
+	it("still redacts API keys, bearer tokens, and field-style secrets", () => {
+		const apiKey = "super-secret-cursor-key-12345";
+		const sample = `Bearer ${apiKey} api_key=${apiKey} http://127.0.0.1:1/cursor-pi-tool-bridge/bridge-token/mcp`;
+		const scrubbed = scrubSensitiveText(sample, apiKey);
+
+		expect(scrubbed).not.toContain(apiKey);
+		expect(scrubbed).toContain("Bearer [redacted]");
+		expect(scrubbed).toContain("api_key=[redacted]");
+		expect(scrubbed).toContain("[redacted-bridge-endpoint]");
+	});
+
+	it("scrubs bridge endpoint material from nested pi tool display values", () => {
+		const endpointToken = "secret-endpoint-token-display";
+		const display = scrubPiToolDisplay({
+			title: "Bridge tool",
+			args: { endpoint: `/cursor-pi-tool-bridge/${endpointToken}/mcp` },
+			result: {
+				content: [{ type: "text", text: `failed at http://127.0.0.1:9999/cursor-pi-tool-bridge/${endpointToken}/mcp` }],
+			},
+		});
+
+		expect(JSON.stringify(display)).not.toContain(endpointToken);
+		expect(JSON.stringify(display)).not.toContain("127.0.0.1");
+		expect(JSON.stringify(display)).toContain("[redacted-bridge-endpoint]");
+	});
+});


### PR DESCRIPTION
## Summary
- Add `cursor-provider-errors` helpers to extract scrubbed SDK run failure detail (including model, short run id, duration when SDK text is generic) and format abort causes.
- Propagate `partial.errorMessage` on abort paths (user interrupt, SDK cancel, live-run dispose) through provider and live-run drain.
- Redact pi bridge MCP endpoint material (`127.0.0.1:*/cursor-pi-tool-bridge/<token>/mcp` and path-only variants) from canonical `scrubSensitiveText` used by provider errors and replay display.
- Update README troubleshooting and unit tests for error/abort message propagation and bridge endpoint scrubbing.

Fixes #55.

## Test plan
- [x] `npm test` (416 tests)
- [x] `npm run typecheck`
- [x] `npm pack --dry-run`
- [x] `gh pr view 63 --json closingIssuesReferences` (closes #55 only)
- [x] Live smoke: isolated `HOME` + `npm run smoke:live` from independent #55 worktree passed prereq/basic/default-settings/noninteractive-math/tui/steering/diagnostics/jsonl (`/tmp/pi-cursor-sdk-live-smoke-issue55-independent-20260525T103039`)

## Notes
- Unrelated to #40 and #43 (error surfacing only).
- Independent of PR #56 (`feature/provider-sdk-event-debug`); branch rebuilt onto current `main` without debug-capture commits.
- Merge-checked against PR #56 via `git merge-tree --write-tree origin/feature/provider-sdk-event-debug HEAD`: auto-merges cleanly except one expected content conflict in `src/cursor-provider-live-run-drain.ts` where #55 adds abort `partial.errorMessage` handling and #56 wraps drain outcomes for debug capture. Resolve by keeping both behaviors when #56 lands.

Made with [Cursor](https://cursor.com)
