### PR TITLE
fix: bound ConnectError/ETIMEDOUT at Cursor SDK async boundaries (#43)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,8 @@ When a Cursor run fails after auth is configured, pi now surfaces scrubbed provi
 
 Aborted runs now include a likely cause when determinable, for example `Cancelled: prompt interrupted.` for user cancel or `Cancelled: Cursor SDK run was cancelled.` for SDK-side cancellation.
 
+Network timeouts from the Cursor SDK connect layer (for example `ConnectError: read ETIMEDOUT`) surface as a scrubbed retry hint instead of crashing pi. Check your connection and retry; persistent timeouts may indicate a transient Cursor service or network issue.
+
 You can also restart pi with a key in the same shell or launcher that starts pi:
 
 ```bash

--- a/src/cursor-live-run-coordinator.ts
+++ b/src/cursor-live-run-coordinator.ts
@@ -440,7 +440,9 @@ export function createCursorLiveRunCoordinator(deps: CursorLiveRunCoordinatorDep
 			if (state.leased || state.leaseQueue.length > 0) return;
 			state.idleDisposeRequested = false;
 			state.idleDisposeTimer = setTimeout(() => {
-				void coordinator.release(run);
+				void coordinator.release(run).catch(() => {
+					// Idle dispose must not leave release failures as unhandled rejections.
+				});
 			}, deps.getIdleDisposeMs());
 			state.idleDisposeTimer.unref?.();
 		},

--- a/src/cursor-provider-errors.ts
+++ b/src/cursor-provider-errors.ts
@@ -7,6 +7,8 @@ const GENERIC_CURSOR_SDK_ERROR_MESSAGE =
 	"Cursor SDK request failed. The API key may be missing, invalid, or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
 const AUTH_CURSOR_SDK_ERROR_MESSAGE =
 	"Cursor SDK request failed because the API key may be invalid or unauthorized. Run /login -> Use an API key -> Cursor, verify CURSOR_API_KEY, or pass --api-key, then retry.";
+const NETWORK_CURSOR_SDK_ERROR_MESSAGE =
+	"Cursor SDK request timed out during network I/O. Check your connection and retry; if this keeps happening, try again later or verify Cursor service availability.";
 
 const GENERIC_CURSOR_RUN_FAILURE_TEXT = "cursor sdk run failed";
 
@@ -24,6 +26,14 @@ function isKnownGenericRunFailureText(message: string): boolean {
 
 function isLikelyAuthError(message: string): boolean {
 	return /\b(unauthorized|unauthorised|forbidden|invalid api key|invalid key|authentication|auth|401|403)\b/i.test(message);
+}
+
+function isLikelyNetworkTimeout(message: string): boolean {
+	return (
+		/\b(ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENETUNREACH|EAI_AGAIN)\b/i.test(message) ||
+		/\bConnectError\b.*\b(unavailable|deadline|timeout|timed out)\b/i.test(message) ||
+		/\bread ETIMEDOUT\b/i.test(message)
+	);
 }
 
 function shortRunId(runId: string): string {
@@ -81,5 +91,6 @@ export function sanitizeCursorProviderError(error: unknown, apiKey?: string): st
 	const scrubbed = scrubSensitiveText(message, apiKey).trim();
 	if (isGenericErrorMessage(scrubbed)) return GENERIC_CURSOR_SDK_ERROR_MESSAGE;
 	if (isLikelyAuthError(scrubbed)) return AUTH_CURSOR_SDK_ERROR_MESSAGE;
+	if (isLikelyNetworkTimeout(scrubbed)) return NETWORK_CURSOR_SDK_ERROR_MESSAGE;
 	return scrubbed || GENERIC_CURSOR_SDK_ERROR_MESSAGE;
 }

--- a/src/cursor-provider.ts
+++ b/src/cursor-provider.ts
@@ -129,7 +129,17 @@ export function streamCursor(
 		let sdkEventDebug: CursorSdkEventDebugSink | undefined;
 		let deferSdkEventDebugFinalize = false;
 
+		const pushSanitizedStreamError = (error: unknown, reason: "error" | "aborted" = "error"): void => {
+			partial.stopReason = reason;
+			partial.errorMessage =
+				reason === "aborted"
+					? formatCursorSdkAbortMessage(resolveCursorSdkAbortCause({ signalAborted: options?.signal?.aborted }))
+					: sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey);
+			stream.push({ type: "error", reason, error: partial });
+		};
+
 		try {
+			try {
 			const throwIfAborted = (): void => {
 				if (options?.signal?.aborted) throw new CursorLiveRunAbortError();
 			};
@@ -150,7 +160,6 @@ export function streamCursor(
 				sdkEventDebug?.recordFinalPartial(partial);
 				await sdkEventDebug?.finalize();
 				sdkEventDebugRef.current = undefined;
-				stream.end();
 				return;
 			}
 
@@ -417,36 +426,41 @@ export function streamCursor(
 				applyCursorApproximateUsage(partial, model, context, promptInputTokens);
 				stream.push({ type: "done", reason: "stop", message: partial });
 			}
-		} catch (error) {
-			sdkEventDebug?.recordError("provider_stream", error);
-			if (activeLiveRun && !activeLiveRun.disposed) await cursorLiveRuns.release(activeLiveRun);
-			else await abandonSessionCursorAgent(sessionAgentScopeKey);
-			if (error instanceof CursorLiveRunAbortError) {
-				partial.stopReason = "aborted";
-				partial.errorMessage = formatCursorSdkAbortMessage(
-					resolveCursorSdkAbortCause({ signalAborted: options?.signal?.aborted }),
-				);
-				stream.push({ type: "error", reason: "aborted", error: partial });
-			} else {
-				partial.stopReason = "error";
-				partial.errorMessage = sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey);
-				stream.push({ type: "error", reason: "error", error: partial });
-			}
-		} finally {
-			if (!deferSdkEventDebugFinalize) {
-				sdkEventDebug?.recordFinalPartial(partial);
-				await sdkEventDebug?.finalize();
-			}
-			sdkEventDebugRef.current = undefined;
-			restoreCursorSdkOutputFilter?.();
+			} catch (error) {
+				sdkEventDebug?.recordError("provider_stream", error);
+				if (activeLiveRun && !activeLiveRun.disposed) await cursorLiveRuns.release(activeLiveRun);
+				else await abandonSessionCursorAgent(sessionAgentScopeKey);
+				if (error instanceof CursorLiveRunAbortError) {
+					pushSanitizedStreamError(error, "aborted");
+				} else {
+					pushSanitizedStreamError(error, "error");
+				}
+			} finally {
+				if (!deferSdkEventDebugFinalize) {
+					sdkEventDebug?.recordFinalPartial(partial);
+					await sdkEventDebug?.finalize();
+				}
+				sdkEventDebugRef.current = undefined;
+				restoreCursorSdkOutputFilter?.();
 
-			if (abortSignal && abortListener) {
-				abortSignal.removeEventListener("abort", abortListener);
+				if (abortSignal && abortListener) {
+					abortSignal.removeEventListener("abort", abortListener);
+				}
 			}
+		} catch (error) {
+			if (activeLiveRun && !activeLiveRun.disposed) await cursorLiveRuns.release(activeLiveRun).catch(() => {});
+			else await abandonSessionCursorAgent(sessionAgentScopeKey).catch(() => {});
+			pushSanitizedStreamError(error, "error");
 		}
 
 		stream.end();
-	})();
+	})().catch((error: unknown) => {
+		const partial = makeInitialMessage(model);
+		partial.stopReason = "error";
+		partial.errorMessage = sanitizeCursorProviderError(error, resolveCursorApiKey(options?.apiKey));
+		stream.push({ type: "error", reason: "error", error: partial });
+		stream.end();
+	});
 
 	return stream;
 }

--- a/src/cursor-session-agent.ts
+++ b/src/cursor-session-agent.ts
@@ -153,8 +153,14 @@ async function disposePoolEntryForScope(scopeKey: string, options?: { terminal?:
 	const entry = sessionAgentsByScope.get(scopeKey);
 	invalidatedScopeKeys.delete(scopeKey);
 	if (!entry) return;
+	const orphanedCreating = entry.creating;
 	sessionAgentsByScope.delete(scopeKey);
-	if (entry.creating || !entry.agent) return;
+	if (entry.creating || !entry.agent) {
+		orphanedCreating?.catch(() => {
+			// In-flight Agent.create was orphaned by scope disposal; active waiters surface errors elsewhere.
+		});
+		return;
+	}
 	await disposePoolEntry(entry);
 }
 

--- a/test/cursor-provider-connect-timeout.test.ts
+++ b/test/cursor-provider-connect-timeout.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	collectEvents,
+	getErrorEvent,
+	makeContext,
+	makeModel,
+	mockedCreate,
+	registerNativeToolDisplayForTest,
+	resetCursorProviderTestState,
+} from "./helpers/cursor-provider-harness.js";
+import { streamCursor } from "../src/cursor-provider.js";
+
+function trackUnhandledRejections(): { rejections: unknown[]; restore: () => void } {
+	const rejections: unknown[] = [];
+	const onUnhandledRejection = (reason: unknown) => {
+		rejections.push(reason);
+	};
+	process.on("unhandledRejection", onUnhandledRejection);
+	return {
+		rejections,
+		restore: () => {
+			process.off("unhandledRejection", onUnhandledRejection);
+		},
+	};
+}
+
+function makeConnectTimeoutError(): Error {
+	const error = new Error("ConnectError: [unavailable] read ETIMEDOUT");
+	error.name = "ConnectError";
+	return error;
+}
+
+describe("streamCursor connect timeout boundary", () => {
+	beforeEach(resetCursorProviderTestState);
+	afterEach(() => {
+		delete process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY;
+	});
+
+	it("surfaces ConnectError from run.wait on the text-only path without unhandled rejections", async () => {
+		const { rejections, restore } = trackUnhandledRejections();
+		const connectError = makeConnectTimeoutError();
+		const mockSend = vi.fn().mockResolvedValue({
+			id: "run-timeout",
+			agentId: "agent-1",
+			status: "running",
+			wait: vi.fn().mockRejectedValue(connectError),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		try {
+			const events = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+			const error = getErrorEvent(events);
+			expect(error.reason).toBe("error");
+			expect(error.error.errorMessage).toContain("timed out during network I/O");
+			expect(error.error.errorMessage).toContain("Check your connection and retry");
+			expect(rejections).toEqual([]);
+		} finally {
+			restore();
+		}
+	});
+
+	it("surfaces ConnectError from background run.wait on the live-run path without unhandled rejections", async () => {
+		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
+		await registerNativeToolDisplayForTest([]);
+		const { rejections, restore } = trackUnhandledRejections();
+		const connectError = makeConnectTimeoutError();
+		const mockSend = vi.fn().mockResolvedValue({
+			id: "run-live-timeout",
+			agentId: "agent-1",
+			status: "running",
+			wait: vi.fn().mockRejectedValue(connectError),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		});
+		mockedCreate.mockResolvedValue({
+			agentId: "agent-1",
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		try {
+			const events = await collectEvents(streamCursor(makeModel(), makeContext(), { apiKey: "test-key" }));
+			const error = getErrorEvent(events);
+			expect(error.reason).toBe("error");
+			expect(error.error.errorMessage).toContain("timed out during network I/O");
+			expect(rejections).toEqual([]);
+		} finally {
+			restore();
+		}
+	});
+});

--- a/test/cursor-provider-errors.test.ts
+++ b/test/cursor-provider-errors.test.ts
@@ -72,6 +72,16 @@ describe("cursor-provider-errors", () => {
 		expect(message).not.toContain("/cursor-pi-tool-bridge/");
 	});
 
+	it("maps connect-layer network timeouts to actionable retry guidance", () => {
+		expect(sanitizeCursorProviderError(new Error("ConnectError: [unavailable] read ETIMEDOUT"), "test-key")).toContain(
+			"timed out during network I/O",
+		);
+		expect(sanitizeCursorProviderError("ConnectError: read ETIMEDOUT", "test-key")).toContain("Check your connection and retry");
+		expect(sanitizeCursorProviderError(new Error("ConnectError: [unavailable] read ETIMEDOUT"), "test-key")).not.toContain(
+			"ETIMEDOUT",
+		);
+	});
+
 	it("formats abort causes deterministically", () => {
 		expect(formatCursorSdkAbortMessage(resolveCursorSdkAbortCause({ signalAborted: true }))).toBe(
 			"Cancelled: prompt interrupted.",

--- a/test/cursor-session-agent.test.ts
+++ b/test/cursor-session-agent.test.ts
@@ -203,6 +203,41 @@ describe("cursor-session-agent", () => {
 		expect(mockDispose).not.toHaveBeenCalled();
 	});
 
+	it("does not leave ConnectError from orphaned Agent.create as an unhandled rejection", async () => {
+		const rejections: unknown[] = [];
+		const onUnhandledRejection = (reason: unknown) => {
+			rejections.push(reason);
+		};
+		process.on("unhandledRejection", onUnhandledRejection);
+
+		let rejectCreate: (error: Error) => void = () => {};
+		const mockDisposeLate = vi.fn().mockResolvedValue(undefined);
+		const createAgent = vi.fn().mockImplementation(
+			() =>
+				new Promise((_resolve, reject) => {
+					rejectCreate = reject;
+				}),
+		);
+
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/test.jsonl");
+		const params = {
+			apiKey: "test-key",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+
+		const acquirePromise = acquireSessionCursorAgent(params);
+		await vi.waitFor(() => expect(createAgent).toHaveBeenCalledTimes(1));
+		await sessionAgentTestUtils.disposeSessionCursorAgent("/tmp/sessions/test.jsonl");
+		rejectCreate(new Error("ConnectError: [unavailable] read ETIMEDOUT"));
+
+		await expect(acquirePromise).rejects.toThrow("ConnectError: [unavailable] read ETIMEDOUT");
+		await Promise.resolve();
+		expect(rejections).toEqual([]);
+		process.off("unhandledRejection", onUnhandledRejection);
+	});
+
 	it("detects when a follow-up send should bootstrap after branch shrink", () => {
 		const sendState = {
 			bootstrapped: true,


### PR DESCRIPTION
## Summary
- Bound Cursor SDK connect-layer failures (`ConnectError`, `read ETIMEDOUT`) at provider/session-agent/live-run async boundaries so they surface as scrubbed pi error events instead of uncaught process exits.
- Map network timeout failures to actionable retry guidance while preserving #55 auth/generic scrubbing.
- Rebased onto latest `main` (includes #56 provider SDK event debug capture); nested error boundaries preserve SDK debug recording/finalization on provider stream failures.
- Document network-timeout behavior in README troubleshooting.

## Root cause
Connect RPC failures could escape as unhandled promise rejections when in-flight `Agent.create` work was orphaned by scope disposal, when idle live-run release rejected without a handler, or when provider stream cleanup threw outside the main catch path.

## Test plan
- [x] `npm test` (433 tests)
- [x] `npm run typecheck`
- [x] `npm pack --dry-run`
- [x] Added mocked regression tests for `run.wait()` ConnectError on text-only and live-run paths
- [x] Added session-agent orphaned-create ConnectError regression test
- [x] Live smoke: isolated HOME + temp `--session-dir`, `PI_CURSOR_SETTING_SOURCES=none pi -e . --cursor-no-fast --model cursor/composer-2.5 --no-tools -p "Live smoke. Reply exactly: PI_CURSOR_SMOKE_OK"` exited 0, stdout contained `PI_CURSOR_SMOKE_OK`, stderr was empty, and a session JSONL file was written. The first non-isolated attempt exposed a duplicate ambient extension load, so the passing run used a copied pi auth file under isolated HOME without printing secrets.

Fixes #43
