### PR TITLE
Refactor provider turn cleanup and canonical run outcomes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-provider-turn-send.ts` owns SDK `agent.send()` wiring and abort listener registration.
 - `src/cursor-provider-turn-finalize.ts` owns unified `awaitFinalizeCursorRunOutcome()` (wait, transcript replay, incomplete tools, artifacts, context cache).
 - `src/cursor-provider-turn-emit.ts` owns live vs direct emission from finalized outcomes.
-- `src/cursor-provider-turn-types.ts` owns immutable turn phase data and mutable per-turn runtime state.
+- `src/cursor-provider-turn-types.ts` owns immutable turn phase data, explicit phase handle types, and the runner cleanup registry.
 - `src/cursor-provider-run-outcome.ts` owns the discriminated `CursorRunOutcome` model and live vs direct emission classification.
 - `src/cursor-run-final-text.ts` owns final assistant text selection for run outcomes and live-run drain.
 - `src/cursor-provider-errors.ts` owns scrubbed Cursor SDK run failure detail, abort reason formatting, and provider error sanitization.

--- a/src/cursor-provider-run-outcome.ts
+++ b/src/cursor-provider-run-outcome.ts
@@ -21,21 +21,18 @@ export type CursorRunOutcome =
 			finalText: string;
 			incompleteTools: IncompleteCursorToolRunOutcome;
 			assistantTextProduced: boolean;
-			signalAborted?: boolean;
 	  }
 	| {
 			kind: "cancelled";
 			waitResult: RunResult;
 			incompleteTools: IncompleteCursorToolRunOutcome;
 			abortMessage: string;
-			signalAborted?: boolean;
 	  }
 	| {
 			kind: "error";
 			waitResult: RunResult;
 			incompleteTools: IncompleteCursorToolRunOutcome;
 			errorMessage: string;
-			signalAborted?: boolean;
 	  };
 
 export interface ResolveCursorRunOutcomeParams {
@@ -63,93 +60,96 @@ function hasCursorAssistantText(
 }
 
 export function isCursorRunFinishedSuccessfully(outcome: CursorRunOutcome): boolean {
-	return outcome.kind === "finished" && !outcome.signalAborted;
+	return outcome.kind === "finished";
+}
+
+function buildCursorRunAbortMessage(signalAborted: boolean | undefined, sdkStatusCancelled: boolean): string {
+	return formatCursorSdkAbortMessage(
+		resolveCursorSdkAbortCause({
+			signalAborted,
+			sdkStatusCancelled,
+		}),
+	);
 }
 
 export function resolveCursorRunOutcome(params: ResolveCursorRunOutcomeParams): CursorRunOutcome {
 	const { waitResult, signalAborted } = params;
-	const finishedSuccessfully = waitResult.status === "finished" && !signalAborted;
-	const incompleteToolsInput: IncompleteCursorToolRunOutcomeInput = {
-		status: waitResult.status,
-		signalAborted,
-		assistantTextProduced:
-			finishedSuccessfully &&
-			hasCursorAssistantText(waitResult.result, params.textDeltas, params.planTextCandidate),
-	};
-	const incompleteTools = buildIncompleteCursorToolRunOutcome(incompleteToolsInput);
+	const sdkCancelled = waitResult.status === "cancelled";
+	const callerAborted = signalAborted === true;
+
+	if (callerAborted || sdkCancelled) {
+		const incompleteTools = buildIncompleteCursorToolRunOutcome({
+			status: "cancelled",
+			signalAborted: callerAborted,
+			assistantTextProduced: false,
+		});
+		return {
+			kind: "cancelled",
+			waitResult,
+			incompleteTools,
+			abortMessage: buildCursorRunAbortMessage(callerAborted, sdkCancelled),
+		};
+	}
 
 	if (waitResult.status === "error") {
 		const failureDetail = formatCursorSdkRunFailureDetail(waitResult, params.runResultFallback);
 		return {
 			kind: "error",
 			waitResult,
-			incompleteTools,
+			incompleteTools: buildIncompleteCursorToolRunOutcome({
+				status: "error",
+				assistantTextProduced: false,
+			}),
 			errorMessage: sanitizeCursorProviderError(failureDetail, params.resolvedApiKey ?? params.optionsApiKey),
-			signalAborted,
 		};
 	}
 
-	if (waitResult.status === "cancelled") {
-		return {
-			kind: "cancelled",
-			waitResult,
-			incompleteTools,
-			abortMessage: formatCursorSdkAbortMessage(
-				resolveCursorSdkAbortCause({
-					signalAborted,
-					sdkStatusCancelled: true,
-				}),
-			),
-			signalAborted,
-		};
-	}
-
-	const finalText = finishedSuccessfully
-		? selectCursorFinalText(
-				waitResult.result,
-				params.textDeltas,
-				params.emittedText,
-				params.planTextCandidate,
-				params.selectFinalTextOptions,
-			)
-		: "";
+	const assistantTextProduced = hasCursorAssistantText(
+		waitResult.result,
+		params.textDeltas,
+		params.planTextCandidate,
+	);
+	const incompleteTools = buildIncompleteCursorToolRunOutcome({
+		status: waitResult.status,
+		assistantTextProduced,
+	});
+	const finalText = selectCursorFinalText(
+		waitResult.result,
+		params.textDeltas,
+		params.emittedText,
+		params.planTextCandidate,
+		params.selectFinalTextOptions,
+	);
 
 	return {
 		kind: "finished",
 		waitResult,
 		finalText,
 		incompleteTools,
-		assistantTextProduced: incompleteToolsInput.assistantTextProduced ?? false,
-		signalAborted,
+		assistantTextProduced,
 	};
 }
 
 export type CursorRunLiveEmission = "finished" | "cancelled" | "failed";
 
-function cursorRunOutcomeSignalAborted(outcome: CursorRunOutcome): boolean | undefined {
-	return outcome.signalAborted;
-}
-
 export function classifyCursorRunLiveEmission(outcome: CursorRunOutcome): CursorRunLiveEmission {
-	if (isCursorRunFinishedSuccessfully(outcome)) return "finished";
-	if (outcome.kind === "cancelled" || cursorRunOutcomeSignalAborted(outcome)) return "cancelled";
-	return "failed";
+	switch (outcome.kind) {
+		case "finished":
+			return "finished";
+		case "cancelled":
+			return "cancelled";
+		case "error":
+			return "failed";
+	}
 }
 
 export type CursorRunDirectEmission = "finished" | "cancelled" | "failed";
 
 export function classifyCursorRunDirectEmission(outcome: CursorRunOutcome): CursorRunDirectEmission {
-	if (outcome.kind === "cancelled") return "cancelled";
-	if (outcome.kind === "error") return "failed";
-	return "finished";
+	return classifyCursorRunLiveEmission(outcome);
 }
 
 export function getCursorRunAbortMessage(outcome: CursorRunOutcome): string {
 	if (outcome.kind === "cancelled") return outcome.abortMessage;
-	return formatCursorSdkAbortMessage(
-		resolveCursorSdkAbortCause({
-			signalAborted: cursorRunOutcomeSignalAborted(outcome),
-			sdkStatusCancelled: outcome.waitResult.status === "cancelled",
-		}),
-	);
+	return buildCursorRunAbortMessage(false, outcome.waitResult.status === "cancelled");
 }

--- a/src/cursor-provider-turn-emit.ts
+++ b/src/cursor-provider-turn-emit.ts
@@ -24,8 +24,8 @@ import type { installCursorSdkAbortErrorSuppression } from "./cursor-sdk-abort-e
 import type { SessionCursorAgentLease } from "./cursor-session-agent.js";
 import { awaitFinalizeCursorRunOutcome } from "./cursor-provider-turn-finalize.js";
 import type {
+	CursorProviderTurnCleanup,
 	CursorProviderTurnRunnerParams,
-	CursorProviderTurnRuntime,
 	CursorProviderTurnSend,
 } from "./cursor-provider-turn-types.js";
 
@@ -52,7 +52,7 @@ function applyLiveRunOutcome(
 
 export interface EmitCursorLiveTurnParams {
 	params: CursorProviderTurnRunnerParams;
-	runtime: CursorProviderTurnRuntime;
+	cleanup: CursorProviderTurnCleanup;
 	send: CursorProviderTurnSend;
 	sdkAbortErrorSuppression: ReturnType<typeof installCursorSdkAbortErrorSuppression>;
 	discardIncompleteTools: (outcome: IncompleteCursorToolRunOutcomeInput) => void;
@@ -60,15 +60,15 @@ export interface EmitCursorLiveTurnParams {
 }
 
 export async function emitCursorLiveTurn(emitParams: EmitCursorLiveTurnParams): Promise<void> {
-	const { params, runtime, send, sdkAbortErrorSuppression, discardIncompleteTools, finalizeSdkEventDebug } = emitParams;
+	const { params, cleanup, send, sdkAbortErrorSuppression, discardIncompleteTools, finalizeSdkEventDebug } = emitParams;
 	const { run, prepared, cursorAgentMessageOffset } = send;
 	const { liveRun, turnCoordinator, sessionAgentLease, bootstrap } = prepared;
 	if (!liveRun) return;
 
-	runtime.deferSdkEventDebugFinalize = true;
+	cleanup.deferSdkEventDebugFinalize = true;
 	const activeSessionAgentLease = sessionAgentLease;
 	const { options, model } = params;
-	const { sdkEventDebug } = runtime;
+	const { sdkEventDebug, resolvedApiKey } = cleanup;
 
 	const waitCompletion = awaitFinalizeCursorRunOutcome({
 		run,
@@ -77,7 +77,7 @@ export async function emitCursorLiveTurn(emitParams: EmitCursorLiveTurnParams): 
 		modelId: model.id,
 		signalAborted: options?.signal?.aborted,
 		runResultFallback: run.result,
-		resolvedApiKey: runtime.resolvedApiKey,
+		resolvedApiKey,
 		optionsApiKey: options?.apiKey,
 		sdkEventDebug,
 		cacheContextWindow: true,
@@ -95,7 +95,7 @@ export async function emitCursorLiveTurn(emitParams: EmitCursorLiveTurnParams): 
 			if (liveRun.disposed) return;
 			cursorLiveRuns.markError(
 				liveRun,
-				sanitizeCursorProviderError(error, runtime.resolvedApiKey ?? options?.apiKey),
+				sanitizeCursorProviderError(error, resolvedApiKey ?? options?.apiKey),
 			);
 		});
 
@@ -138,28 +138,29 @@ export async function emitCursorLiveTurn(emitParams: EmitCursorLiveTurnParams): 
 
 export interface EmitCursorDirectOutcomeParams {
 	params: CursorProviderTurnRunnerParams;
-	runtime: CursorProviderTurnRuntime;
+	cleanup: CursorProviderTurnCleanup;
 	send: CursorProviderTurnSend;
 	outcome: CursorRunOutcome;
 }
 
 export async function emitCursorDirectOutcome(emitParams: EmitCursorDirectOutcomeParams): Promise<void> {
-	const { params, runtime, send, outcome } = emitParams;
+	const { params, cleanup, send, outcome } = emitParams;
 	const { prepared } = send;
 	const { turnCoordinator, sessionAgentLease, bootstrap, promptInputTokens } = prepared;
 	const { stream, partial, model, context } = params;
+	const sessionAgentScopeKey = cleanup.prepare?.sessionAgentScopeKey ?? "";
 
 	turnCoordinator.closeTraceBlock();
 
 	switch (classifyCursorRunDirectEmission(outcome)) {
 		case "cancelled":
-			await abandonSessionCursorAgent(runtime.sessionAgentScopeKey);
+			await abandonSessionCursorAgent(sessionAgentScopeKey);
 			partial.stopReason = "aborted";
 			partial.errorMessage = getCursorRunAbortMessage(outcome);
 			stream.push({ type: "error", reason: "aborted", error: partial });
 			break;
 		case "failed":
-			await abandonSessionCursorAgent(runtime.sessionAgentScopeKey);
+			await abandonSessionCursorAgent(sessionAgentScopeKey);
 			partial.stopReason = "error";
 			partial.errorMessage = outcome.kind === "error" ? outcome.errorMessage : "Cursor SDK run failed.";
 			stream.push({ type: "error", reason: "error", error: partial });
@@ -175,9 +176,9 @@ export async function emitCursorDirectOutcome(emitParams: EmitCursorDirectOutcom
 	}
 }
 
-export function discardIncompleteToolsFromRuntime(
-	runtime: CursorProviderTurnRuntime,
+export function discardIncompleteToolsFromCleanup(
+	cleanup: CursorProviderTurnCleanup,
 	outcome: IncompleteCursorToolRunOutcomeInput,
 ): void {
-	runtime.turnCoordinatorForCleanup?.discardIncompleteStartedToolCalls(buildIncompleteCursorToolRunOutcome(outcome));
+	cleanup.prepare?.turnCoordinator?.discardIncompleteStartedToolCalls(buildIncompleteCursorToolRunOutcome(outcome));
 }

--- a/src/cursor-provider-turn-emit.ts
+++ b/src/cursor-provider-turn-emit.ts
@@ -75,7 +75,7 @@ export async function emitCursorLiveTurn(emitParams: EmitCursorLiveTurnParams): 
 		prepared,
 		cursorAgentMessageOffset,
 		modelId: model.id,
-		signalAborted: options?.signal?.aborted,
+		signal: options?.signal,
 		runResultFallback: run.result,
 		resolvedApiKey,
 		optionsApiKey: options?.apiKey,

--- a/src/cursor-provider-turn-finalize.ts
+++ b/src/cursor-provider-turn-finalize.ts
@@ -28,7 +28,7 @@ export async function cacheSdkContextWindow(agentId: string, modelId: string): P
 export interface BuildCursorRunOutcomeParams {
 	waitResult: Awaited<ReturnType<Awaited<ReturnType<SDKAgent["send"]>>["wait"]>>;
 	prepared: CursorProviderTurnPrepared;
-	signalAborted?: boolean;
+	signal?: AbortSignal;
 	runResultFallback?: string;
 	resolvedApiKey?: string;
 	optionsApiKey?: string;
@@ -39,7 +39,7 @@ export function buildCursorRunOutcomeFromWait(params: BuildCursorRunOutcomeParam
 	const { turnCoordinator, textDeltas, liveRun } = prepared;
 	return resolveCursorRunOutcome({
 		waitResult,
-		signalAborted: params.signalAborted,
+		signalAborted: params.signal?.aborted,
 		textDeltas: liveRun?.textDeltas ?? textDeltas,
 		emittedText: liveRun?.emittedText ?? textDeltas.join(""),
 		planTextCandidate: turnCoordinator.planTextCandidate,
@@ -80,7 +80,7 @@ export interface AwaitFinalizeCursorRunOutcomeParams {
 	prepared: CursorProviderTurnPrepared;
 	cursorAgentMessageOffset: number | undefined;
 	modelId: string;
-	signalAborted?: boolean;
+	signal?: AbortSignal;
 	runResultFallback?: string;
 	resolvedApiKey?: string;
 	optionsApiKey?: string;
@@ -98,7 +98,7 @@ export async function awaitFinalizeCursorRunOutcome(params: AwaitFinalizeCursorR
 	const outcome = buildCursorRunOutcomeFromWait({
 		waitResult,
 		prepared: params.prepared,
-		signalAborted: params.signalAborted,
+		signal: params.signal,
 		runResultFallback: params.runResultFallback,
 		resolvedApiKey: params.resolvedApiKey,
 		optionsApiKey: params.optionsApiKey,

--- a/src/cursor-provider-turn-prepare.ts
+++ b/src/cursor-provider-turn-prepare.ts
@@ -11,6 +11,7 @@ import {
 import type { CursorPiBridgeToolRequest } from "./cursor-pi-tool-bridge.js";
 import { estimateCursorPromptInputTokens, getCursorPromptOptions } from "./cursor-usage-accounting.js";
 import { getActiveContextToolNames } from "./cursor-context-tools.js";
+import type { CursorLiveRun } from "./cursor-live-run-coordinator.js";
 import { cursorLiveRuns } from "./cursor-provider-live-run-drain.js";
 import { createCursorNativeReplayId } from "./cursor-provider-live-run-drain.js";
 import { getEffectiveFastForModelId } from "./cursor-state.js";
@@ -21,32 +22,38 @@ import { MISSING_CURSOR_API_KEY_MESSAGE } from "./cursor-provider-errors.js";
 import { CursorSdkTurnCoordinator } from "./cursor-provider-turn-coordinator.js";
 import { resolveCursorApiKey } from "./cursor-provider-turn-api-key.js";
 import type {
-	CursorProviderTurnPrepared,
+	CursorProviderTurnPrepareHandles,
+	CursorProviderTurnPrepareResult,
 	CursorProviderTurnRunnerParams,
-	CursorProviderTurnRuntime,
 } from "./cursor-provider-turn-types.js";
+import type { CursorSdkEventDebugSink } from "./cursor-sdk-event-debug.js";
 
 export interface PrepareCursorProviderTurnParams {
 	params: CursorProviderTurnRunnerParams;
-	runtime: CursorProviderTurnRuntime;
 	cwd: string;
 	resolvedApiKey: string;
+	sdkEventDebug: CursorSdkEventDebugSink | undefined;
 	throwIfAborted: () => void;
+	/** Merges concrete prepare handles as they become available for runner cleanup on early abort. */
+	registerPrepareHandles: (handles: Partial<CursorProviderTurnPrepareHandles>) => void;
 }
 
 export async function prepareCursorProviderTurn(
 	prepareParams: PrepareCursorProviderTurnParams,
-): Promise<CursorProviderTurnPrepared> {
-	const { params, runtime, cwd, resolvedApiKey, throwIfAborted } = prepareParams;
+): Promise<CursorProviderTurnPrepareResult> {
+	const { params, cwd, resolvedApiKey, sdkEventDebug, throwIfAborted, registerPrepareHandles } = prepareParams;
 	const { model, context, options } = params;
-	const { sdkEventDebug } = runtime;
 
 	const fastEnabled = getEffectiveFastForModelId(model.id);
 	const selection = buildCursorModelSelection(model.id, options?.reasoning ?? "off", fastEnabled);
 	const settingSources = getEffectiveCursorSettingSources();
 
 	installCursorMcpToolTimeoutOverride();
-	runtime.restoreCursorSdkOutputFilter = installCursorSdkOutputFilter();
+	const restoreCursorSdkOutputFilter = installCursorSdkOutputFilter();
+	registerPrepareHandles({ restoreCursorSdkOutputFilter });
+	const queuedBridgeRequestsBeforeLiveRun: CursorPiBridgeToolRequest[] = [];
+	let liveRunForBridgeQueue: CursorLiveRun | undefined;
+
 	const sessionAgentAcquireParams = {
 		apiKey: resolvedApiKey,
 		cwd,
@@ -54,26 +61,26 @@ export async function prepareCursorProviderTurn(
 		settingSources,
 		debugRecorder: sdkEventDebug,
 		onBridgeToolRequest: (request: CursorPiBridgeToolRequest) => {
-			if (runtime.liveRunForBridgeQueue && !runtime.liveRunForBridgeQueue.disposed) {
-				cursorLiveRuns.queueEvent(runtime.liveRunForBridgeQueue, { type: "bridge-tool", request });
+			if (liveRunForBridgeQueue && !liveRunForBridgeQueue.disposed) {
+				cursorLiveRuns.queueEvent(liveRunForBridgeQueue, { type: "bridge-tool", request });
 			} else {
-				runtime.queuedBridgeRequestsBeforeLiveRun.push(request);
+				queuedBridgeRequestsBeforeLiveRun.push(request);
 			}
 		},
 		createAgent: (createOptions: Parameters<typeof Agent.create>[0]) =>
 			suppressCursorSdkOutput(() => Agent.create(createOptions)),
 	};
 	let sessionAgentLease = await acquireSessionCursorAgent(sessionAgentAcquireParams);
-	runtime.sessionAgentScopeKey = sessionAgentLease.scopeKey;
+	const sessionAgentScopeKey = sessionAgentLease.scopeKey;
+	registerPrepareHandles({ sessionAgentScopeKey });
 	throwIfAborted();
 
 	const promptOptions = getCursorPromptOptions(model);
 	let sendPlan = planCursorSessionSend(sessionAgentLease.sendState, context);
 	let prompt = buildCursorSessionSendPrompt(context, promptOptions, sendPlan);
 	if (sendPlan.resetAgent) {
-		await resetSessionCursorAgent(sessionAgentLease.scopeKey);
+		await resetSessionCursorAgent(sessionAgentScopeKey);
 		sessionAgentLease = await acquireSessionCursorAgent(sessionAgentAcquireParams);
-		runtime.sessionAgentScopeKey = sessionAgentLease.scopeKey;
 		sendPlan = planCursorSessionSend(sessionAgentLease.sendState, context);
 		prompt = buildCursorSessionSendPrompt(context, promptOptions, sendPlan);
 	}
@@ -102,7 +109,7 @@ export async function prepareCursorProviderTurn(
 		sendPlan,
 		promptOptions,
 		activeToolNames: activeToolNames ? [...activeToolNames] : [],
-		sessionAgentScopeKey: runtime.sessionAgentScopeKey,
+		sessionAgentScopeKey,
 		bridgeRunId: bridgeRun?.id,
 	});
 	const nativeReplayId = createCursorNativeReplayId();
@@ -114,16 +121,15 @@ export async function prepareCursorProviderTurn(
 				agent,
 				bridgeRun,
 				sessionBridgeRun,
-				sessionAgentScopeKey: runtime.sessionAgentScopeKey,
+				sessionAgentScopeKey,
 				promptInputTokens,
 				textDeltas,
 				debugRecorder: sdkEventDebug,
 			})
 		: undefined;
 	if (liveRun) {
-		runtime.activeLiveRun = liveRun;
-		runtime.liveRunForBridgeQueue = liveRun;
-		for (const request of runtime.queuedBridgeRequestsBeforeLiveRun.splice(0)) {
+		liveRunForBridgeQueue = liveRun;
+		for (const request of queuedBridgeRequestsBeforeLiveRun.splice(0)) {
 			cursorLiveRuns.queueEvent(liveRun, { type: "bridge-tool", request });
 		}
 	}
@@ -139,24 +145,32 @@ export async function prepareCursorProviderTurn(
 		textDeltas,
 		debugRecorder: sdkEventDebug,
 	});
-	runtime.turnCoordinatorForCleanup = turnCoordinator;
+	registerPrepareHandles({ activeLiveRun: liveRun, turnCoordinator });
 
 	return {
-		cwd,
-		sessionAgentLease,
-		agent,
-		bridgeRun,
-		sendPlan,
-		prompt,
-		sendPayload,
-		bootstrap,
-		promptInputTokens,
-		useNativeToolReplay,
-		activeToolNames,
-		nativeReplayId,
-		textDeltas,
-		liveRun,
-		turnCoordinator,
+		prepared: {
+			cwd,
+			sessionAgentLease,
+			agent,
+			bridgeRun,
+			sendPlan,
+			prompt,
+			sendPayload,
+			bootstrap,
+			promptInputTokens,
+			useNativeToolReplay,
+			activeToolNames,
+			nativeReplayId,
+			textDeltas,
+			liveRun,
+			turnCoordinator,
+		},
+		handles: {
+			sessionAgentScopeKey,
+			restoreCursorSdkOutputFilter,
+			activeLiveRun: liveRun,
+			turnCoordinator,
+		},
 	};
 }
 

--- a/src/cursor-provider-turn-runner.ts
+++ b/src/cursor-provider-turn-runner.ts
@@ -14,23 +14,23 @@ import { installCursorSdkAbortErrorSuppression } from "./cursor-sdk-abort-error-
 import { CursorSdkEventDebugSink } from "./cursor-sdk-event-debug.js";
 import { awaitFinalizeCursorRunOutcome } from "./cursor-provider-turn-finalize.js";
 import {
-	discardIncompleteToolsFromRuntime,
+	discardIncompleteToolsFromCleanup,
 	emitCursorDirectOutcome,
 	emitCursorLiveTurn,
 } from "./cursor-provider-turn-emit.js";
 import { prepareCursorProviderTurn, requireCursorApiKey } from "./cursor-provider-turn-prepare.js";
 import { sendCursorProviderTurn } from "./cursor-provider-turn-send.js";
 import {
-	createCursorProviderTurnRuntime,
+	createCursorProviderTurnCleanup,
+	type CursorProviderTurnCleanup,
 	type CursorProviderTurnRunnerParams,
-	type CursorProviderTurnRuntime,
 } from "./cursor-provider-turn-types.js";
 
 export { resolveCursorApiKey } from "./cursor-provider-turn-api-key.js";
 export type { CursorProviderTurnRunnerParams } from "./cursor-provider-turn-types.js";
 
 export class CursorProviderTurnRunner {
-	private readonly runtime: CursorProviderTurnRuntime = createCursorProviderTurnRuntime();
+	private readonly cleanup: CursorProviderTurnCleanup = createCursorProviderTurnCleanup();
 
 	constructor(private readonly params: CursorProviderTurnRunnerParams) {}
 
@@ -39,7 +39,7 @@ export class CursorProviderTurnRunner {
 	}
 
 	private get sdkEventDebug() {
-		return this.runtime.sdkEventDebug;
+		return this.cleanup.sdkEventDebug;
 	}
 
 	private throwIfAborted(): void {
@@ -54,14 +54,14 @@ export class CursorProviderTurnRunner {
 				? formatCursorSdkAbortMessage(
 						resolveCursorSdkAbortCause({ signalAborted: options?.signal?.aborted }),
 					)
-				: sanitizeCursorProviderError(error, this.runtime.resolvedApiKey ?? options?.apiKey);
+				: sanitizeCursorProviderError(error, this.cleanup.resolvedApiKey ?? options?.apiKey);
 		this.params.stream.push({ type: "error", reason, error: partial });
 	}
 
 	private discardIncompleteTools(
 		outcome: import("./cursor-incomplete-tool-visibility.js").IncompleteCursorToolRunOutcomeInput,
 	): void {
-		discardIncompleteToolsFromRuntime(this.runtime, outcome);
+		discardIncompleteToolsFromCleanup(this.cleanup, outcome);
 	}
 
 	private async finalizeSdkEventDebug(): Promise<void> {
@@ -76,12 +76,12 @@ export class CursorProviderTurnRunner {
 			stream.push({ type: "start", partial });
 			this.throwIfAborted();
 			const cwd = getCursorSessionCwd();
-			this.runtime.sdkEventDebug = CursorSdkEventDebugSink.maybeCreate({
+			this.cleanup.sdkEventDebug = CursorSdkEventDebugSink.maybeCreate({
 				cwd,
 				modelId: model.id,
 				provider: model.provider,
 			});
-			sdkEventDebugRef.current = this.runtime.sdkEventDebug;
+			sdkEventDebugRef.current = this.cleanup.sdkEventDebug;
 			this.sdkEventDebug?.recordContextSnapshot(context);
 			if (
 				(await drainExistingCursorLiveRunBeforeSend(stream, partial, model, context, options?.signal, this.sdkEventDebug)) ===
@@ -92,27 +92,34 @@ export class CursorProviderTurnRunner {
 				return;
 			}
 
-			this.runtime.resolvedApiKey = requireCursorApiKey(options);
-			const prepared = await prepareCursorProviderTurn({
+			this.cleanup.resolvedApiKey = requireCursorApiKey(options);
+			const { prepared, handles: prepareHandles } = await prepareCursorProviderTurn({
 				params: this.params,
-				runtime: this.runtime,
 				cwd,
-				resolvedApiKey: this.runtime.resolvedApiKey,
+				resolvedApiKey: this.cleanup.resolvedApiKey,
+				sdkEventDebug: this.cleanup.sdkEventDebug,
 				throwIfAborted: () => this.throwIfAborted(),
+				registerPrepareHandles: (partial) => {
+					this.cleanup.prepare = { ...this.cleanup.prepare, ...partial };
+				},
 			});
-			const sent = await sendCursorProviderTurn({
+			this.cleanup.prepare = { ...this.cleanup.prepare, ...prepareHandles };
+
+			const { send, handles: sendHandles } = await sendCursorProviderTurn({
 				params: this.params,
-				runtime: this.runtime,
+				cleanup: this.cleanup,
 				prepared,
+				sdkEventDebug: this.cleanup.sdkEventDebug,
 				sdkAbortErrorSuppression,
 				throwIfAborted: () => this.throwIfAborted(),
 			});
+			this.cleanup.send = sendHandles;
 
 			if (prepared.liveRun) {
 				await emitCursorLiveTurn({
 					params: this.params,
-					runtime: this.runtime,
-					send: sent,
+					cleanup: this.cleanup,
+					send,
 					sdkAbortErrorSuppression,
 					discardIncompleteTools: (outcome) => this.discardIncompleteTools(outcome),
 					finalizeSdkEventDebug: () => this.finalizeSdkEventDebug(),
@@ -121,33 +128,34 @@ export class CursorProviderTurnRunner {
 			}
 
 			const outcome = await awaitFinalizeCursorRunOutcome({
-				run: sent.run,
-				prepared: sent.prepared,
-				cursorAgentMessageOffset: sent.cursorAgentMessageOffset,
+				run: send.run,
+				prepared: send.prepared,
+				cursorAgentMessageOffset: send.cursorAgentMessageOffset,
 				modelId: model.id,
 				signalAborted: options?.signal?.aborted,
-				runResultFallback: sent.run.result,
-				resolvedApiKey: this.runtime.resolvedApiKey,
+				runResultFallback: send.run.result,
+				resolvedApiKey: this.cleanup.resolvedApiKey,
 				optionsApiKey: options?.apiKey,
-				sdkEventDebug: this.runtime.sdkEventDebug,
+				sdkEventDebug: this.cleanup.sdkEventDebug,
 				contextWindowAgentId: prepared.agent.agentId,
 			});
 			await emitCursorDirectOutcome({
 				params: this.params,
-				runtime: this.runtime,
-				send: sent,
+				cleanup: this.cleanup,
+				send,
 				outcome,
 			});
 		} catch (error) {
-			this.runtime.sdkEventDebug?.recordError("provider_stream", error);
+			this.cleanup.sdkEventDebug?.recordError("provider_stream", error);
 			this.discardIncompleteTools({
 				status: error instanceof CursorLiveRunAbortError ? "cancelled" : "error",
 				signalAborted: error instanceof CursorLiveRunAbortError,
 			});
-			if (this.runtime.activeLiveRun && !this.runtime.activeLiveRun.disposed) {
-				await cursorLiveRuns.release(this.runtime.activeLiveRun);
+			const activeLiveRun = this.cleanup.prepare?.activeLiveRun;
+			if (activeLiveRun && !activeLiveRun.disposed) {
+				await cursorLiveRuns.release(activeLiveRun);
 			} else {
-				await abandonSessionCursorAgent(this.runtime.sessionAgentScopeKey);
+				await abandonSessionCursorAgent(this.cleanup.prepare?.sessionAgentScopeKey ?? "");
 			}
 			if (error instanceof CursorLiveRunAbortError) {
 				sdkAbortErrorSuppression.suppressAbortErrors();
@@ -156,12 +164,14 @@ export class CursorProviderTurnRunner {
 				this.pushSanitizedStreamError(error, "error");
 			}
 		} finally {
-			await this.cleanup(sdkAbortErrorSuppression);
+			await this.cleanupTurn(sdkAbortErrorSuppression);
 		}
 	}
 
-	private async cleanup(sdkAbortErrorSuppression: ReturnType<typeof installCursorSdkAbortErrorSuppression>): Promise<void> {
-		if (!this.runtime.deferSdkEventDebugFinalize) {
+	private async cleanupTurn(
+		sdkAbortErrorSuppression: ReturnType<typeof installCursorSdkAbortErrorSuppression>,
+	): Promise<void> {
+		if (!this.cleanup.deferSdkEventDebugFinalize) {
 			try {
 				await this.finalizeSdkEventDebug();
 			} finally {
@@ -169,17 +179,19 @@ export class CursorProviderTurnRunner {
 			}
 		}
 		this.params.sdkEventDebugRef.current = undefined;
-		this.runtime.restoreCursorSdkOutputFilter?.();
-		if (this.runtime.abortSignal && this.runtime.abortListener) {
-			this.runtime.abortSignal.removeEventListener("abort", this.runtime.abortListener);
+		this.cleanup.prepare?.restoreCursorSdkOutputFilter?.();
+		const abortRegistration = this.cleanup.send?.abortRegistration;
+		if (abortRegistration) {
+			abortRegistration.signal.removeEventListener("abort", abortRegistration.listener);
 		}
 	}
 
 	async handleOuterCatch(error: unknown): Promise<void> {
-		if (this.runtime.activeLiveRun && !this.runtime.activeLiveRun.disposed) {
-			await cursorLiveRuns.release(this.runtime.activeLiveRun).catch(() => {});
+		const activeLiveRun = this.cleanup.prepare?.activeLiveRun;
+		if (activeLiveRun && !activeLiveRun.disposed) {
+			await cursorLiveRuns.release(activeLiveRun).catch(() => {});
 		} else {
-			await abandonSessionCursorAgent(this.runtime.sessionAgentScopeKey).catch(() => {});
+			await abandonSessionCursorAgent(this.cleanup.prepare?.sessionAgentScopeKey ?? "").catch(() => {});
 		}
 		this.pushSanitizedStreamError(error, error instanceof CursorLiveRunAbortError ? "aborted" : "error");
 	}

--- a/src/cursor-provider-turn-runner.ts
+++ b/src/cursor-provider-turn-runner.ts
@@ -107,11 +107,13 @@ export class CursorProviderTurnRunner {
 
 			const { send, handles: sendHandles } = await sendCursorProviderTurn({
 				params: this.params,
-				cleanup: this.cleanup,
 				prepared,
 				sdkEventDebug: this.cleanup.sdkEventDebug,
 				sdkAbortErrorSuppression,
 				throwIfAborted: () => this.throwIfAborted(),
+				registerSendHandles: (partial) => {
+					this.cleanup.send = { ...this.cleanup.send, ...partial };
+				},
 			});
 			this.cleanup.send = sendHandles;
 
@@ -132,7 +134,7 @@ export class CursorProviderTurnRunner {
 				prepared: send.prepared,
 				cursorAgentMessageOffset: send.cursorAgentMessageOffset,
 				modelId: model.id,
-				signalAborted: options?.signal?.aborted,
+				signal: options?.signal,
 				runResultFallback: send.run.result,
 				resolvedApiKey: this.cleanup.resolvedApiKey,
 				optionsApiKey: options?.apiKey,

--- a/src/cursor-provider-turn-send.ts
+++ b/src/cursor-provider-turn-send.ts
@@ -3,36 +3,41 @@ import { cursorLiveRuns } from "./cursor-provider-live-run-drain.js";
 import { getCursorAgentMessageOffset } from "./cursor-provider-turn-finalize.js";
 import type { installCursorSdkAbortErrorSuppression } from "./cursor-sdk-abort-error-guard.js";
 import type {
+	CursorProviderTurnCleanup,
 	CursorProviderTurnPrepared,
 	CursorProviderTurnRunnerParams,
-	CursorProviderTurnRuntime,
-	CursorProviderTurnSend,
+	CursorProviderTurnSendResult,
 } from "./cursor-provider-turn-types.js";
+import type { CursorSdkEventDebugSink } from "./cursor-sdk-event-debug.js";
 
 export interface SendCursorProviderTurnParams {
 	params: CursorProviderTurnRunnerParams;
-	runtime: CursorProviderTurnRuntime;
+	cleanup: CursorProviderTurnCleanup;
 	prepared: CursorProviderTurnPrepared;
+	sdkEventDebug: CursorSdkEventDebugSink | undefined;
 	sdkAbortErrorSuppression: ReturnType<typeof installCursorSdkAbortErrorSuppression>;
 	throwIfAborted: () => void;
 }
 
-export async function sendCursorProviderTurn(sendParams: SendCursorProviderTurnParams): Promise<CursorProviderTurnSend> {
-	const { params, runtime, prepared, sdkAbortErrorSuppression, throwIfAborted } = sendParams;
+export async function sendCursorProviderTurn(sendParams: SendCursorProviderTurnParams): Promise<CursorProviderTurnSendResult> {
+	const { params, cleanup, prepared, sdkEventDebug, sdkAbortErrorSuppression, throwIfAborted } = sendParams;
 	const { options } = params;
 	const { agent, turnCoordinator, sendPlan, bootstrap, liveRun, prompt, sendPayload, cwd } = prepared;
-	const { sdkEventDebug } = runtime;
+	const activeLiveRun = cleanup.prepare?.activeLiveRun;
 
-	runtime.sdkRun = null;
-	runtime.abortListener = () => {
+	let sdkRun: Awaited<ReturnType<typeof agent.send>> | null = null;
+	const abortListener = () => {
 		sdkAbortErrorSuppression.suppressAbortErrors();
-		runtime.activeLiveRun?.bridgeRun?.cancel("Cursor SDK run aborted");
-		if (runtime.sdkRun) {
-			runtime.sdkRun.cancel().catch(() => {});
+		activeLiveRun?.bridgeRun?.cancel("Cursor SDK run aborted");
+		if (sdkRun) {
+			sdkRun.cancel().catch(() => {});
 		}
 	};
-	runtime.abortSignal = options?.signal;
-	runtime.abortSignal?.addEventListener("abort", runtime.abortListener, { once: true });
+	const abortSignal = options?.signal;
+	const abortRegistration = abortSignal
+		? { signal: abortSignal, listener: abortListener }
+		: undefined;
+	abortSignal?.addEventListener("abort", abortListener, { once: true });
 
 	throwIfAborted();
 	const cursorAgentMessageOffset = await getCursorAgentMessageOffset(agent.agentId, cwd, sdkEventDebug);
@@ -61,7 +66,7 @@ export async function sendCursorProviderTurn(sendParams: SendCursorProviderTurnP
 			turnCoordinator.handleStep(args.step);
 		},
 	});
-	runtime.sdkRun = run;
+	sdkRun = run;
 	sdkEventDebug?.recordRunMeta({
 		runId: run.id,
 		agentId: run.agentId,
@@ -81,5 +86,8 @@ export async function sendCursorProviderTurn(sendParams: SendCursorProviderTurnP
 		throw new CursorLiveRunAbortError();
 	}
 
-	return { run, prepared, cursorAgentMessageOffset };
+	return {
+		send: { run, prepared, cursorAgentMessageOffset },
+		handles: { abortRegistration },
+	};
 }

--- a/src/cursor-provider-turn-send.ts
+++ b/src/cursor-provider-turn-send.ts
@@ -3,32 +3,31 @@ import { cursorLiveRuns } from "./cursor-provider-live-run-drain.js";
 import { getCursorAgentMessageOffset } from "./cursor-provider-turn-finalize.js";
 import type { installCursorSdkAbortErrorSuppression } from "./cursor-sdk-abort-error-guard.js";
 import type {
-	CursorProviderTurnCleanup,
 	CursorProviderTurnPrepared,
 	CursorProviderTurnRunnerParams,
+	CursorProviderTurnSendHandles,
 	CursorProviderTurnSendResult,
 } from "./cursor-provider-turn-types.js";
 import type { CursorSdkEventDebugSink } from "./cursor-sdk-event-debug.js";
 
 export interface SendCursorProviderTurnParams {
 	params: CursorProviderTurnRunnerParams;
-	cleanup: CursorProviderTurnCleanup;
 	prepared: CursorProviderTurnPrepared;
 	sdkEventDebug: CursorSdkEventDebugSink | undefined;
 	sdkAbortErrorSuppression: ReturnType<typeof installCursorSdkAbortErrorSuppression>;
 	throwIfAborted: () => void;
+	registerSendHandles: (partial: Partial<CursorProviderTurnSendHandles>) => void;
 }
 
 export async function sendCursorProviderTurn(sendParams: SendCursorProviderTurnParams): Promise<CursorProviderTurnSendResult> {
-	const { params, cleanup, prepared, sdkEventDebug, sdkAbortErrorSuppression, throwIfAborted } = sendParams;
+	const { params, prepared, sdkEventDebug, sdkAbortErrorSuppression, throwIfAborted, registerSendHandles } = sendParams;
 	const { options } = params;
 	const { agent, turnCoordinator, sendPlan, bootstrap, liveRun, prompt, sendPayload, cwd } = prepared;
-	const activeLiveRun = cleanup.prepare?.activeLiveRun;
 
 	let sdkRun: Awaited<ReturnType<typeof agent.send>> | null = null;
 	const abortListener = () => {
 		sdkAbortErrorSuppression.suppressAbortErrors();
-		activeLiveRun?.bridgeRun?.cancel("Cursor SDK run aborted");
+		liveRun?.bridgeRun?.cancel("Cursor SDK run aborted");
 		if (sdkRun) {
 			sdkRun.cancel().catch(() => {});
 		}
@@ -37,7 +36,10 @@ export async function sendCursorProviderTurn(sendParams: SendCursorProviderTurnP
 	const abortRegistration = abortSignal
 		? { signal: abortSignal, listener: abortListener }
 		: undefined;
-	abortSignal?.addEventListener("abort", abortListener, { once: true });
+	if (abortRegistration) {
+		abortRegistration.signal.addEventListener("abort", abortListener, { once: true });
+		registerSendHandles({ abortRegistration });
+	}
 
 	throwIfAborted();
 	const cursorAgentMessageOffset = await getCursorAgentMessageOffset(agent.agentId, cwd, sdkEventDebug);

--- a/src/cursor-provider-turn-types.ts
+++ b/src/cursor-provider-turn-types.ts
@@ -47,40 +47,50 @@ export interface CursorProviderTurnPrepared {
 	turnCoordinator: CursorSdkTurnCoordinator;
 }
 
+/** Concrete handles produced during prepare; owned by runner cleanup. */
+export interface CursorProviderTurnPrepareHandles {
+	sessionAgentScopeKey: string;
+	restoreCursorSdkOutputFilter: () => void;
+	activeLiveRun: CursorLiveRun | undefined;
+	turnCoordinator: CursorSdkTurnCoordinator;
+}
+
+export interface CursorProviderTurnPrepareResult {
+	prepared: CursorProviderTurnPrepared;
+	handles: CursorProviderTurnPrepareHandles;
+}
+
 export interface CursorProviderTurnSend {
 	run: Awaited<ReturnType<SDKAgent["send"]>>;
 	prepared: CursorProviderTurnPrepared;
 	cursorAgentMessageOffset: number | undefined;
 }
 
-export interface CursorProviderTurnRuntime {
-	sdkEventDebug: CursorSdkEventDebugSink | undefined;
-	resolvedApiKey: string | undefined;
-	sessionAgentScopeKey: string;
-	activeLiveRun: CursorLiveRun | undefined;
-	liveRunForBridgeQueue: CursorLiveRun | undefined;
-	queuedBridgeRequestsBeforeLiveRun: CursorPiBridgeToolRequest[];
-	abortSignal: AbortSignal | undefined;
-	abortListener: (() => void) | undefined;
-	restoreCursorSdkOutputFilter: (() => void) | undefined;
-	deferSdkEventDebugFinalize: boolean;
-	turnCoordinatorForCleanup: CursorSdkTurnCoordinator | undefined;
-	sdkRun: Awaited<ReturnType<SDKAgent["send"]>> | null;
+/** Concrete handles produced during send; owned by runner cleanup. */
+export interface CursorProviderTurnSendHandles {
+	abortRegistration: { signal: AbortSignal; listener: () => void } | undefined;
 }
 
-export function createCursorProviderTurnRuntime(): CursorProviderTurnRuntime {
+export interface CursorProviderTurnSendResult {
+	send: CursorProviderTurnSend;
+	handles: CursorProviderTurnSendHandles;
+}
+
+/** Explicit cleanup registry populated as phases complete; not a cross-phase API surface. */
+export interface CursorProviderTurnCleanup {
+	sdkEventDebug: CursorSdkEventDebugSink | undefined;
+	resolvedApiKey: string | undefined;
+	prepare: Partial<CursorProviderTurnPrepareHandles> | undefined;
+	send: CursorProviderTurnSendHandles | undefined;
+	deferSdkEventDebugFinalize: boolean;
+}
+
+export function createCursorProviderTurnCleanup(): CursorProviderTurnCleanup {
 	return {
 		sdkEventDebug: undefined,
 		resolvedApiKey: undefined,
-		sessionAgentScopeKey: "",
-		activeLiveRun: undefined,
-		liveRunForBridgeQueue: undefined,
-		queuedBridgeRequestsBeforeLiveRun: [],
-		abortSignal: undefined,
-		abortListener: undefined,
-		restoreCursorSdkOutputFilter: undefined,
+		prepare: undefined,
+		send: undefined,
 		deferSdkEventDebugFinalize: false,
-		turnCoordinatorForCleanup: undefined,
-		sdkRun: null,
 	};
 }

--- a/src/cursor-provider-turn-types.ts
+++ b/src/cursor-provider-turn-types.ts
@@ -81,7 +81,7 @@ export interface CursorProviderTurnCleanup {
 	sdkEventDebug: CursorSdkEventDebugSink | undefined;
 	resolvedApiKey: string | undefined;
 	prepare: Partial<CursorProviderTurnPrepareHandles> | undefined;
-	send: CursorProviderTurnSendHandles | undefined;
+	send: Partial<CursorProviderTurnSendHandles> | undefined;
 	deferSdkEventDebugFinalize: boolean;
 }
 

--- a/test/cursor-provider-run-outcome.test.ts
+++ b/test/cursor-provider-run-outcome.test.ts
@@ -18,28 +18,41 @@ function makeWaitResult(status: "finished" | "cancelled" | "error", result?: str
 }
 
 describe("cursor-provider-run-outcome", () => {
-	it("classifies live finished vs direct finished when signal aborted after SDK finish", () => {
+	it("normalizes signal-aborted finished waits to cancelled outcomes", () => {
 		const outcome = resolveCursorRunOutcome({
 			waitResult: makeWaitResult("finished", "hello"),
 			signalAborted: true,
 			textDeltas: ["hello"],
 			emittedText: "",
 		});
+		expect(outcome.kind).toBe("cancelled");
 		expect(isCursorRunFinishedSuccessfully(outcome)).toBe(false);
 		expect(classifyCursorRunLiveEmission(outcome)).toBe("cancelled");
-		expect(classifyCursorRunDirectEmission(outcome)).toBe("finished");
+		expect(classifyCursorRunDirectEmission(outcome)).toBe("cancelled");
 	});
 
-	it("classifies live cancelled but direct failed when wait errors after caller abort", () => {
+	it("normalizes signal-aborted error waits to cancelled outcomes", () => {
 		const outcome = resolveCursorRunOutcome({
 			waitResult: makeWaitResult("error", "boom"),
 			signalAborted: true,
 			textDeltas: [],
 			emittedText: "",
 		});
-		expect(outcome.kind).toBe("error");
+		expect(outcome.kind).toBe("cancelled");
 		expect(classifyCursorRunLiveEmission(outcome)).toBe("cancelled");
-		expect(classifyCursorRunDirectEmission(outcome)).toBe("failed");
+		expect(classifyCursorRunDirectEmission(outcome)).toBe("cancelled");
+	});
+
+	it("never produces finished outcomes with signalAborted", () => {
+		const outcome = resolveCursorRunOutcome({
+			waitResult: makeWaitResult("finished", "hello"),
+			signalAborted: true,
+			textDeltas: [],
+			emittedText: "",
+		});
+		if (outcome.kind === "finished") {
+			expect.fail("finished outcome must not carry caller abort");
+		}
 	});
 
 	it("classifies SDK cancelled and error statuses for both emission strategies", () => {

--- a/test/cursor-provider-stream-auth.test.ts
+++ b/test/cursor-provider-stream-auth.test.ts
@@ -198,6 +198,47 @@ describe("streamCursor auth and abort", () => {
 		bridgeCancelSpy.mockRestore();
 	});
 
+	it.each([
+		{ sdkStatus: "finished" as const, sdkResult: "hello" },
+		{ sdkStatus: "error" as const, sdkResult: "boom" },
+	])(
+		"treats caller abort during pending wait as cancelled when SDK resolves $sdkStatus",
+		async ({ sdkStatus, sdkResult }) => {
+			const controller = new AbortController();
+			let resolveWait!: (value: { id: string; status: typeof sdkStatus; result?: string }) => void;
+			const waitPromise = new Promise<{ id: string; status: typeof sdkStatus; result?: string }>((resolve) => {
+				resolveWait = resolve;
+			});
+			const mockSend = vi.fn().mockResolvedValue(
+				asMockCursorRun({
+					id: "run-1",
+					agentId: "agent-1",
+					status: "running",
+					wait: vi.fn().mockReturnValue(waitPromise),
+					cancel: vi.fn().mockResolvedValue(undefined),
+				}),
+			);
+			mockCreatedAgent({
+				send: mockSend,
+				[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+			});
+
+			const stream = streamCursor(makeModel(), makeContext(), {
+				apiKey: "test-key",
+				signal: controller.signal,
+			});
+			const eventsPromise = collectEvents(stream);
+
+			await vi.waitFor(() => expect(mockSend).toHaveBeenCalled());
+			controller.abort();
+			resolveWait({ id: "run-1", status: sdkStatus, result: sdkResult });
+
+			const events = await eventsPromise;
+			expect(getErrorEvent(events).reason).toBe("aborted");
+			expect(hasEventType(events, "done")).toBe(false);
+		},
+	);
+
 	it("cancels run on abort signal", async () => {
 		const controller = new AbortController();
 		const mockCancel = vi.fn().mockResolvedValue(undefined);
@@ -238,6 +279,57 @@ describe("streamCursor auth and abort", () => {
 		await collectEvents(stream);
 
 		expect(mockCancel).toHaveBeenCalled();
+	});
+
+	it("removes abort listener when agent.send throws after listener registration", async () => {
+		const controller = new AbortController();
+		const removeListenerSpy = vi.spyOn(AbortSignal.prototype, "removeEventListener");
+		const mockSend = vi.fn().mockRejectedValue(new Error("send failed"));
+		mockCreatedAgent({
+			send: mockSend,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+
+		const stream = streamCursor(makeModel(), makeContext(), {
+			apiKey: "test-key",
+			signal: controller.signal,
+		});
+		const events = await collectEvents(stream);
+
+		expect(getErrorEvent(events).reason).toBe("error");
+		expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+		removeListenerSpy.mockRestore();
+	});
+
+	it("removes abort listener when abort happens during send offset probing", async () => {
+		const controller = new AbortController();
+		const removeListenerSpy = vi.spyOn(AbortSignal.prototype, "removeEventListener");
+		let releaseMessagesList: () => void = () => {};
+		const messagesListGate = new Promise<void>((resolve) => {
+			releaseMessagesList = resolve;
+		});
+		mockedMessagesList.mockImplementation(async () => {
+			await messagesListGate;
+			return [];
+		});
+		const mockSend = vi.fn();
+		mockCreatedAgent({ send: mockSend });
+
+		const stream = streamCursor(makeModel(), makeContext(), {
+			apiKey: "test-key",
+			signal: controller.signal,
+		});
+		const eventsPromise = collectEvents(stream);
+
+		await vi.waitFor(() => expect(mockedMessagesList).toHaveBeenCalled());
+		controller.abort();
+		releaseMessagesList();
+		const events = await eventsPromise;
+
+		expect(getErrorEvent(events).reason).toBe("aborted");
+		expect(mockSend).not.toHaveBeenCalled();
+		expect(removeListenerSpy).toHaveBeenCalledWith("abort", expect.any(Function));
+		removeListenerSpy.mockRestore();
 	});
 
 	it("emits start before sanitized error and disposes abort suppression when debug run dir setup fails", async () => {


### PR DESCRIPTION
## Summary

Addresses final maintainability review findings **#1** and **#2** on the provider turn / run-outcome split.

- **Finding #1 — mutable phase-state bag:** Replaces `CursorProviderTurnRuntime` with explicit `CursorProviderTurnPrepareResult` / `CursorProviderTurnSendResult` handle types and a runner-owned `CursorProviderTurnCleanup` registry. Prepare/send phases return concrete handles; cleanup merges partial prepare handles as they become available (output-filter restore, session scope, coordinator) so early abort still abandons the session agent.
- **Finding #2 — finished-but-aborted outcomes:** `resolveCursorRunOutcome()` now normalizes caller-aborted waits to `kind: "cancelled"` at construction (including SDK `finished` + `signalAborted` and `error` + `signalAborted`). Removed `signalAborted` from the outcome union; live/direct classifiers map canonical `finished | cancelled | error` only.

Public provider streaming behavior is preserved; emission differences are rendering policy on canonical terminal states.

## Test plan

- [x] `git diff --check origin/main...HEAD`
- [x] `npm run typecheck`
- [x] Provider-focused tests (`cursor-provider-run-outcome`, stream-auth, turn, sdk-event-debug, session-agent`) plus abort-race regressions
- [x] `npm test` (578 passed)
- [x] `npm pack --dry-run`
- [x] `PI_LIVE_TIMEOUT=240 npm run smoke:isolated` — passed after `e283f50` with clean replay-error scans for basic provider, native replay, and plan-strip prompts. Artifact root: `/tmp/pi-cursor-sdk-isolated-20260526T190847` (local temp only; not committed).

## Files changed

- `src/cursor-provider-turn-types.ts` — phase result/handle types + cleanup registry
- `src/cursor-provider-turn-prepare.ts`, `send.ts`, `emit.ts`, `runner.ts` — explicit phase I/O
- `src/cursor-provider-run-outcome.ts` — canonical outcome normalization
- `test/cursor-provider-run-outcome.test.ts` — structural invariants
- `AGENTS.md` — repo map note


Made with [Cursor](https://cursor.com)
