### PR TITLE
fix: render unknown Cursor SDK tools as neutral activity cards (#69)

### DIFF
--- a/docs/cursor-native-tool-replay.md
+++ b/docs/cursor-native-tool-replay.md
@@ -88,8 +88,9 @@ This matrix covers **Cursor native tool replay only**. It does not describe the 
 | `recordScreen` | neutral activity | `cursor` | Collapsed label **Cursor screen recording** |
 | *(host/MCP alias)* `WebSearch` / `web_search` / similar | neutral activity | `cursor` | Collapsed label **Cursor web search**; display-only Cursor web access reported by the SDK, not an executable pi web tool |
 | *(host/MCP alias)* `WebFetch` / `web_fetch` / similar | neutral activity | `cursor` | Collapsed label **Cursor web fetch**; display-only Cursor web access reported by the SDK, not an executable pi web tool |
+| _(no spec; future/unknown SDK name)_ | neutral activity | `cursor` | Collapsed label **Cursor** plus SDK tool name via `buildGenericPiToolDisplay()`; bounded fallback transcript only |
 
-**Fallback path:** SDK tool names with no spec entry (future or unknown types) use `formatCursorToolTranscriptFromSpec()` → `formatFallback()` in `src/cursor-transcript-tool-formatters.ts`. Those completions still appear as bounded scrubbed transcript activity, not native pi tool cards.
+**Unknown/future fallback path:** SDK tool names with no `TOOL_DISPLAY_SPECS` entry (future or unknown types) use `buildGenericPiToolDisplay()` in `src/cursor-transcript-tool-specs.ts` with bounded `formatFallback()` content from `src/cursor-transcript-tool-formatters.ts`. When native replay is enabled, those completions queue through neutral pi tool name `cursor` (not native pi `read`/`bash`/… cards). Collapsed labels read like **Cursor futureSemSearchWidget** (title `Cursor` plus the SDK tool name) with optional bounded `activitySummary` from scrubbed args/result lines. Errors keep `details.summary` undefined so unbounded raw errors do not leak into replay cards (#52). Known explicit specs still win over this path; pi and bridge tool names are never shadowed.
 
 Neutral activity rows use pi tool name `cursor` with `activityTitle` / `activitySummary` metadata. Legacy internal replay label keys such as `cursor_sem_search` are compatibility details; user-visible collapsed cards use labels like **Cursor semantic search**.
 
@@ -122,7 +123,7 @@ These behaviors are by design. They are not pi replay execution bugs:
 - **Plan/todo tools:** `createPlan` and `updateTodos` replay is display-only and does not drive pi plan mode or pi todo state (see [What replay does not do](#what-replay-does-not-do)).
 - **`semSearch`:** semantic codebase search activity, not web search.
 - **Web search/fetch:** visible **Cursor web search** / **Cursor web fetch** activity when the SDK reports completed replayable tool data (SDK `mcp` with web `toolName` or host aliases above). These cards are display-only; pi does not expose executable web search/fetch tools through replay.
-- **Unknown/future SDK tools:** bounded scrubbed activity transcript fallback until a spec is added.
+- **Unknown/future SDK tools:** neutral Cursor activity cards titled with the SDK tool name (for example **Cursor futureSemSearchWidget**) and bounded scrubbed args/result/error text until an explicit spec is added.
 
 ## What replay does not do
 

--- a/src/cursor-transcript-tool-specs.ts
+++ b/src/cursor-transcript-tool-specs.ts
@@ -153,17 +153,28 @@ function buildActivityReplayDisplay(cursorToolName: string, spec: ToolDisplaySpe
 	);
 }
 
+function buildGenericUnknownToolActivityTitle(displayName: string): string {
+	if (displayName === "unknown") return "Cursor tool";
+	return `Cursor ${truncateArg(displayName)}`;
+}
+
 function buildGenericPiToolDisplay(context: ToolDisplayContext): CursorPiToolDisplay {
 	const { rawName, name, args, result, options } = context;
 	const displayName = rawName.trim() || name;
-	const activityTitle = getCursorReplayDisplayLabel(CURSOR_REPLAY_ACTIVITY_TOOL_NAME);
-	const activitySummary = truncateArg(displayName === "unknown" ? "tool" : displayName);
-	const activityArgs = buildCursorActivityDisplayArgs({ cursorToolName: activitySummary }, activityTitle, activitySummary);
+	const activityTitle = buildGenericUnknownToolActivityTitle(displayName);
 	const contentText = formatFallback(name, args, result, options);
+	const fallbackBody = contentText.includes("\n\n") ? contentText.slice(contentText.indexOf("\n\n") + 2) : "";
+	const activitySummary =
+		result.status === "error" ? undefined : firstNonEmptyLine(fallbackBody);
+	const activityArgs = buildCursorActivityDisplayArgs(
+		{ cursorToolName: displayName === "unknown" ? "tool" : displayName },
+		activityTitle,
+		activitySummary,
+	);
 	const summary =
 		result.status === "error"
 			? undefined
-			: firstNonEmptyLine(contentText) ?? activitySummary;
+			: activitySummary ?? truncateArg(displayName === "unknown" ? "tool" : displayName);
 	return buildReplaySummaryDisplay(CURSOR_REPLAY_ACTIVITY_TOOL_NAME, activityArgs, result, contentText, {
 		cursorToolName: name,
 		title: activityTitle,

--- a/test/cursor-tool-transcript.test.ts
+++ b/test/cursor-tool-transcript.test.ts
@@ -938,17 +938,17 @@ describe("formatCursorToolTranscript", () => {
 			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
 			args: {
 				cursorToolName: "futureSemSearchWidget",
-				activityTitle: "Cursor activity",
-				activitySummary: "futureSemSearchWidget",
+				activityTitle: "Cursor futureSemSearchWidget",
 			},
 			result: {
 				details: {
 					cursorToolName: "futureSemSearchWidget",
-					title: "Cursor activity",
+					title: "Cursor futureSemSearchWidget",
 				},
 			},
 			isError: false,
 		});
+		expect(display.args.activitySummary).toContain("query=");
 		expect(display.result.content[0].text.length).toBeLessThan(1200);
 	});
 
@@ -978,11 +978,11 @@ describe("formatCursorToolTranscript", () => {
 			toolName: CURSOR_REPLAY_ACTIVITY_TOOL_NAME,
 			args: {
 				cursorToolName: "futureBrokenWidget",
-				activityTitle: "Cursor activity",
-				activitySummary: "futureBrokenWidget",
+				activityTitle: "Cursor futureBrokenWidget",
 			},
 			isError: true,
 		});
+		expect(display.args.activitySummary).toBeUndefined();
 		expect(display.result.content[0].text.length).toBeLessThan(1200);
 		expect(display.result.content[0].text).not.toContain("x".repeat(500));
 		expect(display.result.details?.summary).toBeUndefined();


### PR DESCRIPTION
## Summary

- Unknown/future SDK tool completions without a `TOOL_DISPLAY_SPECS` entry now queue neutral `cursor` replay cards titled **Cursor \<sdk tool name\>** (for example **Cursor futureSemSearchWidget**), with bounded `formatFallback()` body text and optional scrubbed `activitySummary` from args/result lines.
- Error completions keep `details.summary` undefined (#52) while still showing bounded fallback content in the card body.
- Document the unknown/future fallback contract in `docs/cursor-native-tool-replay.md` (matrix row + fallback path), merged with #70 web search/fetch labels (**Cursor web search** / **Cursor web fetch**; `semSearch` remains semantic search).

Rebased onto `main` after #70 merged; docs conflict in `docs/cursor-native-tool-replay.md` resolved to keep both web activity labels and unknown-tool fallback documentation.

Builds on #52/#60 generic replay hardening; this PR finishes the #69 UX (tool name in title) and docs.

## Test plan

- [x] `npm test`
- [x] `npm run typecheck`
- [x] `npm pack --dry-run`
- [x] Live smoke: `SKIP_UNIT=1 PI_LIVE_TIMEOUT=90 npm run smoke:isolated` (isolated `/tmp` HOME + packed extension; PASS at `/tmp/pi-cursor-sdk-isolated-20260525T121910`)

Closes #69

Made with [Cursor](https://cursor.com)