### PR TITLE
Cache discovered Cursor model catalog to cut startup time (#78)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 ## Unreleased
 
+### Added
+
+- Cache the discovered Cursor model catalog on disk at `~/.pi/agent/cursor-sdk-model-list.json` (`0600`, keyed by an API-key fingerprint) so warm pi startups skip the live `Cursor.models.list` network round-trip that added several seconds to boot (#78). Tune with `PI_CURSOR_SDK_MODEL_CACHE_TTL_MS` (default 24h) or disable with `PI_CURSOR_SDK_DISABLE_MODEL_CACHE=1`.
+
 ### Changed
 
 - Clarify setup docs and runtime auth messages: `pi-cursor-sdk` requires a Cursor SDK API key and does not reuse Cursor Agent CLI/Desktop login or subscription auth.
+- `/cursor-refresh-models` now forces a live catalog refresh, bypassing the on-disk cache and rewriting it. A previously cached catalog is preferred over the bundled fallback when a live refresh fails.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,18 @@ pi --api-key "your-key" --model cursor/composer-2.5 --cursor-no-fast -p "Say ok 
 
 Discovery uses pi's native resolution order for this extension: `--api-key`, the stored `cursor` key in `~/.pi/agent/auth.json`, then `CURSOR_API_KEY`.
 
+### Model catalog cache
+
+To avoid a live `Cursor.models.list` network round-trip on every pi startup, the discovered catalog is cached on disk at `~/.pi/agent/cursor-sdk-model-list.json` (written `0600`, keyed by an API-key fingerprint — the key itself is never stored). Warm startups within the cache TTL skip the network call; `/cursor-refresh-models` always bypasses the cache and refreshes the live catalog. If a refresh fails, a previously cached catalog is preferred over the generic bundled fallback.
+
+```bash
+# Cache lifetime in milliseconds (default 86400000 = 24h).
+PI_CURSOR_SDK_MODEL_CACHE_TTL_MS=3600000 pi --model cursor/composer-2.5
+
+# Disable the cache and always discover live.
+PI_CURSOR_SDK_DISABLE_MODEL_CACHE=1 pi --model cursor/composer-2.5
+```
+
 Do not store the API key in `~/.pi/agent/cursor-sdk.json`. That file is only for non-secret extension state such as Cursor fast defaults. `PATH` is only for executable lookup and should not contain the API key.
 
 ## Verify your setup

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,7 @@ export default async function (pi: CursorExtensionApi) {
 		handler: async (_args, ctx) => {
 			let refreshFallbackIssue: CursorModelFallbackIssue | undefined;
 			const refreshedModels = await discoverModels({
+				forceRefresh: true,
 				onFallback: (issue) => {
 					refreshFallbackIssue = issue;
 				},
@@ -74,7 +75,7 @@ export default async function (pi: CursorExtensionApi) {
 			registerCursorProvider(pi, refreshedModels);
 			if (!ctx.hasUI) return;
 			if (refreshFallbackIssue) {
-				ctx.ui.notify(`Cursor model catalog refresh still using fallback models: ${refreshFallbackIssue.message}`, "warning");
+				ctx.ui.notify(`Cursor model catalog refresh did not use a live catalog: ${refreshFallbackIssue.message}`, "warning");
 			} else {
 				ctx.ui.notify(`Cursor model catalog refreshed with ${refreshedModels.length} model${refreshedModels.length === 1 ? "" : "s"}.`, "info");
 			}

--- a/src/model-discovery.ts
+++ b/src/model-discovery.ts
@@ -10,6 +10,12 @@ import type { ModelThinkingLevel, ThinkingLevelMap } from "@earendil-works/pi-ai
 import { loadContextWindowCache } from "./context-window-cache.js";
 import { CURSOR_API_KEY_ENV_VAR, resolveCursorApiKey } from "./cursor-api-key.js";
 import { FALLBACK_MODEL_ITEMS } from "./cursor-fallback-models.generated.js";
+import {
+	fingerprintApiKey,
+	loadAnyCachedModelCatalog,
+	loadFreshCachedModels,
+	saveModelListCache,
+} from "./model-list-cache.js";
 
 const CURSOR_PROVIDER_ID = "cursor";
 const FALLBACK_CONTEXT_WINDOW = 128000;
@@ -20,7 +26,7 @@ const AUTH_SETUP_HINT = "/login (Use an API key -> Cursor), CURSOR_API_KEY, or -
 const CATALOG_REFRESH_HINT =
 	"After adding auth to an already-started pi session, run /cursor-refresh-models to refresh the full live Cursor model catalog without restarting pi.";
 
-export type CursorModelFallbackReason = "missing-api-key" | "discovery-failed" | "empty-model-list";
+export type CursorModelFallbackReason = "missing-api-key" | "discovery-failed" | "empty-model-list" | "cached-after-error";
 
 export interface CursorModelFallbackIssue {
 	reason: CursorModelFallbackReason;
@@ -30,6 +36,10 @@ export interface CursorModelFallbackIssue {
 
 export interface DiscoverModelsOptions {
 	onFallback?: (issue: CursorModelFallbackIssue) => void;
+	// Bypass the on-disk model cache and always hit the live catalog. Used by the
+	// /cursor-refresh-models command; the startup path leaves this false so warm
+	// boots skip the slow network round-trip.
+	forceRefresh?: boolean;
 }
 
 function getCliApiKeyFromArgv(argv: string[] = process.argv): string | undefined {
@@ -442,9 +452,19 @@ export async function discoverModels(options: DiscoverModelsOptions = {}): Promi
 		});
 	}
 
+	const keyFingerprint = fingerprintApiKey(apiKey);
+
+	if (!options.forceRefresh) {
+		const cachedModels = loadFreshCachedModels(keyFingerprint);
+		if (cachedModels && cachedModels.length > 0) {
+			return registerModelItems(cachedModels);
+		}
+	}
+
 	try {
 		const models = await Cursor.models.list({ apiKey });
 		if (models.length > 0) {
+			saveModelListCache(keyFingerprint, models);
 			return registerModelItems(models);
 		}
 		return useFallbackModels(options, {
@@ -453,6 +473,18 @@ export async function discoverModels(options: DiscoverModelsOptions = {}): Promi
 		});
 	} catch (error) {
 		const errorMessage = sanitizeDiscoveryError(error, apiKey);
+		// Prefer a previously cached catalog over the generic bundled fallback when
+		// a live refresh fails (e.g. transient network/auth errors), but keep the
+		// provenance visible so refresh commands do not claim a live refresh worked.
+		const cachedCatalog = loadAnyCachedModelCatalog(keyFingerprint);
+		if (cachedCatalog && cachedCatalog.models.length > 0) {
+			options.onFallback?.({
+				reason: "cached-after-error",
+				message: `Cursor model discovery failed; using cached Cursor model catalog from ${new Date(cachedCatalog.fetchedAt).toISOString()}. ${errorMessage}`,
+				errorMessage,
+			});
+			return registerModelItems(cachedCatalog.models);
+		}
 		return useFallbackModels(options, {
 			reason: "discovery-failed",
 			message: `Cursor model discovery failed${errorMessage ? `: ${errorMessage}` : ""}. Using fallback Cursor models; verify ${AUTH_SETUP_HINT}. ${CATALOG_REFRESH_HINT}`,

--- a/src/model-list-cache.ts
+++ b/src/model-list-cache.ts
@@ -1,0 +1,116 @@
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getAgentDir } from "@earendil-works/pi-coding-agent";
+import type { ModelListItem } from "@cursor/sdk";
+import { parseEnvBoolean } from "./cursor-env-boolean.js";
+
+const MODEL_LIST_CACHE_FILE = "cursor-sdk-model-list.json";
+const MODEL_LIST_CACHE_VERSION = 1;
+const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const DISABLE_ENV_VAR = "PI_CURSOR_SDK_DISABLE_MODEL_CACHE";
+const TTL_ENV_VAR = "PI_CURSOR_SDK_MODEL_CACHE_TTL_MS";
+
+interface ModelListCacheFile {
+	version: number;
+	fetchedAt: number;
+	keyFingerprint: string;
+	models: ModelListItem[];
+}
+
+export interface CachedModelList {
+	fetchedAt: number;
+	models: ModelListItem[];
+}
+
+function getCachePath(): string {
+	return join(getAgentDir(), MODEL_LIST_CACHE_FILE);
+}
+
+export function isModelCacheDisabled(): boolean {
+	return parseEnvBoolean(process.env[DISABLE_ENV_VAR], false);
+}
+
+export function getModelCacheTtlMs(): number {
+	const raw = process.env[TTL_ENV_VAR];
+	if (raw === undefined) return DEFAULT_TTL_MS;
+	const parsed = Number.parseInt(raw, 10);
+	if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_TTL_MS;
+	return parsed;
+}
+
+// Fingerprint the API key so a key change invalidates the cache, without ever
+// persisting the key itself.
+export function fingerprintApiKey(apiKey: string): string {
+	return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+}
+
+function readCacheFile(): ModelListCacheFile | undefined {
+	const path = getCachePath();
+	if (!existsSync(path)) return undefined;
+	try {
+		const parsed = JSON.parse(readFileSync(path, "utf-8")) as ModelListCacheFile;
+		if (
+			parsed.version !== MODEL_LIST_CACHE_VERSION ||
+			typeof parsed.fetchedAt !== "number" ||
+			typeof parsed.keyFingerprint !== "string" ||
+			!Array.isArray(parsed.models)
+		) {
+			return undefined;
+		}
+		return parsed;
+	} catch {
+		return undefined;
+	}
+}
+
+// Return cached models only when caching is enabled, the key matches, and the
+// entry is within the TTL. Used on the hot startup path to skip the network.
+export function loadFreshCachedModels(keyFingerprint: string, now: number = Date.now()): ModelListItem[] | undefined {
+	if (isModelCacheDisabled()) return undefined;
+	const ttlMs = getModelCacheTtlMs();
+	if (ttlMs <= 0) return undefined;
+	const cache = readCacheFile();
+	if (!cache || cache.keyFingerprint !== keyFingerprint) return undefined;
+	if (now - cache.fetchedAt > ttlMs) return undefined;
+	return cache.models;
+}
+
+// Return cached models regardless of age, as long as the key matches. Used as a
+// resilience fallback when a live discovery request fails.
+export function loadAnyCachedModelCatalog(keyFingerprint: string): CachedModelList | undefined {
+	if (isModelCacheDisabled()) return undefined;
+	const cache = readCacheFile();
+	if (!cache || cache.keyFingerprint !== keyFingerprint) return undefined;
+	return { fetchedAt: cache.fetchedAt, models: cache.models };
+}
+
+export function loadAnyCachedModels(keyFingerprint: string): ModelListItem[] | undefined {
+	return loadAnyCachedModelCatalog(keyFingerprint)?.models;
+}
+
+export function saveModelListCache(keyFingerprint: string, models: ModelListItem[]): boolean {
+	if (isModelCacheDisabled()) return false;
+	try {
+		const path = getCachePath();
+		mkdirSync(dirname(path), { recursive: true });
+		const data: ModelListCacheFile = {
+			version: MODEL_LIST_CACHE_VERSION,
+			fetchedAt: Date.now(),
+			keyFingerprint,
+			models,
+		};
+		writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`, { mode: 0o600 });
+		chmodSync(path, 0o600);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+export const __testUtils = {
+	getCachePath,
+	DEFAULT_TTL_MS,
+	DISABLE_ENV_VAR,
+	TTL_ENV_VAR,
+};

--- a/test/index-registration.test.ts
+++ b/test/index-registration.test.ts
@@ -299,7 +299,7 @@ describe("extension registration and discovery", () => {
 		expect(notify).toHaveBeenCalledWith("Cursor model catalog refreshed with 1 model.", "info");
 	});
 
-	it("warns when live Cursor model refresh still uses fallback models", async () => {
+	it("warns when live Cursor model refresh does not use a live catalog", async () => {
 		mockedDiscover
 			.mockResolvedValueOnce([])
 			.mockImplementationOnce(async (options: DiscoverOptions) => {
@@ -322,7 +322,7 @@ describe("extension registration and discovery", () => {
 
 		expect(pi.registerProvider).toHaveBeenCalledTimes(2);
 		expect(notify).toHaveBeenCalledWith(
-			"Cursor model catalog refresh still using fallback models: missing key; using fallback models",
+			"Cursor model catalog refresh did not use a live catalog: missing key; using fallback models",
 			"warning",
 		);
 	});

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -888,3 +888,94 @@ describe("discoverModels", () => {
 		});
 	});
 });
+
+describe("discoverModels model-list cache", () => {
+	const originalEnv = process.env;
+	const originalArgv = process.argv;
+	let tmpAgentDir: string;
+
+	const MODEL: ModelListItem = {
+		id: "composer-2",
+		displayName: "Composer 2",
+		variants: [{ params: [], displayName: "Composer 2", isDefault: true }],
+	};
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env.CURSOR_API_KEY;
+		delete process.env.PI_CURSOR_SDK_DISABLE_MODEL_CACHE;
+		delete process.env.PI_CURSOR_SDK_MODEL_CACHE_TTL_MS;
+		tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-discovery-cache-"));
+		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+		process.argv = ["node", "vitest"];
+	});
+
+	afterEach(() => {
+		rmSync(tmpAgentDir, { recursive: true, force: true });
+		process.env = originalEnv;
+		process.argv = originalArgv;
+		vi.clearAllMocks();
+	});
+
+	it("serves a warm catalog from cache without a second network call", async () => {
+		writeStoredCursorApiKey("cache-key");
+		mockedList.mockResolvedValueOnce([MODEL]);
+
+		const first = await discoverModels();
+		const second = await discoverModels();
+
+		expect(mockedList).toHaveBeenCalledTimes(1);
+		expect(second.map((model) => model.id)).toEqual(first.map((model) => model.id));
+	});
+
+	it("bypasses the cache when forceRefresh is set", async () => {
+		writeStoredCursorApiKey("cache-key");
+		mockedList.mockResolvedValue([MODEL]);
+
+		await discoverModels();
+		await discoverModels({ forceRefresh: true });
+
+		expect(mockedList).toHaveBeenCalledTimes(2);
+	});
+
+	it("does not read the cache when disabled via env", async () => {
+		process.env.PI_CURSOR_SDK_DISABLE_MODEL_CACHE = "1";
+		writeStoredCursorApiKey("cache-key");
+		mockedList.mockResolvedValue([MODEL]);
+
+		await discoverModels();
+		await discoverModels();
+
+		expect(mockedList).toHaveBeenCalledTimes(2);
+	});
+
+	it("keeps successful live discovery when cache persistence fails", async () => {
+		const badAgentDir = join(tmpAgentDir, "not-a-directory");
+		writeFileSync(badAgentDir, "file");
+		process.env.PI_CODING_AGENT_DIR = badAgentDir;
+		process.env.CURSOR_API_KEY = "cache-key";
+		mockedList.mockResolvedValueOnce([MODEL]);
+		const issues: CursorModelFallbackIssue[] = [];
+
+		const models = await discoverModels({ onFallback: (issue) => issues.push(issue) });
+
+		expect(models.map((model) => model.id)).toEqual(["composer-2"]);
+		expect(issues).toEqual([]);
+	});
+
+	it("falls back to the cached catalog with a warning when a forced refresh fails", async () => {
+		writeStoredCursorApiKey("cache-key");
+		mockedList.mockResolvedValueOnce([MODEL]);
+		await discoverModels();
+
+		mockedList.mockRejectedValueOnce(new Error("network down"));
+		const issues: CursorModelFallbackIssue[] = [];
+		const refreshed = await discoverModels({ forceRefresh: true, onFallback: (issue) => issues.push(issue) });
+
+		expect(refreshed.map((model) => model.id)).toEqual(["composer-2"]);
+		expect(issues).toHaveLength(1);
+		expect(issues[0].reason).toBe("cached-after-error");
+		expect(issues[0].message).toContain("using cached Cursor model catalog");
+		expect(issues[0].errorMessage).toContain("network down");
+	});
+});

--- a/test/model-list-cache.test.ts
+++ b/test/model-list-cache.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { ModelListItem } from "@cursor/sdk";
+import {
+	fingerprintApiKey,
+	getModelCacheTtlMs,
+	isModelCacheDisabled,
+	loadAnyCachedModels,
+	loadFreshCachedModels,
+	saveModelListCache,
+	__testUtils,
+} from "../src/model-list-cache.js";
+
+const MODELS: ModelListItem[] = [
+	{
+		id: "composer-2",
+		displayName: "Composer 2",
+		variants: [{ params: [], displayName: "Composer 2", isDefault: true }],
+	},
+];
+
+describe("model-list-cache", () => {
+	const originalEnv = process.env;
+	let tmpAgentDir: string;
+	const fp = fingerprintApiKey("test-key");
+
+	beforeEach(() => {
+		process.env = { ...originalEnv };
+		delete process.env[__testUtils.DISABLE_ENV_VAR];
+		delete process.env[__testUtils.TTL_ENV_VAR];
+		tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-model-cache-"));
+		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+	});
+
+	afterEach(() => {
+		rmSync(tmpAgentDir, { recursive: true, force: true });
+		process.env = originalEnv;
+	});
+
+	it("round-trips a saved catalog for a matching key", () => {
+		saveModelListCache(fp, MODELS);
+		expect(loadFreshCachedModels(fp)).toEqual(MODELS);
+	});
+
+	it("writes the cache file with 0600 permissions and no API key", () => {
+		expect(saveModelListCache(fp, MODELS)).toBe(true);
+		const path = __testUtils.getCachePath();
+		expect(statSync(path).mode & 0o777).toBe(0o600);
+		const raw = readFileSync(path, "utf-8");
+		expect(raw).not.toContain("test-key");
+		expect(JSON.parse(raw).keyFingerprint).toBe(fp);
+	});
+
+	it("tightens permissions when rewriting an existing loose cache file", () => {
+		const path = __testUtils.getCachePath();
+		writeFileSync(path, "{}", { mode: 0o644 });
+
+		expect(saveModelListCache(fp, MODELS)).toBe(true);
+
+		expect(statSync(path).mode & 0o777).toBe(0o600);
+	});
+
+	it("misses when the key fingerprint differs", () => {
+		saveModelListCache(fp, MODELS);
+		expect(loadFreshCachedModels(fingerprintApiKey("other-key"))).toBeUndefined();
+	});
+
+	it("treats entries older than the TTL as a miss but still returns them as stale", () => {
+		saveModelListCache(fp, MODELS);
+		const future = Date.now() + __testUtils.DEFAULT_TTL_MS + 1000;
+		expect(loadFreshCachedModels(fp, future)).toBeUndefined();
+		expect(loadAnyCachedModels(fp)).toEqual(MODELS);
+	});
+
+	it("ignores a corrupt cache file", () => {
+		writeFileSync(__testUtils.getCachePath(), "{ not json");
+		expect(loadFreshCachedModels(fp)).toBeUndefined();
+		expect(loadAnyCachedModels(fp)).toBeUndefined();
+	});
+
+	it("disables read and write when the disable env flag is set", () => {
+		process.env[__testUtils.DISABLE_ENV_VAR] = "1";
+		saveModelListCache(fp, MODELS);
+		expect(loadFreshCachedModels(fp)).toBeUndefined();
+		expect(loadAnyCachedModels(fp)).toBeUndefined();
+	});
+
+	it("honors a custom TTL from the environment", () => {
+		process.env[__testUtils.TTL_ENV_VAR] = "1000";
+		expect(getModelCacheTtlMs()).toBe(1000);
+		saveModelListCache(fp, MODELS);
+		expect(loadFreshCachedModels(fp, Date.now() + 2000)).toBeUndefined();
+	});
+
+	it("falls back to the default TTL for invalid env values", () => {
+		process.env[__testUtils.TTL_ENV_VAR] = "not-a-number";
+		expect(getModelCacheTtlMs()).toBe(__testUtils.DEFAULT_TTL_MS);
+	});
+
+	it.each(["1", "true", "on", "yes", "enabled"])("reports disabled state from truthy env flag %s", (value) => {
+		expect(isModelCacheDisabled()).toBe(false);
+		process.env[__testUtils.DISABLE_ENV_VAR] = value;
+		expect(isModelCacheDisabled()).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary
- cache the discovered Cursor model catalog at `~/.pi/agent/cursor-sdk-model-list.json` so warm startups skip the live `Cursor.models.list` network round-trip
- key the cache by a truncated SHA-256 fingerprint of the API key; the key itself is never stored
- make cache persistence best-effort so disk/cache failures never degrade a successful live discovery
- have `/cursor-refresh-models` force a live refresh and warn if it must fall back to a cached catalog or bundled fallback
- add TTL/disable env knobs: `PI_CURSOR_SDK_MODEL_CACHE_TTL_MS` and `PI_CURSOR_SDK_DISABLE_MODEL_CACHE`

Fixes #78.

## Validation
- `npm test -- --run test/model-list-cache.test.ts test/model-discovery.test.ts test/index-registration.test.ts`
- `npm test`
- `npm run typecheck`
- `npm pack --dry-run`
- `npm run smoke:live`
- `git diff --check`
- thermo-nuclear reviewer: signed off with no findings after remediation

## Notes
- This addresses the live model-catalog network call. Static import cost remains tracked separately in #100.
