### PR TITLE
Split CursorSdkTurnCoordinator into focused state components (#82)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,12 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-session-agent.ts` owns session-scoped SDK agent pooling, send-state commits, and lifecycle invalidation on compaction/tree/shutdown.
 - `src/cursor-session-send-policy.ts` owns session send planning (`bootstrap` vs `incremental`), periodic agent rebootstrap threshold, and prompt mode selection.
 - `src/cursor-provider-live-run-drain.ts` owns live-run drain/replay mirroring, pre-send continuation, and native replay turn emission.
-- `src/cursor-provider-turn-coordinator.ts` owns SDK delta/step handling, tool completion routing, and trace/native-replay emission during a turn.
+- `src/cursor-provider-turn-coordinator.ts` orchestrates SDK delta/step handling during a turn over focused collaborators.
+- `src/cursor-provider-turn-shell-output.ts` owns shell-output-delta tracking and merging into completed shell tool calls.
+- `src/cursor-provider-turn-tool-ledger.ts` owns started/completed tool identities, fingerprints, and duplicate suppression.
+- `src/cursor-provider-turn-sdk-normalizer.ts` normalizes SDK delta/step completions via the ledger and shell tracker.
+- `src/cursor-provider-turn-display-router.ts` owns trace vs native-replay display routing during a turn.
+- `src/cursor-provider-turn-lifecycle-emitter.ts` owns deferred in-progress lifecycle labels during a turn.
 - `src/cursor-tool-lifecycle.ts` owns low-noise deferred in-progress lifecycle labels for long-running Cursor tools (coalesced with completed replay cards; bridge excluded).
 - `src/cursor-tool-visibility.ts` owns canonical Cursor tool visibility classification for lifecycle, incomplete-tool, and replay activity titles.
 - `src/cursor-incomplete-tool-visibility.ts` owns bounded user-visible labels/traces for started Cursor SDK tool calls discarded without completion.

--- a/src/cursor-provider-turn-coordinator.ts
+++ b/src/cursor-provider-turn-coordinator.ts
@@ -2,109 +2,39 @@ import type { AssistantMessage, AssistantMessageEventStream } from "@earendil-wo
 import type { InteractionUpdate } from "@cursor/sdk";
 import type { CursorLiveRun } from "./cursor-live-run-coordinator.js";
 import { cursorLiveRuns } from "./cursor-provider-live-run-drain.js";
-import { formatInactiveCursorReplayTrace } from "./cursor-native-replay-trace.js";
-import { resolveNativeReplayDisposition } from "./cursor-native-replay-routing.js";
 import { truncateCursorDisplayLine } from "./cursor-display-text.js";
-import { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js";
-import { asRecord, getField, hasUsableText } from "./cursor-record-utils.js";
-import { scrubPiToolDisplay, scrubSensitiveText } from "./cursor-sensitive-text.js";
-import { buildCursorPiToolDisplay, formatCursorToolTranscript, getCursorCreatePlanText, mergeCursorToolCalls } from "./cursor-tool-transcript.js";
 import {
 	recordDiscardedIncompleteStartedToolCall,
 	type CursorSdkEventDebugRecorder,
-	DISCARDED_INCOMPLETE_TOOL_CALL_REASON,
 } from "./cursor-sdk-event-debug.js";
 import {
-	buildIncompleteCursorToolDisplay,
 	buildIncompleteCursorToolRunOutcome,
-	formatIncompleteCursorToolTrace,
 	resolveIncompleteCursorToolVisibility,
 	type IncompleteCursorToolRunOutcome,
-	type IncompleteCursorToolDiscardReason,
 } from "./cursor-incomplete-tool-visibility.js";
 import { getToolName } from "./cursor-transcript-utils.js";
-import {
-	CURSOR_TOOL_LIFECYCLE_DEFER_MS,
-	formatCursorToolLifecycleProgressText,
-	isCursorToolLifecycleEligible,
-} from "./cursor-tool-lifecycle.js";
 import { classifyCursorToolVisibility } from "./cursor-tool-visibility.js";
-
-function formatCursorToolName(toolCall: unknown): string {
-	return truncateCursorDisplayLine(getToolName(toolCall), 80) || "unknown";
-}
-
-interface CursorShellOutputDelta {
-	stream: "stdout" | "stderr";
-	data: string;
-}
-
-interface CursorShellOutputDeltas {
-	stdout: string[];
-	stderr: string[];
-}
+import { buildCursorPiToolDisplay } from "./cursor-tool-transcript.js";
+import { getField } from "./cursor-record-utils.js";
+import { CursorTurnDisplayRouter } from "./cursor-provider-turn-display-router.js";
+import {
+	createTurnCoordinatorContentEmitter,
+	CursorToolLifecycleEmitter,
+} from "./cursor-provider-turn-lifecycle-emitter.js";
+import { resolveCursorToolCompletion } from "./cursor-provider-turn-sdk-normalizer.js";
+import {
+	CursorShellOutputTracker,
+	getCursorShellOutputDelta,
+	isCursorShellToolCall,
+} from "./cursor-provider-turn-shell-output.js";
+import {
+	CursorToolCompletionLedger,
+	getToolFingerprint,
+} from "./cursor-provider-turn-tool-ledger.js";
 
 function getNormalizedCursorToolName(toolCall: unknown): string {
 	return classifyCursorToolVisibility(toolCall).normalizedName;
 }
-
-function isCursorShellToolCall(toolCall: unknown): boolean {
-	return classifyCursorToolVisibility(toolCall).normalizedKey === "shell";
-}
-
-function getCursorShellOutputDelta(update: InteractionUpdate): CursorShellOutputDelta | undefined {
-	if (update.type !== "shell-output-delta") return undefined;
-	const event = getField(update, "event");
-	const eventCase = getField(event, "case");
-	if (eventCase !== "stdout" && eventCase !== "stderr") return undefined;
-	const value = getField(event, "value");
-	const data = getField(value, "data");
-	if (typeof data !== "string" || data.length === 0) return undefined;
-	return { stream: eventCase, data };
-}
-
-function mergeShellOutputDeltasIntoCursorToolCall(toolCall: unknown, deltas: CursorShellOutputDeltas | undefined): unknown {
-	if (!deltas) return toolCall;
-	const stdout = deltas.stdout.join("");
-	const stderr = deltas.stderr.join("");
-	if (!hasUsableText(stdout) && !hasUsableText(stderr)) return toolCall;
-
-	const toolRecord = asRecord(toolCall);
-	const result = getField(toolRecord, "result");
-	const resultRecord = asRecord(result);
-	if (!toolRecord || !resultRecord || resultRecord.status !== "success") return toolCall;
-
-	const value = getField(resultRecord, "value");
-	const valueRecord = asRecord(value);
-	const completedStdout = getField(valueRecord, "stdout");
-	const completedStderr = getField(valueRecord, "stderr");
-	if (hasUsableText(typeof completedStdout === "string" ? completedStdout : undefined)) return toolCall;
-	if (hasUsableText(typeof completedStderr === "string" ? completedStderr : undefined)) return toolCall;
-
-	return {
-		...toolRecord,
-		result: {
-			...resultRecord,
-			value: {
-				...(valueRecord ?? {}),
-				stdout,
-				stderr,
-			},
-		},
-	};
-}
-
-type CursorToolDisplaySource = "started" | "fallback" | "transcript";
-
-type ToolCompletionResolution =
-	| { action: "ignore-bridge"; identity?: string }
-	| {
-			action: "handle";
-			toolCall: unknown;
-			identity?: string;
-			source?: CursorToolDisplaySource;
-			matchedStartedCallId?: string;
-	  };
 
 export interface CursorSdkTurnCoordinatorOptions {
 	stream: AssistantMessageEventStream;
@@ -130,21 +60,12 @@ export class CursorSdkTurnCoordinator {
 	readonly nativeReplayId: string;
 	readonly textDeltas: string[];
 
-	private readonly contentEmitter: CursorPartialContentEmitter;
 	private readonly debugRecorder?: CursorSdkEventDebugRecorder;
-	private nativeToolDisplayCounter = 0;
-	private nativeToolReplayStarted = false;
-	private cursorPlanTextCandidate: string | undefined;
-	private readonly startedToolCalls = new Map<string, unknown>();
-	private readonly bridgeStartedToolCallIds = new Set<string>();
-	private readonly activeShellCallIds = new Set<string>();
-	private readonly ambiguousShellOutputCallIds = new Set<string>();
-	private readonly shellOutputDeltasByCallId = new Map<string, CursorShellOutputDeltas>();
-	private readonly completedToolIdentities = new Set<string>();
-	private readonly completedStartedToolFingerprints = new Set<string>();
-	private readonly completedFallbackToolFingerprints = new Set<string>();
-	private readonly emittedLifecycleCallIds = new Set<string>();
-	private readonly lifecycleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	private readonly ledger = new CursorToolCompletionLedger();
+	private readonly shellOutput = new CursorShellOutputTracker();
+	private readonly displayRouter: CursorTurnDisplayRouter;
+	private readonly lifecycleEmitter: CursorToolLifecycleEmitter;
+	private readonly contentEmitter;
 
 	constructor(options: CursorSdkTurnCoordinatorOptions) {
 		this.stream = options.stream;
@@ -157,22 +78,39 @@ export class CursorSdkTurnCoordinator {
 		this.nativeReplayId = options.nativeReplayId;
 		this.textDeltas = options.textDeltas;
 		this.debugRecorder = options.debugRecorder;
-		this.contentEmitter = new CursorPartialContentEmitter(options.stream, options.partial, undefined, false);
+		this.contentEmitter = createTurnCoordinatorContentEmitter(options.stream, options.partial);
+		this.displayRouter = new CursorTurnDisplayRouter({
+			cwd: options.cwd,
+			resolvedApiKey: options.resolvedApiKey,
+			liveRun: options.liveRun,
+			useNativeToolReplay: options.useNativeToolReplay,
+			activeToolNames: options.activeToolNames,
+			nativeReplayId: options.nativeReplayId,
+			contentEmitter: this.contentEmitter,
+			debugRecorder: options.debugRecorder,
+		});
+		this.lifecycleEmitter = new CursorToolLifecycleEmitter({
+			liveRun: options.liveRun,
+			resolvedApiKey: options.resolvedApiKey,
+			contentEmitter: this.contentEmitter,
+			debugRecorder: options.debugRecorder,
+			hasStartedToolCall: (callId) => this.ledger.hasStartedToolCall(callId),
+			isBridgeMcpToolCall: (toolCall) => options.liveRun?.bridgeRun?.isBridgeMcpToolCall(toolCall) ?? false,
+		});
 	}
 
 	get planTextCandidate(): string | undefined {
-		return this.cursorPlanTextCandidate;
+		return this.displayRouter.planTextCandidate;
 	}
 
 	get replayStarted(): boolean {
-		return this.nativeToolReplayStarted;
+		return this.displayRouter.nativeToolReplayStarted;
 	}
 
 	discardIncompleteStartedToolCalls(
 		outcome: IncompleteCursorToolRunOutcome = buildIncompleteCursorToolRunOutcome(),
 	): void {
-		for (const [callId, toolCall] of this.startedToolCalls) {
-			if (typeof callId !== "string") continue;
+		for (const [callId, toolCall] of this.ledger.startedToolCallEntries()) {
 			const toolName = getNormalizedCursorToolName(toolCall);
 			recordDiscardedIncompleteStartedToolCall(this.debugRecorder, process.env, {
 				toolName,
@@ -181,27 +119,20 @@ export class CursorSdkTurnCoordinator {
 			});
 			const visibilityDecision = resolveIncompleteCursorToolVisibility(toolCall, outcome);
 			if (visibilityDecision !== "emit") {
-				this.recordDisplayDecision({
-					action: "skip-incomplete-fast-local",
+				this.displayRouter.recordIncompleteSkip(
 					toolName,
-					source: "started",
-					reason:
-						visibilityDecision === "debugOnly" && outcome.assistantTextProduced
-							? "successful-run-text-produced"
-							: visibilityDecision,
-				});
+					visibilityDecision === "debugOnly" && outcome.assistantTextProduced
+						? "successful-run-text-produced"
+						: visibilityDecision,
+				);
 				continue;
 			}
-			this.emitIncompleteStartedToolCall(toolCall, outcome.reason);
+			const action = this.displayRouter.routeIncompleteStartedToolCall(toolCall, outcome.reason);
+			if (action) this.displayRouter.emitDisplayAction(action);
 		}
-		this.startedToolCalls.clear();
-		this.bridgeStartedToolCallIds.clear();
-		this.activeShellCallIds.clear();
-		this.ambiguousShellOutputCallIds.clear();
-		this.shellOutputDeltasByCallId.clear();
-		this.emittedLifecycleCallIds.clear();
-		for (const timer of this.lifecycleTimers.values()) clearTimeout(timer);
-		this.lifecycleTimers.clear();
+		this.ledger.clearStartedToolCalls();
+		this.shellOutput.clear();
+		this.lifecycleEmitter.clear();
 	}
 
 	closeTraceBlock(): void {
@@ -239,28 +170,37 @@ export class CursorSdkTurnCoordinator {
 			return;
 		}
 		if (update.type === "partial-tool-call") {
-			this.maybeScheduleCursorToolLifecycle(update.callId, update.toolCall);
+			this.lifecycleEmitter.maybeSchedule(update.callId, update.toolCall);
 			return;
 		}
 		if (update.type === "tool-call-started") {
 			if (this.liveRun?.bridgeRun?.isBridgeMcpToolCall(update.toolCall)) {
-				if (typeof update.callId === "string") this.bridgeStartedToolCallIds.add(update.callId);
+				if (typeof update.callId === "string") this.ledger.markBridgeStarted(update.callId);
 			} else {
-				this.maybeScheduleCursorToolLifecycle(update.callId, update.toolCall);
-				this.startedToolCalls.set(update.callId, update.toolCall);
-				if (isCursorShellToolCall(update.toolCall)) this.activeShellCallIds.add(update.callId);
+				this.lifecycleEmitter.maybeSchedule(update.callId, update.toolCall);
+				this.ledger.registerStartedToolCall(update.callId, update.toolCall);
+				if (isCursorShellToolCall(update.toolCall) && typeof update.callId === "string") {
+					this.shellOutput.onShellToolStarted(update.callId);
+				}
 			}
 			return;
 		}
 		if (update.type === "tool-call-completed") {
-			const resolution = this.resolveToolCompletion({
+			const resolution = resolveCursorToolCompletion({
 				source: "delta",
 				callId: update.callId,
 				toolCall: update.toolCall,
-				startedToolCall: this.startedToolCalls.get(update.callId),
+				startedToolCall: this.ledger.getStartedToolCall(update.callId),
+				liveRun: this.liveRun,
+				ledger: this.ledger,
+				shellOutput: this.shellOutput,
+				onClearStartedCallId: (callId) => {
+					this.lifecycleEmitter.cancel(callId);
+					this.shellOutput.onShellToolCleared(callId);
+				},
 			});
 			if (resolution.action === "ignore-bridge") {
-				this.recordIgnoreBridgeDecision(resolution.identity, getToolName(update.toolCall), "delta");
+				this.displayRouter.recordIgnoreBridgeDecision(resolution.identity, getToolName(update.toolCall), "delta");
 				return;
 			}
 			this.handleCompletedToolCall(resolution.toolCall, {
@@ -271,7 +211,7 @@ export class CursorSdkTurnCoordinator {
 		}
 		if (update.type === "shell-output-delta") {
 			const delta = getCursorShellOutputDelta(update);
-			if (delta) this.appendShellOutputDelta(delta);
+			if (delta) this.shellOutput.appendShellOutputDelta(delta);
 			return;
 		}
 		if (update.type === "summary") {
@@ -293,13 +233,20 @@ export class CursorSdkTurnCoordinator {
 		const stepId = getField(stepEnvelope, "id") ?? getField(toolCall, "id") ?? getField(toolCall, "callId");
 		if (!toolCall) return;
 
-		const resolution = this.resolveToolCompletion({
+		const resolution = resolveCursorToolCompletion({
 			source: "step",
 			callId: stepId,
 			toolCall,
+			liveRun: this.liveRun,
+			ledger: this.ledger,
+			shellOutput: this.shellOutput,
+			onClearStartedCallId: (callId) => {
+				this.lifecycleEmitter.cancel(callId);
+				this.shellOutput.onShellToolCleared(callId);
+			},
 		});
 		if (resolution.action === "ignore-bridge") {
-			this.recordIgnoreBridgeDecision(resolution.identity, getToolName(toolCall), "step");
+			this.displayRouter.recordIgnoreBridgeDecision(resolution.identity, getToolName(toolCall), "step");
 			return;
 		}
 		this.handleCompletedToolCall(resolution.toolCall, {
@@ -307,66 +254,8 @@ export class CursorSdkTurnCoordinator {
 			source: resolution.source,
 		});
 		if (resolution.matchedStartedCallId && resolution.matchedStartedCallId !== stepId) {
-			this.completedToolIdentities.add(`cursor-tool:${resolution.matchedStartedCallId}`);
+			this.ledger.recordCompletedIdentity(`cursor-tool:${resolution.matchedStartedCallId}`);
 		}
-	}
-
-	private resolveToolCompletion(options: {
-		source: "delta" | "step";
-		callId: unknown;
-		toolCall: unknown;
-		startedToolCall?: unknown;
-	}): ToolCompletionResolution {
-		const bridgeStartedCallId = this.takeBridgeStartedToolCallId(options.callId);
-		if (bridgeStartedCallId) {
-			this.completedToolIdentities.add(`cursor-tool:${bridgeStartedCallId}`);
-			return { action: "ignore-bridge", identity: `cursor-tool:${bridgeStartedCallId}` };
-		}
-
-		let matchedStartedCallId: string | undefined;
-		let resolvedToolCall: unknown;
-		let identity: string | undefined;
-		let source: "started" | "fallback" | undefined;
-
-		if (options.source === "delta") {
-			const callId = options.callId;
-			identity = typeof callId === "string" ? `cursor-tool:${callId}` : undefined;
-			resolvedToolCall = mergeCursorToolCalls(options.startedToolCall, options.toolCall);
-			if (typeof callId === "string") {
-				this.clearStartedToolCall(callId);
-			}
-			resolvedToolCall = mergeShellOutputDeltasIntoCursorToolCall(
-				resolvedToolCall,
-				typeof callId === "string" ? this.takeShellOutputDeltas(callId) : undefined,
-			);
-			source = identity ? "started" : "fallback";
-		} else {
-			matchedStartedCallId = this.removeStartedToolCallForStep(options.toolCall, options.callId);
-			resolvedToolCall = mergeShellOutputDeltasIntoCursorToolCall(
-				options.toolCall,
-				matchedStartedCallId ? this.takeShellOutputDeltas(matchedStartedCallId) : undefined,
-			);
-			const identityId = typeof options.callId === "string" ? options.callId : matchedStartedCallId;
-			identity = identityId ? `cursor-tool:${identityId}` : undefined;
-		}
-
-		if (this.liveRun?.bridgeRun?.isBridgeMcpToolCall(resolvedToolCall)) {
-			const bridgeIdentity = options.source === "step" && matchedStartedCallId
-				? `cursor-tool:${matchedStartedCallId}`
-				: identity;
-			if (bridgeIdentity) this.completedToolIdentities.add(bridgeIdentity);
-			return { action: "ignore-bridge", identity: bridgeIdentity };
-		}
-
-		if (options.source === "delta") {
-			return { action: "handle", toolCall: resolvedToolCall, identity, source };
-		}
-		return {
-			action: "handle",
-			toolCall: resolvedToolCall,
-			identity,
-			matchedStartedCallId,
-		};
 	}
 
 	handleTranscriptCompletedToolCalls(toolCalls: readonly { identity: string; toolCall: unknown }[]): void {
@@ -377,271 +266,34 @@ export class CursorSdkTurnCoordinator {
 
 	private handleCompletedToolCall(
 		toolCall: unknown,
-		options: { identity?: string; source?: CursorToolDisplaySource } = {},
+		options: { identity?: string; source?: "started" | "fallback" | "transcript" } = {},
 	): void {
-		const planText = getCursorCreatePlanText(toolCall);
-		if (planText) this.cursorPlanTextCandidate = scrubSensitiveText(planText, this.resolvedApiKey);
-
-		const transcript = scrubSensitiveText(formatCursorToolTranscript(toolCall, { cwd: this.cwd }), this.resolvedApiKey);
 		const display = buildCursorPiToolDisplay(toolCall, { cwd: this.cwd });
-		const toolName = display.toolName;
-		const fingerprint = this.getToolFingerprint({ toolName: display.toolName, args: display.args, result: display.result });
-		if (options.identity && this.completedToolIdentities.has(options.identity)) {
-			this.recordDisplayDecision({
-				action: "skip-duplicate",
-				toolName,
-				identity: options.identity,
-				source: options.source,
-				reason: "identity-already-completed",
-			});
-			return;
-		}
-		if (options.source === "started") {
-			if (this.completedFallbackToolFingerprints.has(fingerprint)) {
-				this.recordDisplayDecision({
-					action: "skip-duplicate",
-					toolName,
-					identity: options.identity,
-					source: options.source,
-					reason: "fallback-fingerprint-already-completed",
-				});
-				return;
-			}
-		} else if (this.completedStartedToolFingerprints.has(fingerprint) || this.completedFallbackToolFingerprints.has(fingerprint)) {
-			this.recordDisplayDecision({
-				action: "skip-duplicate",
-				toolName,
-				identity: options.identity,
-				source: options.source,
-				reason: "fingerprint-already-completed",
-			});
-			return;
-		}
-		if (options.identity) this.completedToolIdentities.add(options.identity);
-		if (options.source === "started") {
-			this.completedStartedToolFingerprints.add(fingerprint);
-		} else {
-			this.completedFallbackToolFingerprints.add(fingerprint);
-		}
-
-		const disposition = resolveNativeReplayDisposition({
+		const fingerprint = getToolFingerprint({
 			toolName: display.toolName,
-			useNativeToolReplay: this.useNativeToolReplay,
-			activeToolNames: this.activeToolNames,
-			hasLiveRun: this.liveRun !== undefined,
+			args: display.args,
+			result: display.result,
 		});
-
-		if (disposition === "queue_replay" && this.liveRun) {
-			this.nativeToolReplayStarted = true;
-			const id = `${this.nativeReplayId}-tool-${++this.nativeToolDisplayCounter}`;
-			const scrubbedDisplay = scrubPiToolDisplay(display, this.resolvedApiKey);
-			this.recordDisplayDecision({
-				action: "queue_replay",
-				disposition,
-				toolName,
-				identity: options.identity,
-				source: options.source,
-				transcript,
-				replayToolId: id,
-			});
-			cursorLiveRuns.queueEvent(this.liveRun, {
-				type: "tool",
-				tool: { ...scrubbedDisplay, id },
-			});
-			return;
-		}
-
-		const traceText =
-			disposition === "inactive_trace"
-				? formatInactiveCursorReplayTrace(scrubPiToolDisplay(display, this.resolvedApiKey))
-				: transcript || `Cursor tool: ${formatCursorToolName(toolCall)} completed`;
-		this.recordDisplayDecision({
-			action: "emit_trace",
-			disposition,
-			toolName,
+		const duplicateReason = this.ledger.shouldSkipDuplicateCompletion({
 			identity: options.identity,
 			source: options.source,
-			transcript,
-			traceText,
+			fingerprint,
 		});
-		this.emitCursorToolTrace(traceText);
-	}
-
-	private emitIncompleteStartedToolCall(toolCall: unknown, reason: IncompleteCursorToolDiscardReason): void {
-		const display = scrubPiToolDisplay(
-			buildIncompleteCursorToolDisplay(toolCall, reason, { apiKey: this.resolvedApiKey }),
-			this.resolvedApiKey,
-		);
-		const toolName = display.toolName;
-		const disposition = resolveNativeReplayDisposition({
-			toolName,
-			useNativeToolReplay: this.useNativeToolReplay,
-			activeToolNames: this.activeToolNames,
-			hasLiveRun: this.liveRun !== undefined,
-		});
-
-		// Aborted live runs emit trace visibility only; do not synthesize a toolUse replay turn.
-		if (disposition === "queue_replay" && this.liveRun && reason !== "abort") {
-			this.nativeToolReplayStarted = true;
-			const id = `${this.nativeReplayId}-tool-${++this.nativeToolDisplayCounter}`;
-			this.recordDisplayDecision({
-				action: "queue_replay",
-				disposition,
-				toolName,
-				source: "started",
-				reason: "incomplete-started-tool-call",
-				replayToolId: id,
-			});
-			cursorLiveRuns.queueEvent(this.liveRun, {
-				type: "tool",
-				tool: { ...display, id },
+		if (duplicateReason) {
+			this.displayRouter.recordDuplicateSkip(display.toolName, {
+				identity: options.identity,
+				source: options.source,
+				reason: duplicateReason,
 			});
 			return;
 		}
-
-		const traceText =
-			disposition === "inactive_trace"
-				? formatInactiveCursorReplayTrace(display)
-				: formatIncompleteCursorToolTrace(display);
-		this.recordDisplayDecision({
-			action: "emit_trace",
-			disposition,
-			toolName,
-			source: "started",
-			reason: "incomplete-started-tool-call",
-			traceText,
+		this.ledger.recordCompletedTool({
+			identity: options.identity,
+			source: options.source,
+			fingerprint,
 		});
-		this.emitCursorToolTrace(traceText);
-	}
 
-	private recordIgnoreBridgeDecision(
-		identity: string | undefined,
-		toolName: string,
-		source: "delta" | "step",
-	): void {
-		this.debugRecorder?.recordDisplayDecision({
-			action: "ignore-bridge",
-			toolName,
-			identity,
-			source,
-		});
-	}
-
-	private recordDisplayDecision(decision: Parameters<CursorSdkEventDebugRecorder["recordDisplayDecision"]>[0]): void {
-		this.debugRecorder?.recordDisplayDecision(decision);
-	}
-
-	private emitCursorToolTrace(text: string): void {
-		const traceText = text.endsWith("\n") ? text : `${text}\n`;
-		if (this.liveRun) {
-			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-delta", text: traceText });
-			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-completed" });
-			return;
-		}
-		this.contentEmitter.appendThinkingBlock(traceText);
-	}
-
-	private maybeScheduleCursorToolLifecycle(callId: unknown, toolCall: unknown): void {
-		if (typeof callId !== "string" || this.emittedLifecycleCallIds.has(callId)) return;
-		if (this.liveRun?.bridgeRun?.isBridgeMcpToolCall(toolCall)) return;
-		if (!isCursorToolLifecycleEligible(toolCall)) return;
-
-		this.cancelCursorToolLifecycleTimer(callId);
-		const timer = setTimeout(() => {
-			this.lifecycleTimers.delete(callId);
-			if (!this.startedToolCalls.has(callId)) return;
-			if (this.emittedLifecycleCallIds.has(callId)) return;
-			this.emitCursorToolLifecycle(callId, toolCall);
-		}, CURSOR_TOOL_LIFECYCLE_DEFER_MS);
-		timer.unref?.();
-		this.lifecycleTimers.set(callId, timer);
-	}
-
-	private cancelCursorToolLifecycleTimer(callId: string): void {
-		const timer = this.lifecycleTimers.get(callId);
-		if (!timer) return;
-		clearTimeout(timer);
-		this.lifecycleTimers.delete(callId);
-	}
-
-	private emitCursorToolLifecycle(callId: string, toolCall: unknown): void {
-		const progressText = formatCursorToolLifecycleProgressText(toolCall, this.resolvedApiKey);
-		if (!progressText) return;
-		this.emittedLifecycleCallIds.add(callId);
-		this.debugRecorder?.recordCoordinatorEvent("tool_lifecycle", {
-			callId,
-			toolName: getNormalizedCursorToolName(toolCall),
-			progressText,
-			liveRun: this.liveRun !== undefined,
-		});
-		if (this.liveRun) {
-			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-delta", text: progressText });
-			return;
-		}
-		this.contentEmitter.appendThinkingDelta(progressText);
-	}
-
-	private getToolFingerprint(value: unknown): string {
-		try {
-			return JSON.stringify(value);
-		} catch {
-			return String(value);
-		}
-	}
-
-	private getStartedToolCallFingerprint(toolCall: unknown): string {
-		return this.getToolFingerprint({ toolName: getToolName(toolCall), args: getField(toolCall, "args") });
-	}
-
-	private clearStartedToolCall(callId: string): void {
-		this.cancelCursorToolLifecycleTimer(callId);
-		this.startedToolCalls.delete(callId);
-		this.bridgeStartedToolCallIds.delete(callId);
-		this.activeShellCallIds.delete(callId);
-		this.ambiguousShellOutputCallIds.delete(callId);
-	}
-
-	private takeBridgeStartedToolCallId(callId: unknown): string | undefined {
-		if (typeof callId !== "string" || !this.bridgeStartedToolCallIds.has(callId)) return undefined;
-		this.bridgeStartedToolCallIds.delete(callId);
-		return callId;
-	}
-
-	private takeShellOutputDeltas(callId: string): CursorShellOutputDeltas | undefined {
-		const deltas = this.shellOutputDeltasByCallId.get(callId);
-		this.shellOutputDeltasByCallId.delete(callId);
-		return deltas;
-	}
-
-	private appendShellOutputDelta(delta: CursorShellOutputDelta): void {
-		if (this.activeShellCallIds.size !== 1) {
-			for (const activeCallId of this.activeShellCallIds) {
-				this.ambiguousShellOutputCallIds.add(activeCallId);
-				this.shellOutputDeltasByCallId.delete(activeCallId);
-			}
-			return;
-		}
-		const [callId] = this.activeShellCallIds;
-		if (!callId || this.ambiguousShellOutputCallIds.has(callId)) return;
-		let deltas = this.shellOutputDeltasByCallId.get(callId);
-		if (!deltas) {
-			deltas = { stdout: [], stderr: [] };
-			this.shellOutputDeltasByCallId.set(callId, deltas);
-		}
-		deltas[delta.stream].push(delta.data);
-	}
-
-	private removeStartedToolCallForStep(toolCall: unknown, stepId: unknown): string | undefined {
-		if (typeof stepId === "string" && this.startedToolCalls.has(stepId)) {
-			this.clearStartedToolCall(stepId);
-			return stepId;
-		}
-		const fingerprint = this.getStartedToolCallFingerprint(toolCall);
-		for (const [callId, startedToolCall] of this.startedToolCalls) {
-			if (this.getStartedToolCallFingerprint(startedToolCall) !== fingerprint) continue;
-			this.clearStartedToolCall(callId);
-			return callId;
-		}
-		return undefined;
+		const action = this.displayRouter.routeCompletedToolCall(toolCall, options);
+		if (action) this.displayRouter.emitDisplayAction(action);
 	}
 }

--- a/src/cursor-provider-turn-display-router.ts
+++ b/src/cursor-provider-turn-display-router.ts
@@ -1,0 +1,216 @@
+import type { CursorLiveRun } from "./cursor-live-run-coordinator.js";
+import { cursorLiveRuns } from "./cursor-provider-live-run-drain.js";
+import { truncateCursorDisplayLine } from "./cursor-display-text.js";
+import { formatInactiveCursorReplayTrace } from "./cursor-native-replay-trace.js";
+import { resolveNativeReplayDisposition, type NativeReplayDisposition } from "./cursor-native-replay-routing.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
+import {
+	buildIncompleteCursorToolDisplay,
+	formatIncompleteCursorToolTrace,
+	type IncompleteCursorToolDiscardReason,
+} from "./cursor-incomplete-tool-visibility.js";
+import { scrubPiToolDisplay, scrubSensitiveText } from "./cursor-sensitive-text.js";
+import { buildCursorPiToolDisplay, formatCursorToolTranscript, getCursorCreatePlanText } from "./cursor-tool-transcript.js";
+import { getToolName } from "./cursor-transcript-utils.js";
+import type { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js";
+import type { CursorToolDisplaySource } from "./cursor-provider-turn-tool-ledger.js";
+
+function formatCursorToolName(toolCall: unknown): string {
+	return truncateCursorDisplayLine(getToolName(toolCall), 80) || "unknown";
+}
+
+export interface CursorTurnDisplayRouterOptions {
+	cwd: string;
+	resolvedApiKey?: string;
+	liveRun?: CursorLiveRun;
+	useNativeToolReplay: boolean;
+	activeToolNames?: ReadonlySet<string>;
+	nativeReplayId: string;
+	contentEmitter: CursorPartialContentEmitter;
+	debugRecorder?: CursorSdkEventDebugRecorder;
+}
+
+export type CursorTurnDisplayAction =
+	| { kind: "queue_replay"; tool: ReturnType<typeof scrubPiToolDisplay>; replayToolId: string; disposition: NativeReplayDisposition }
+	| { kind: "emit_trace"; traceText: string; disposition: NativeReplayDisposition };
+
+export class CursorTurnDisplayRouter {
+	private readonly cwd: string;
+	private readonly resolvedApiKey?: string;
+	private readonly liveRun?: CursorLiveRun;
+	private readonly useNativeToolReplay: boolean;
+	private readonly activeToolNames?: ReadonlySet<string>;
+	private readonly nativeReplayId: string;
+	private readonly contentEmitter: CursorPartialContentEmitter;
+	private readonly debugRecorder?: CursorSdkEventDebugRecorder;
+	private nativeToolDisplayCounter = 0;
+	nativeToolReplayStarted = false;
+	planTextCandidate: string | undefined;
+
+	constructor(options: CursorTurnDisplayRouterOptions) {
+		this.cwd = options.cwd;
+		this.resolvedApiKey = options.resolvedApiKey;
+		this.liveRun = options.liveRun;
+		this.useNativeToolReplay = options.useNativeToolReplay;
+		this.activeToolNames = options.activeToolNames;
+		this.nativeReplayId = options.nativeReplayId;
+		this.contentEmitter = options.contentEmitter;
+		this.debugRecorder = options.debugRecorder;
+	}
+
+	routeCompletedToolCall(
+		toolCall: unknown,
+		options: { identity?: string; source?: CursorToolDisplaySource } = {},
+	): CursorTurnDisplayAction | undefined {
+		const planText = getCursorCreatePlanText(toolCall);
+		if (planText) this.planTextCandidate = scrubSensitiveText(planText, this.resolvedApiKey);
+
+		const transcript = scrubSensitiveText(formatCursorToolTranscript(toolCall, { cwd: this.cwd }), this.resolvedApiKey);
+		const display = buildCursorPiToolDisplay(toolCall, { cwd: this.cwd });
+		const disposition = resolveNativeReplayDisposition({
+			toolName: display.toolName,
+			useNativeToolReplay: this.useNativeToolReplay,
+			activeToolNames: this.activeToolNames,
+			hasLiveRun: this.liveRun !== undefined,
+		});
+
+		if (disposition === "queue_replay" && this.liveRun) {
+			this.nativeToolReplayStarted = true;
+			const id = `${this.nativeReplayId}-tool-${++this.nativeToolDisplayCounter}`;
+			const scrubbedDisplay = scrubPiToolDisplay(display, this.resolvedApiKey);
+			this.recordDisplayDecision({
+				action: "queue_replay",
+				disposition,
+				toolName: display.toolName,
+				identity: options.identity,
+				source: options.source,
+				transcript,
+				replayToolId: id,
+			});
+			return { kind: "queue_replay", tool: scrubbedDisplay, replayToolId: id, disposition };
+		}
+
+		const traceText =
+			disposition === "inactive_trace"
+				? formatInactiveCursorReplayTrace(scrubPiToolDisplay(display, this.resolvedApiKey))
+				: transcript || `Cursor tool: ${formatCursorToolName(toolCall)} completed`;
+		this.recordDisplayDecision({
+			action: "emit_trace",
+			disposition,
+			toolName: display.toolName,
+			identity: options.identity,
+			source: options.source,
+			transcript,
+			traceText,
+		});
+		return { kind: "emit_trace", traceText, disposition };
+	}
+
+	routeIncompleteStartedToolCall(
+		toolCall: unknown,
+		reason: IncompleteCursorToolDiscardReason,
+	): CursorTurnDisplayAction | undefined {
+		const display = scrubPiToolDisplay(
+			buildIncompleteCursorToolDisplay(toolCall, reason, { apiKey: this.resolvedApiKey }),
+			this.resolvedApiKey,
+		);
+		const disposition = resolveNativeReplayDisposition({
+			toolName: display.toolName,
+			useNativeToolReplay: this.useNativeToolReplay,
+			activeToolNames: this.activeToolNames,
+			hasLiveRun: this.liveRun !== undefined,
+		});
+
+		if (disposition === "queue_replay" && this.liveRun && reason !== "abort") {
+			this.nativeToolReplayStarted = true;
+			const id = `${this.nativeReplayId}-tool-${++this.nativeToolDisplayCounter}`;
+			this.recordDisplayDecision({
+				action: "queue_replay",
+				disposition,
+				toolName: display.toolName,
+				source: "started",
+				reason: "incomplete-started-tool-call",
+				replayToolId: id,
+			});
+			return { kind: "queue_replay", tool: display, replayToolId: id, disposition };
+		}
+
+		const traceText =
+			disposition === "inactive_trace"
+				? formatInactiveCursorReplayTrace(display)
+				: formatIncompleteCursorToolTrace(display);
+		this.recordDisplayDecision({
+			action: "emit_trace",
+			disposition,
+			toolName: display.toolName,
+			source: "started",
+			reason: "incomplete-started-tool-call",
+			traceText,
+		});
+		return { kind: "emit_trace", traceText, disposition };
+	}
+
+	emitDisplayAction(action: CursorTurnDisplayAction): void {
+		if (action.kind === "queue_replay") {
+			if (!this.liveRun) return;
+			cursorLiveRuns.queueEvent(this.liveRun, {
+				type: "tool",
+				tool: { ...action.tool, id: action.replayToolId },
+			});
+			return;
+		}
+		this.emitCursorToolTrace(action.traceText);
+	}
+
+	recordIgnoreBridgeDecision(
+		identity: string | undefined,
+		toolName: string,
+		source: "delta" | "step",
+	): void {
+		this.debugRecorder?.recordDisplayDecision({
+			action: "ignore-bridge",
+			toolName,
+			identity,
+			source,
+		});
+	}
+
+	recordDuplicateSkip(
+		toolName: string,
+		options: { identity?: string; source?: CursorToolDisplaySource; reason: string },
+	): void {
+		this.recordDisplayDecision({
+			action: "skip-duplicate",
+			toolName,
+			identity: options.identity,
+			source: options.source,
+			reason: options.reason,
+		});
+	}
+
+	recordIncompleteSkip(
+		toolName: string,
+		reason: string,
+	): void {
+		this.recordDisplayDecision({
+			action: "skip-incomplete-fast-local",
+			toolName,
+			source: "started",
+			reason,
+		});
+	}
+
+	private recordDisplayDecision(decision: Parameters<CursorSdkEventDebugRecorder["recordDisplayDecision"]>[0]): void {
+		this.debugRecorder?.recordDisplayDecision(decision);
+	}
+
+	private emitCursorToolTrace(text: string): void {
+		const traceText = text.endsWith("\n") ? text : `${text}\n`;
+		if (this.liveRun) {
+			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-delta", text: traceText });
+			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-completed" });
+			return;
+		}
+		this.contentEmitter.appendThinkingBlock(traceText);
+	}
+}

--- a/src/cursor-provider-turn-lifecycle-emitter.ts
+++ b/src/cursor-provider-turn-lifecycle-emitter.ts
@@ -1,0 +1,97 @@
+import type { AssistantMessage, AssistantMessageEventStream } from "@earendil-works/pi-ai";
+import type { CursorLiveRun } from "./cursor-live-run-coordinator.js";
+import { cursorLiveRuns } from "./cursor-provider-live-run-drain.js";
+import { CursorPartialContentEmitter } from "./cursor-partial-content-emitter.js";
+import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
+import {
+	CURSOR_TOOL_LIFECYCLE_DEFER_MS,
+	formatCursorToolLifecycleProgressText,
+	isCursorToolLifecycleEligible,
+} from "./cursor-tool-lifecycle.js";
+import { classifyCursorToolVisibility } from "./cursor-tool-visibility.js";
+
+function getNormalizedCursorToolName(toolCall: unknown): string {
+	return classifyCursorToolVisibility(toolCall).normalizedName;
+}
+
+export interface CursorToolLifecycleEmitterOptions {
+	liveRun?: CursorLiveRun;
+	resolvedApiKey?: string;
+	contentEmitter: CursorPartialContentEmitter;
+	debugRecorder?: CursorSdkEventDebugRecorder;
+	hasStartedToolCall: (callId: string) => boolean;
+	isBridgeMcpToolCall: (toolCall: unknown) => boolean;
+}
+
+export class CursorToolLifecycleEmitter {
+	private readonly liveRun?: CursorLiveRun;
+	private readonly resolvedApiKey?: string;
+	private readonly contentEmitter: CursorPartialContentEmitter;
+	private readonly debugRecorder?: CursorSdkEventDebugRecorder;
+	private readonly hasStartedToolCall: (callId: string) => boolean;
+	private readonly isBridgeMcpToolCall: (toolCall: unknown) => boolean;
+	private readonly emittedLifecycleCallIds = new Set<string>();
+	private readonly lifecycleTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+	constructor(options: CursorToolLifecycleEmitterOptions) {
+		this.liveRun = options.liveRun;
+		this.resolvedApiKey = options.resolvedApiKey;
+		this.contentEmitter = options.contentEmitter;
+		this.debugRecorder = options.debugRecorder;
+		this.hasStartedToolCall = options.hasStartedToolCall;
+		this.isBridgeMcpToolCall = options.isBridgeMcpToolCall;
+	}
+
+	maybeSchedule(callId: unknown, toolCall: unknown): void {
+		if (typeof callId !== "string" || this.emittedLifecycleCallIds.has(callId)) return;
+		if (this.isBridgeMcpToolCall(toolCall)) return;
+		if (!isCursorToolLifecycleEligible(toolCall)) return;
+
+		this.cancel(callId);
+		const timer = setTimeout(() => {
+			this.lifecycleTimers.delete(callId);
+			if (!this.hasStartedToolCall(callId)) return;
+			if (this.emittedLifecycleCallIds.has(callId)) return;
+			this.emit(callId, toolCall);
+		}, CURSOR_TOOL_LIFECYCLE_DEFER_MS);
+		timer.unref?.();
+		this.lifecycleTimers.set(callId, timer);
+	}
+
+	cancel(callId: string): void {
+		const timer = this.lifecycleTimers.get(callId);
+		if (!timer) return;
+		clearTimeout(timer);
+		this.lifecycleTimers.delete(callId);
+	}
+
+	clear(): void {
+		this.emittedLifecycleCallIds.clear();
+		for (const timer of this.lifecycleTimers.values()) clearTimeout(timer);
+		this.lifecycleTimers.clear();
+	}
+
+	private emit(callId: string, toolCall: unknown): void {
+		const progressText = formatCursorToolLifecycleProgressText(toolCall, this.resolvedApiKey);
+		if (!progressText) return;
+		this.emittedLifecycleCallIds.add(callId);
+		this.debugRecorder?.recordCoordinatorEvent("tool_lifecycle", {
+			callId,
+			toolName: getNormalizedCursorToolName(toolCall),
+			progressText,
+			liveRun: this.liveRun !== undefined,
+		});
+		if (this.liveRun) {
+			cursorLiveRuns.queueEvent(this.liveRun, { type: "thinking-delta", text: progressText });
+			return;
+		}
+		this.contentEmitter.appendThinkingDelta(progressText);
+	}
+}
+
+export function createTurnCoordinatorContentEmitter(
+	stream: AssistantMessageEventStream,
+	partial: AssistantMessage,
+): CursorPartialContentEmitter {
+	return new CursorPartialContentEmitter(stream, partial, undefined, false);
+}

--- a/src/cursor-provider-turn-sdk-normalizer.ts
+++ b/src/cursor-provider-turn-sdk-normalizer.ts
@@ -1,0 +1,88 @@
+import { mergeCursorToolCalls } from "./cursor-tool-transcript.js";
+import type { CursorLiveRun } from "./cursor-live-run-coordinator.js";
+import {
+	mergeShellOutputDeltasIntoCursorToolCall,
+	type CursorShellOutputTracker,
+} from "./cursor-provider-turn-shell-output.js";
+import type { CursorToolCompletionLedger } from "./cursor-provider-turn-tool-ledger.js";
+
+export type CursorToolCompletionSource = "delta" | "step";
+
+export type ToolCompletionResolution =
+	| { action: "ignore-bridge"; identity?: string }
+	| {
+			action: "handle";
+			toolCall: unknown;
+			identity?: string;
+			source?: "started" | "fallback";
+			matchedStartedCallId?: string;
+	  };
+
+export interface ResolveCursorToolCompletionOptions {
+	source: CursorToolCompletionSource;
+	callId: unknown;
+	toolCall: unknown;
+	startedToolCall?: unknown;
+	liveRun?: CursorLiveRun;
+	ledger: CursorToolCompletionLedger;
+	shellOutput: CursorShellOutputTracker;
+	onClearStartedCallId?: (callId: string) => void;
+}
+
+export function resolveCursorToolCompletion(options: ResolveCursorToolCompletionOptions): ToolCompletionResolution {
+	const bridgeStartedCallId = options.ledger.takeBridgeStartedCallId(
+		typeof options.callId === "string" ? options.callId : "",
+	);
+	if (bridgeStartedCallId) {
+		options.ledger.recordCompletedIdentity(`cursor-tool:${bridgeStartedCallId}`);
+		return { action: "ignore-bridge", identity: `cursor-tool:${bridgeStartedCallId}` };
+	}
+
+	let matchedStartedCallId: string | undefined;
+	let resolvedToolCall: unknown;
+	let identity: string | undefined;
+	let source: "started" | "fallback" | undefined;
+
+	if (options.source === "delta") {
+		const callId = options.callId;
+		identity = typeof callId === "string" ? `cursor-tool:${callId}` : undefined;
+		resolvedToolCall = mergeCursorToolCalls(options.startedToolCall, options.toolCall);
+		if (typeof callId === "string") {
+			options.onClearStartedCallId?.(callId);
+			options.ledger.clearStartedToolCall(callId);
+		}
+		resolvedToolCall = mergeShellOutputDeltasIntoCursorToolCall(
+			resolvedToolCall,
+			typeof callId === "string" ? options.shellOutput.takeDeltasForCall(callId) : undefined,
+		);
+		source = identity ? "started" : "fallback";
+	} else {
+		matchedStartedCallId = options.ledger.removeStartedToolCallForStep(options.toolCall, options.callId);
+		if (matchedStartedCallId) {
+			options.onClearStartedCallId?.(matchedStartedCallId);
+		}
+		resolvedToolCall = mergeShellOutputDeltasIntoCursorToolCall(
+			options.toolCall,
+			matchedStartedCallId ? options.shellOutput.takeDeltasForCall(matchedStartedCallId) : undefined,
+		);
+		const identityId = typeof options.callId === "string" ? options.callId : matchedStartedCallId;
+		identity = identityId ? `cursor-tool:${identityId}` : undefined;
+	}
+
+	if (options.liveRun?.bridgeRun?.isBridgeMcpToolCall(resolvedToolCall)) {
+		const bridgeIdentity =
+			options.source === "step" && matchedStartedCallId ? `cursor-tool:${matchedStartedCallId}` : identity;
+		if (bridgeIdentity) options.ledger.recordCompletedIdentity(bridgeIdentity);
+		return { action: "ignore-bridge", identity: bridgeIdentity };
+	}
+
+	if (options.source === "delta") {
+		return { action: "handle", toolCall: resolvedToolCall, identity, source };
+	}
+	return {
+		action: "handle",
+		toolCall: resolvedToolCall,
+		identity,
+		matchedStartedCallId,
+	};
+}

--- a/src/cursor-provider-turn-shell-output.ts
+++ b/src/cursor-provider-turn-shell-output.ts
@@ -1,0 +1,107 @@
+import type { InteractionUpdate } from "@cursor/sdk";
+import { asRecord, getField, hasUsableText } from "./cursor-record-utils.js";
+import { classifyCursorToolVisibility } from "./cursor-tool-visibility.js";
+
+export interface CursorShellOutputDelta {
+	stream: "stdout" | "stderr";
+	data: string;
+}
+
+export interface CursorShellOutputDeltas {
+	stdout: string[];
+	stderr: string[];
+}
+
+export function isCursorShellToolCall(toolCall: unknown): boolean {
+	return classifyCursorToolVisibility(toolCall).normalizedKey === "shell";
+}
+
+export function getCursorShellOutputDelta(update: InteractionUpdate): CursorShellOutputDelta | undefined {
+	if (update.type !== "shell-output-delta") return undefined;
+	const event = getField(update, "event");
+	const eventCase = getField(event, "case");
+	if (eventCase !== "stdout" && eventCase !== "stderr") return undefined;
+	const value = getField(event, "value");
+	const data = getField(value, "data");
+	if (typeof data !== "string" || data.length === 0) return undefined;
+	return { stream: eventCase, data };
+}
+
+export function mergeShellOutputDeltasIntoCursorToolCall(
+	toolCall: unknown,
+	deltas: CursorShellOutputDeltas | undefined,
+): unknown {
+	if (!deltas) return toolCall;
+	const stdout = deltas.stdout.join("");
+	const stderr = deltas.stderr.join("");
+	if (!hasUsableText(stdout) && !hasUsableText(stderr)) return toolCall;
+
+	const toolRecord = asRecord(toolCall);
+	const result = getField(toolRecord, "result");
+	const resultRecord = asRecord(result);
+	if (!toolRecord || !resultRecord || resultRecord.status !== "success") return toolCall;
+
+	const value = getField(resultRecord, "value");
+	const valueRecord = asRecord(value);
+	const completedStdout = getField(valueRecord, "stdout");
+	const completedStderr = getField(valueRecord, "stderr");
+	if (hasUsableText(typeof completedStdout === "string" ? completedStdout : undefined)) return toolCall;
+	if (hasUsableText(typeof completedStderr === "string" ? completedStderr : undefined)) return toolCall;
+
+	return {
+		...toolRecord,
+		result: {
+			...resultRecord,
+			value: {
+				...(valueRecord ?? {}),
+				stdout,
+				stderr,
+			},
+		},
+	};
+}
+
+export class CursorShellOutputTracker {
+	private readonly activeShellCallIds = new Set<string>();
+	private readonly ambiguousShellOutputCallIds = new Set<string>();
+	private readonly shellOutputDeltasByCallId = new Map<string, CursorShellOutputDeltas>();
+
+	onShellToolStarted(callId: string): void {
+		this.activeShellCallIds.add(callId);
+	}
+
+	onShellToolCleared(callId: string): void {
+		this.activeShellCallIds.delete(callId);
+		this.ambiguousShellOutputCallIds.delete(callId);
+	}
+
+	appendShellOutputDelta(delta: CursorShellOutputDelta): void {
+		if (this.activeShellCallIds.size !== 1) {
+			for (const activeCallId of this.activeShellCallIds) {
+				this.ambiguousShellOutputCallIds.add(activeCallId);
+				this.shellOutputDeltasByCallId.delete(activeCallId);
+			}
+			return;
+		}
+		const [callId] = this.activeShellCallIds;
+		if (!callId || this.ambiguousShellOutputCallIds.has(callId)) return;
+		let deltas = this.shellOutputDeltasByCallId.get(callId);
+		if (!deltas) {
+			deltas = { stdout: [], stderr: [] };
+			this.shellOutputDeltasByCallId.set(callId, deltas);
+		}
+		deltas[delta.stream].push(delta.data);
+	}
+
+	takeDeltasForCall(callId: string): CursorShellOutputDeltas | undefined {
+		const deltas = this.shellOutputDeltasByCallId.get(callId);
+		this.shellOutputDeltasByCallId.delete(callId);
+		return deltas;
+	}
+
+	clear(): void {
+		this.activeShellCallIds.clear();
+		this.ambiguousShellOutputCallIds.clear();
+		this.shellOutputDeltasByCallId.clear();
+	}
+}

--- a/src/cursor-provider-turn-tool-ledger.ts
+++ b/src/cursor-provider-turn-tool-ledger.ts
@@ -1,0 +1,126 @@
+import { getField } from "./cursor-record-utils.js";
+import { getToolName } from "./cursor-transcript-utils.js";
+
+export type CursorToolDisplaySource = "started" | "fallback" | "transcript";
+
+export interface ToolCompletionDedupeInput {
+	identity?: string;
+	source?: CursorToolDisplaySource;
+	fingerprint: string;
+}
+
+export type ToolCompletionDedupeReason =
+	| "identity-already-completed"
+	| "fallback-fingerprint-already-completed"
+	| "fingerprint-already-completed";
+
+export class CursorToolCompletionLedger {
+	private readonly startedToolCalls = new Map<string, unknown>();
+	private readonly bridgeStartedToolCallIds = new Set<string>();
+	private readonly completedToolIdentities = new Set<string>();
+	private readonly completedStartedToolFingerprints = new Set<string>();
+	private readonly completedFallbackToolFingerprints = new Set<string>();
+
+	getStartedToolCall(callId: string): unknown | undefined {
+		return this.startedToolCalls.get(callId);
+	}
+
+	hasStartedToolCall(callId: string): boolean {
+		return this.startedToolCalls.has(callId);
+	}
+
+	registerStartedToolCall(callId: string, toolCall: unknown): void {
+		this.startedToolCalls.set(callId, toolCall);
+	}
+
+	markBridgeStarted(callId: string): void {
+		this.bridgeStartedToolCallIds.add(callId);
+	}
+
+	takeBridgeStartedCallId(callId: string): string | undefined {
+		if (!this.bridgeStartedToolCallIds.has(callId)) return undefined;
+		this.bridgeStartedToolCallIds.delete(callId);
+		return callId;
+	}
+
+	clearStartedToolCall(callId: string): void {
+		this.startedToolCalls.delete(callId);
+		this.bridgeStartedToolCallIds.delete(callId);
+	}
+
+	removeStartedToolCallForStep(toolCall: unknown, stepId: unknown): string | undefined {
+		if (typeof stepId === "string" && this.startedToolCalls.has(stepId)) {
+			this.clearStartedToolCall(stepId);
+			return stepId;
+		}
+		const fingerprint = getStartedToolCallFingerprint(toolCall);
+		for (const [callId, startedToolCall] of this.startedToolCalls) {
+			if (getStartedToolCallFingerprint(startedToolCall) !== fingerprint) continue;
+			this.clearStartedToolCall(callId);
+			return callId;
+		}
+		return undefined;
+	}
+
+	recordCompletedIdentity(identity: string): void {
+		this.completedToolIdentities.add(identity);
+	}
+
+	shouldSkipDuplicateCompletion(input: ToolCompletionDedupeInput): ToolCompletionDedupeReason | undefined {
+		if (input.identity && this.completedToolIdentities.has(input.identity)) {
+			return "identity-already-completed";
+		}
+		if (input.source === "started") {
+			if (this.completedFallbackToolFingerprints.has(input.fingerprint)) {
+				return "fallback-fingerprint-already-completed";
+			}
+			return undefined;
+		}
+		if (
+			this.completedStartedToolFingerprints.has(input.fingerprint) ||
+			this.completedFallbackToolFingerprints.has(input.fingerprint)
+		) {
+			return "fingerprint-already-completed";
+		}
+		return undefined;
+	}
+
+	recordCompletedTool(input: ToolCompletionDedupeInput): void {
+		if (input.identity) this.completedToolIdentities.add(input.identity);
+		if (input.source === "started") {
+			this.completedStartedToolFingerprints.add(input.fingerprint);
+		} else {
+			this.completedFallbackToolFingerprints.add(input.fingerprint);
+		}
+	}
+
+	clear(): void {
+		this.startedToolCalls.clear();
+		this.bridgeStartedToolCallIds.clear();
+		this.completedToolIdentities.clear();
+		this.completedStartedToolFingerprints.clear();
+		this.completedFallbackToolFingerprints.clear();
+	}
+
+	/** Exposed for incomplete-tool discard iteration. */
+	startedToolCallEntries(): IterableIterator<[string, unknown]> {
+		return this.startedToolCalls.entries();
+	}
+
+	clearStartedToolCalls(): void {
+		this.startedToolCalls.clear();
+		this.bridgeStartedToolCallIds.clear();
+	}
+}
+
+export function getToolFingerprint(value: unknown): string {
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+export function getStartedToolCallFingerprint(toolCall: unknown): string {
+	return getToolFingerprint({ toolName: getToolName(toolCall), args: getField(toolCall, "args") });
+}

--- a/test/cursor-pi-tool-bridge.test.ts
+++ b/test/cursor-pi-tool-bridge.test.ts
@@ -204,7 +204,7 @@ describe("cursor pi tool bridge flags and snapshots", () => {
 				createBuiltinToolInfo("write", "Write files"),
 				createToolInfo("sem_reindex", "Reindex semantic cache"),
 			];
-			const pi = createMockPi({
+			const pi = createBridgePiHarness({
 				active: tools.map((tool) => tool.name),
 				tools,
 			});

--- a/test/cursor-provider-stream-auth.test.ts
+++ b/test/cursor-provider-stream-auth.test.ts
@@ -181,7 +181,7 @@ describe("streamCursor auth and abort", () => {
 	it("cancels bridge runs promptly when aborted during Agent.messages.list offset probing", async () => {
 		registerBridgeForProviderTest({
 			active: ["sem_reindex"],
-			tools: [createBridgeToolInfo("sem_reindex", Type.Object({ target: Type.String() }), "Reindex semantic cache")],
+			tools: [createTestToolInfo("sem_reindex", Type.Object({ target: Type.String() }), "Reindex semantic cache")],
 		});
 		const bridgeCancelSpy = vi.spyOn(CursorPiToolBridgeRunImpl.prototype, "cancel");
 
@@ -201,7 +201,7 @@ describe("streamCursor auth and abort", () => {
 					// Intentionally never resolves so abort during offset probing is observable.
 				}),
 		);
-		mockedCreate.mockResolvedValue({
+		mockCreatedAgent({
 			agentId: "agent-1",
 			send: mockSend,
 			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),

--- a/test/cursor-provider-turn-sdk-normalizer.test.ts
+++ b/test/cursor-provider-turn-sdk-normalizer.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveCursorToolCompletion } from "../src/cursor-provider-turn-sdk-normalizer.js";
+import { CursorShellOutputTracker } from "../src/cursor-provider-turn-shell-output.js";
+import { CursorToolCompletionLedger } from "../src/cursor-provider-turn-tool-ledger.js";
+
+describe("resolveCursorToolCompletion", () => {
+	it("merges shell-output deltas into delta completions", () => {
+		const ledger = new CursorToolCompletionLedger();
+		const shellOutput = new CursorShellOutputTracker();
+		ledger.registerStartedToolCall("shell-1", {
+			name: "shell",
+			args: { command: "printf done" },
+		});
+		shellOutput.onShellToolStarted("shell-1");
+		shellOutput.appendShellOutputDelta({ stream: "stdout", data: "delta\n" });
+
+		const resolution = resolveCursorToolCompletion({
+			source: "delta",
+			callId: "shell-1",
+			toolCall: {
+				name: "shell",
+				result: { status: "success", value: { stdout: "", stderr: "" } },
+			},
+			startedToolCall: ledger.getStartedToolCall("shell-1"),
+			ledger,
+			shellOutput,
+		});
+
+		expect(resolution).toMatchObject({
+			action: "handle",
+			identity: "cursor-tool:shell-1",
+			source: "started",
+		});
+		if (resolution.action !== "handle") return;
+		expect(resolution.toolCall).toMatchObject({
+			result: { status: "success", value: { stdout: "delta\n" } },
+		});
+	});
+
+	it("ignores bridge MCP tool completions after bridge start", () => {
+		const ledger = new CursorToolCompletionLedger();
+		const shellOutput = new CursorShellOutputTracker();
+		ledger.markBridgeStarted("bridge-1");
+
+		const resolution = resolveCursorToolCompletion({
+			source: "delta",
+			callId: "bridge-1",
+			toolCall: { toolName: "pi__run_test" },
+			ledger,
+			shellOutput,
+			liveRun: {
+				bridgeRun: { isBridgeMcpToolCall: () => false },
+			} as never,
+		});
+
+		expect(resolution).toEqual({
+			action: "ignore-bridge",
+			identity: "cursor-tool:bridge-1",
+		});
+	});
+
+	it("ignores bridge tool calls detected on the live run", () => {
+		const ledger = new CursorToolCompletionLedger();
+		const shellOutput = new CursorShellOutputTracker();
+		const isBridgeMcpToolCall = vi.fn(() => true);
+
+		const resolution = resolveCursorToolCompletion({
+			source: "delta",
+			callId: "call-1",
+			toolCall: { toolName: "pi__cursor_ask_question" },
+			ledger,
+			shellOutput,
+			liveRun: { bridgeRun: { isBridgeMcpToolCall } } as never,
+		});
+
+		expect(resolution.action).toBe("ignore-bridge");
+		expect(isBridgeMcpToolCall).toHaveBeenCalled();
+	});
+});

--- a/test/cursor-provider-turn-shell-output.test.ts
+++ b/test/cursor-provider-turn-shell-output.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+	CursorShellOutputTracker,
+	getCursorShellOutputDelta,
+	mergeShellOutputDeltasIntoCursorToolCall,
+} from "../src/cursor-provider-turn-shell-output.js";
+
+describe("CursorShellOutputTracker", () => {
+	it("buffers stdout/stderr for a single active shell call", () => {
+		const tracker = new CursorShellOutputTracker();
+		tracker.onShellToolStarted("shell-1");
+		tracker.appendShellOutputDelta({ stream: "stdout", data: "line one\n" });
+		tracker.appendShellOutputDelta({ stream: "stderr", data: "warn\n" });
+
+		expect(tracker.takeDeltasForCall("shell-1")).toEqual({
+			stdout: ["line one\n"],
+			stderr: ["warn\n"],
+		});
+	});
+
+	it("drops buffered deltas when multiple shell calls overlap", () => {
+		const tracker = new CursorShellOutputTracker();
+		tracker.onShellToolStarted("shell-1");
+		tracker.appendShellOutputDelta({ stream: "stdout", data: "first\n" });
+		tracker.onShellToolStarted("shell-2");
+		tracker.appendShellOutputDelta({ stream: "stdout", data: "ambiguous\n" });
+
+		expect(tracker.takeDeltasForCall("shell-1")).toBeUndefined();
+		expect(tracker.takeDeltasForCall("shell-2")).toBeUndefined();
+	});
+});
+
+describe("mergeShellOutputDeltasIntoCursorToolCall", () => {
+	it("fills empty completed stdout from buffered deltas", () => {
+		const merged = mergeShellOutputDeltasIntoCursorToolCall(
+			{
+				name: "shell",
+				result: { status: "success", value: { stdout: "", stderr: "", exitCode: 0 } },
+			},
+			{ stdout: ["delta output\n"], stderr: [] },
+		);
+		expect(merged).toMatchObject({
+			result: { status: "success", value: { stdout: "delta output\n", stderr: "" } },
+		});
+	});
+
+	it("keeps completed stdout when already present", () => {
+		const toolCall = {
+			name: "shell",
+			result: { status: "success", value: { stdout: "completed\n", stderr: "" } },
+		};
+		expect(
+			mergeShellOutputDeltasIntoCursorToolCall(toolCall, {
+				stdout: ["delta\n"],
+				stderr: [],
+			}),
+		).toBe(toolCall);
+	});
+});
+
+describe("getCursorShellOutputDelta", () => {
+	it("parses stdout shell-output-delta updates", () => {
+		expect(
+			getCursorShellOutputDelta({
+				type: "shell-output-delta",
+				event: { case: "stdout", value: { data: "ok\n" } },
+			} as never),
+		).toEqual({ stream: "stdout", data: "ok\n" });
+	});
+});

--- a/test/cursor-provider-turn-tool-ledger.test.ts
+++ b/test/cursor-provider-turn-tool-ledger.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CursorToolCompletionLedger, getToolFingerprint } from "../src/cursor-provider-turn-tool-ledger.js";
+
+describe("CursorToolCompletionLedger", () => {
+	it("suppresses duplicate completions by identity", () => {
+		const ledger = new CursorToolCompletionLedger();
+		const fingerprint = getToolFingerprint({ toolName: "read", args: { path: "a.ts" }, result: {} });
+
+		ledger.recordCompletedTool({ identity: "cursor-tool:call-1", source: "started", fingerprint });
+		expect(
+			ledger.shouldSkipDuplicateCompletion({
+				identity: "cursor-tool:call-1",
+				source: "started",
+				fingerprint,
+			}),
+		).toBe("identity-already-completed");
+	});
+
+	it("suppresses started completions when fallback fingerprint already completed", () => {
+		const ledger = new CursorToolCompletionLedger();
+		const fingerprint = getToolFingerprint({ toolName: "grep", args: { pattern: "x" }, result: {} });
+
+		ledger.recordCompletedTool({ source: "fallback", fingerprint });
+		expect(
+			ledger.shouldSkipDuplicateCompletion({
+				identity: "cursor-tool:call-2",
+				source: "started",
+				fingerprint,
+			}),
+		).toBe("fallback-fingerprint-already-completed");
+	});
+
+	it("matches started tool calls by fingerprint for step completions", () => {
+		const ledger = new CursorToolCompletionLedger();
+		const toolCall = { toolName: "shell", args: { command: "echo hi" } };
+		ledger.registerStartedToolCall("call-a", toolCall);
+
+		expect(ledger.removeStartedToolCallForStep(toolCall, "other-id")).toBe("call-a");
+		expect(ledger.hasStartedToolCall("call-a")).toBe(false);
+	});
+
+	it("tracks bridge-started call ids separately from normal starts", () => {
+		const ledger = new CursorToolCompletionLedger();
+		ledger.markBridgeStarted("bridge-1");
+		expect(ledger.takeBridgeStartedCallId("bridge-1")).toBe("bridge-1");
+		expect(ledger.takeBridgeStartedCallId("bridge-1")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Decompose `CursorSdkTurnCoordinator` into focused collaborators: shell-output tracker, tool completion ledger, SDK completion normalizer, display/replay router, and lifecycle emitter.
- Keep `CursorSdkTurnCoordinator` as a thin orchestration layer; provider streaming/replay/trace behavior is unchanged.
- Add focused unit tests for ledger, shell-output merging, and SDK normalization; existing replay-shell and tool-lifecycle provider tests pass.

Closes #82.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` (560/560)
- [x] Focused: `test/cursor-provider-turn-{shell-output,tool-ledger,sdk-normalizer}.test.ts`
- [x] Provider regression: `test/cursor-provider-replay-shell.test.ts`, `test/cursor-provider-tool-lifecycle.test.ts`
- [x] `npm pack --dry-run`
- [x] `git diff --check origin/main...HEAD`

## Live smoke

Skipped — behavior-preserving refactor only; no runtime contract changes beyond internal module boundaries.

Made with [Cursor](https://cursor.com)