### PR TITLE
Harden Cursor web search/fetch activity labels (fixes #66)

### DIFF
--- a/docs/cursor-native-tool-replay.md
+++ b/docs/cursor-native-tool-replay.md
@@ -83,9 +83,11 @@ This matrix covers **Cursor native tool replay only**. It does not describe the 
 | `createPlan` | neutral activity | `cursor` | Collapsed label **Cursor plan**; display-only, does not drive pi plan mode |
 | `task` | neutral activity | `cursor` | Collapsed label **Cursor task** |
 | `generateImage` | neutral activity | `cursor` | Collapsed label **Cursor image generation** |
-| `mcp` | neutral activity | `cursor` | Collapsed label **Cursor MCP**; includes host/MCP completions routed as SDK `mcp` |
+| `mcp` | neutral activity | `cursor` | Collapsed label **Cursor MCP** for non-web MCP completions; web search/fetch MCP `toolName` values reclassify to the rows below |
 | `semSearch` | neutral activity | `cursor` | Collapsed label **Cursor semantic search**; semantic codebase search, not web search |
 | `recordScreen` | neutral activity | `cursor` | Collapsed label **Cursor screen recording** |
+| *(host/MCP alias)* `WebSearch` / `web_search` / similar | neutral activity | `cursor` | Collapsed label **Cursor web search**; display-only Cursor web access reported by the SDK, not an executable pi web tool |
+| *(host/MCP alias)* `WebFetch` / `web_fetch` / similar | neutral activity | `cursor` | Collapsed label **Cursor web fetch**; display-only Cursor web access reported by the SDK, not an executable pi web tool |
 
 **Fallback path:** SDK tool names with no spec entry (future or unknown types) use `formatCursorToolTranscriptFromSpec()` → `formatFallback()` in `src/cursor-transcript-tool-formatters.ts`. Those completions still appear as bounded scrubbed transcript activity, not native pi tool cards.
 
@@ -104,8 +106,10 @@ Before lookup in `TOOL_DISPLAY_SPECS`, completed SDK tool names pass through `no
 | `file_search` | `glob` |
 | `write_file`, `writefile` | `write` |
 | `strreplace`, `str_replace`, `str-replace`, `edit_file`, `editfile`, `edit_notebook`, `editnotebook`, `notebook_edit`, `notebookedit` | `edit` |
+| `websearch`, `web_search`, `web-search` | `webSearch` (via `resolveTranscriptToolName()`) |
+| `webfetch`, `web_fetch`, `web-fetch` | `webFetch` (via `resolveTranscriptToolName()`) |
 
-Unlisted aliases keep their original name and fall through to the spec lookup or fallback transcript path.
+Unlisted aliases keep their original name and fall through to the spec lookup or fallback transcript path. SDK `mcp` completions whose nested `toolName` is `WebSearch` / `web_search` / `WebFetch` / `web_fetch` (or `tool_name`) also resolve to `webSearch` / `webFetch` before display lookup.
 
 ## Intentional mappings and fallbacks
 
@@ -117,6 +121,7 @@ These behaviors are by design. They are not pi replay execution bugs:
 - **`write`:** native pi `write` cards only when recorded content/path args satisfy pi's schema; otherwise neutral **Cursor write** activity.
 - **Plan/todo tools:** `createPlan` and `updateTodos` replay is display-only and does not drive pi plan mode or pi todo state (see [What replay does not do](#what-replay-does-not-do)).
 - **`semSearch`:** semantic codebase search activity, not web search.
+- **Web search/fetch:** visible **Cursor web search** / **Cursor web fetch** activity when the SDK reports completed replayable tool data (SDK `mcp` with web `toolName` or host aliases above). These cards are display-only; pi does not expose executable web search/fetch tools through replay.
 - **Unknown/future SDK tools:** bounded scrubbed activity transcript fallback until a spec is added.
 
 ## What replay does not do
@@ -128,6 +133,7 @@ Native replay is display-only:
 - pi does not call Cursor-side MCP servers.
 - replay-only cards do not update pi state or generate images.
 - replay does not expose pi tool schemas to Cursor; the local pi MCP bridge is the separate path that exposes active pi tools.
+- replay does not add pi web search, web fetch, or browser tools; **Cursor web search** / **Cursor web fetch** cards only mirror SDK-reported Cursor web activity.
 - Cursor workflow tools such as `SwitchMode` and Cursor todo state are not pi workflow controls; reported todo/plan events are displayed as Cursor activity only. Plan/todo replay cards do not drive pi plan-mode state.
 
 If a Cursor read completion reports no content, the extension may include a bounded local file preview for safe in-workspace paths. That preview is labeled as a local preview captured at transcript time, not guaranteed Cursor-observed content.

--- a/src/cursor-web-tool-activity.ts
+++ b/src/cursor-web-tool-activity.ts
@@ -28,6 +28,12 @@ function getNestedMcpArgs(args: Record<string, unknown>): Record<string, unknown
 	return nested && typeof nested === "object" && !Array.isArray(nested) ? (nested as Record<string, unknown>) : {};
 }
 
+function getMcpToolName(args: Record<string, unknown>): string | undefined {
+	const toolName = typeof args.toolName === "string" ? args.toolName : typeof args.tool_name === "string" ? args.tool_name : undefined;
+	const trimmed = toolName?.trim();
+	return trimmed || undefined;
+}
+
 function firstNonEmptyString(...values: Array<string | undefined>): string | undefined {
 	for (const value of values) {
 		const trimmed = value?.trim();
@@ -71,8 +77,7 @@ export function resolveTranscriptToolName(rawName: string, args: Record<string, 
 	const directWebKind = classifyCursorWebToolKind(rawName) ?? classifyCursorWebToolKind(normalized);
 	if (directWebKind) return directWebKind;
 	if (normalized === "mcp") {
-		const mcpToolName = typeof args.toolName === "string" ? args.toolName : undefined;
-		const mcpWebKind = classifyCursorWebToolKind(mcpToolName);
+		const mcpWebKind = classifyCursorWebToolKind(getMcpToolName(args));
 		if (mcpWebKind) return mcpWebKind;
 	}
 	return normalized;

--- a/test/cursor-tool-transcript.test.ts
+++ b/test/cursor-tool-transcript.test.ts
@@ -473,6 +473,40 @@ describe("formatCursorToolTranscript", () => {
 		expect(transcript).not.toContain("base64-image-data");
 	});
 
+	it("labels completed Cursor web search MCP activity instead of generic Cursor MCP", () => {
+		const toolCall = {
+			name: "mcp",
+			args: { toolName: "WebSearch", args: { search_term: "pi extension" } },
+			result: { status: "success", value: { content: [{ text: { text: "result snippet" } }], isError: false } },
+		};
+		const display = buildCursorPiToolDisplay(toolCall);
+		const transcript = formatCursorToolTranscript(toolCall);
+
+		expect(display).toMatchObject({
+			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
+			args: { query: "pi extension", activityTitle: "Cursor web search", activitySummary: "pi extension" },
+			result: { details: { cursorToolName: "webSearch", title: "Cursor web search" } },
+		});
+		expect(display.args.activityTitle).not.toBe("Cursor MCP");
+		expect(transcript).toContain("web search pi extension");
+		expect(transcript).not.toContain("WebSearch\n");
+	});
+
+	it("labels completed Cursor web fetch host activity with bounded URL summary", () => {
+		const toolCall = {
+			name: "web_fetch",
+			args: { url: "https://example.com/docs" },
+			result: { status: "success", value: { content: [{ text: { text: "docs page" } }], isError: false } },
+		};
+		const display = buildCursorPiToolDisplay(toolCall);
+
+		expect(display).toMatchObject({
+			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
+			args: { url: "https://example.com/docs", activityTitle: "Cursor web fetch", activitySummary: "https://example.com/docs" },
+			result: { details: { cursorToolName: "webFetch", title: "Cursor web fetch" } },
+		});
+	});
+
 	it("formats completed semSearch activity with bounded results text", () => {
 		const results = "src/index.ts:42 — export function main()\nsrc/util.ts:10 — helper";
 		const display = buildCursorPiToolDisplay({

--- a/test/cursor-web-tool-activity.test.ts
+++ b/test/cursor-web-tool-activity.test.ts
@@ -9,11 +9,37 @@ import { buildCursorPiToolDisplay, formatCursorToolTranscript } from "../src/cur
 import { CURSOR_REPLAY_ACTIVITY_TOOL_NAME } from "../src/cursor-tool-names.js";
 
 describe("cursor web tool activity", () => {
-	it("classifies host and MCP web tool names separately from semSearch", () => {
-		expect(classifyCursorWebToolKind("WebSearch")).toBe("webSearch");
-		expect(classifyCursorWebToolKind("web_fetch")).toBe("webFetch");
+	it.each([
+		["WebSearch", "webSearch"],
+		["web_search", "webSearch"],
+		["web-search", "webSearch"],
+		["websearch", "webSearch"],
+		["WebFetch", "webFetch"],
+		["web_fetch", "webFetch"],
+		["web-fetch", "webFetch"],
+		["webfetch", "webFetch"],
+	])("classifies host tool name %s as %s", (name, expected) => {
+		expect(classifyCursorWebToolKind(name)).toBe(expected);
+		expect(resolveTranscriptToolName(name, {})).toBe(expected);
+	});
+
+	it.each([
+		["WebSearch", "webSearch"],
+		["web_search", "webSearch"],
+		["WebFetch", "webFetch"],
+		["web_fetch", "webFetch"],
+	])("reclassifies MCP toolName %s to %s display", (mcpToolName, expected) => {
+		expect(resolveTranscriptToolName("mcp", { toolName: mcpToolName })).toBe(expected);
+		expect(resolveTranscriptToolName("mcp", { tool_name: mcpToolName })).toBe(expected);
+	});
+
+	it("keeps semSearch separate from web search", () => {
 		expect(classifyCursorWebToolKind("semSearch")).toBeUndefined();
 		expect(resolveTranscriptToolName("semSearch", {})).toBe("semSearch");
+	});
+
+	it("leaves non-web MCP tools on the generic mcp path", () => {
+		expect(resolveTranscriptToolName("mcp", { toolName: "git" })).toBe("mcp");
 	});
 
 	it("reclassifies MCP WebSearch completions to webSearch display", () => {
@@ -36,8 +62,25 @@ describe("cursor web tool activity", () => {
 			result: { details: { cursorToolName: "webSearch", title: "Cursor web search", summary: "web search pi mathematics" } },
 			isError: false,
 		});
+		expect(display.args).not.toMatchObject({ activityTitle: "Cursor MCP" });
 		expect(formatCursorToolTranscript(toolCall)).toContain("web search pi mathematics");
 		expect(formatCursorToolTranscript(toolCall)).toContain("Example Domain");
+	});
+
+	it("formats MCP web_search completions as Cursor web search activity", () => {
+		const toolCall = {
+			name: "mcp",
+			args: { toolName: "web_search", args: { query: "typescript sdk" } },
+			result: { status: "success", value: { content: [{ text: { text: "SDK docs" } }], isError: false } },
+		};
+
+		const display = buildCursorPiToolDisplay(toolCall);
+		expect(display).toMatchObject({
+			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
+			args: { query: "typescript sdk", activityTitle: "Cursor web search", activitySummary: "typescript sdk" },
+			result: { details: { cursorToolName: "webSearch", title: "Cursor web search" } },
+		});
+		expect(formatCursorToolTranscript(toolCall)).toContain("web search typescript sdk");
 	});
 
 	it("formats host WebFetch completions as Cursor web fetch activity", () => {
@@ -59,5 +102,22 @@ describe("cursor web tool activity", () => {
 			args: { url: "https://example.com", activityTitle: "Cursor web fetch", activitySummary: "https://example.com" },
 			result: { details: { cursorToolName: "webFetch", title: "Cursor web fetch" } },
 		});
+		expect(display.args).not.toMatchObject({ activityTitle: "Cursor MCP" });
+	});
+
+	it("formats MCP web_fetch completions as Cursor web fetch activity", () => {
+		const toolCall = {
+			name: "mcp",
+			args: { toolName: "web_fetch", args: { url: "https://example.org/page" } },
+			result: { status: "success", value: { content: [{ text: { text: "Fetched page" } }], isError: false } },
+		};
+
+		const display = buildCursorPiToolDisplay(toolCall);
+		expect(display).toMatchObject({
+			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
+			args: { url: "https://example.org/page", activityTitle: "Cursor web fetch", activitySummary: "https://example.org/page" },
+			result: { details: { cursorToolName: "webFetch", title: "Cursor web fetch" } },
+		});
+		expect(formatCursorToolTranscript(toolCall)).toContain("web fetch https://example.org/page");
 	});
 });


### PR DESCRIPTION
## Summary
- Resolve SDK `mcp` web completions via `toolName`/`tool_name` into dedicated **Cursor web search** / **Cursor web fetch** activity cards instead of generic **Cursor MCP**.
- Expand unit/regression tests for host and MCP name variants (`WebSearch`, `web_search`, `WebFetch`, `web_fetch`) and keep `semSearch` labeled as semantic search.
- Document the display-only web activity contract in `docs/cursor-native-tool-replay.md`.

## Test plan
- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm pack --dry-run`
- [x] Live smoke: `SKIP_UNIT=1 PI_LIVE_TIMEOUT=90 npm run smoke:isolated` (isolated `/tmp` HOME + packed extension; PASS at `/tmp/pi-cursor-sdk-isolated-20260525T120748`)

Closes #66

Made with [Cursor](https://cursor.com)
