### PR TITLE
Lazy-load Cursor SDK runtime imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Clarify setup docs and runtime auth messages: `pi-cursor-sdk` requires a Cursor SDK API key and does not reuse Cursor Agent CLI/Desktop login or subscription auth.
 - `/cursor-refresh-models` now forces a live catalog refresh, bypassing the on-disk cache and rewriting it. A previously cached catalog is preferred over the bundled fallback when a live refresh fails.
+- Lazy-load the Cursor SDK runtime so warm cached startup paths avoid importing `@cursor/sdk` until live model discovery or a Cursor turn needs it (#100).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Discovery uses pi's native resolution order for this extension: `--api-key`, the
 
 ### Model catalog cache
 
-To avoid a live `Cursor.models.list` network round-trip on every pi startup, the discovered catalog is cached on disk at `~/.pi/agent/cursor-sdk-model-list.json` (written `0600`, keyed by an API-key fingerprint — the key itself is never stored). Warm startups within the cache TTL skip the network call; `/cursor-refresh-models` always bypasses the cache and refreshes the live catalog. If a refresh fails, a previously cached catalog is preferred over the generic bundled fallback.
+To avoid a live `Cursor.models.list` network round-trip on every pi startup, the discovered catalog is cached on disk at `~/.pi/agent/cursor-sdk-model-list.json` (written `0600`, keyed by an API-key fingerprint — the key itself is never stored). Warm startups within the cache TTL skip the network call and avoid loading `@cursor/sdk` until a Cursor turn needs it; `/cursor-refresh-models` always bypasses the cache and refreshes the live catalog. If a refresh fails, a previously cached catalog is preferred over the generic bundled fallback.
 
 ```bash
 # Cache lifetime in milliseconds (default 86400000 = 24h).

--- a/src/cursor-agent-message-web-tools.ts
+++ b/src/cursor-agent-message-web-tools.ts
@@ -1,5 +1,6 @@
-import { Agent, type AgentMessage } from "@cursor/sdk";
+import type { AgentMessage } from "@cursor/sdk";
 import { asRecord, getArray, getString, stringifyUnknown } from "./cursor-transcript-utils.js";
+import { loadCursorSdk } from "./cursor-sdk-runtime.js";
 
 const CURSOR_AGENT_MESSAGE_PAGE_LIMIT = 8;
 
@@ -21,6 +22,7 @@ function getOneofCaseValue(value: unknown, caseName: string): unknown {
 }
 
 async function hasCursorAgentMessageAt(agentId: string, cwd: string, offset: number): Promise<boolean> {
+	const { Agent } = await loadCursorSdk();
 	const messages = await Agent.messages.list(agentId, { runtime: "local", cwd, limit: 1, offset });
 	return messages.length > 0;
 }
@@ -46,6 +48,7 @@ export async function loadCursorTranscriptWebToolCallsAfterOffset(options: {
 	offset: number | undefined;
 }): Promise<CursorTranscriptCompletedToolCall[]> {
 	if (options.offset === undefined) return [];
+	const { Agent } = await loadCursorSdk();
 	const messages = await Agent.messages.list(options.agentId, {
 		runtime: "local",
 		cwd: options.cwd,

--- a/src/cursor-pi-tool-bridge-constants.ts
+++ b/src/cursor-pi-tool-bridge-constants.ts
@@ -1,0 +1,2 @@
+export const MCP_SERVER_NAME = "pi_tools";
+export const MCP_ENDPOINT_ROOT = "/cursor-pi-tool-bridge";

--- a/src/cursor-pi-tool-bridge-run.ts
+++ b/src/cursor-pi-tool-bridge-run.ts
@@ -9,6 +9,7 @@ import {
 	ListToolsRequestSchema,
 	type CallToolResult,
 } from "@modelcontextprotocol/sdk/types.js";
+import { MCP_ENDPOINT_ROOT, MCP_SERVER_NAME } from "./cursor-pi-tool-bridge-constants.js";
 import {
 	type CursorPiToolBridgeDiagnosticEvent,
 	type CursorPiToolBridgeLifecycleDiagnosticFields,
@@ -38,8 +39,6 @@ export interface CursorPiToolBridgeRunHost {
 	unregisterRun(pathname: string, run: CursorPiToolBridgeRunImpl): Promise<void>;
 }
 
-export const MCP_SERVER_NAME = "pi_tools";
-export const MCP_ENDPOINT_ROOT = "/cursor-pi-tool-bridge";
 const MCP_SERVER_VERSION = "0.1.0";
 
 interface PendingBridgeCall {

--- a/src/cursor-pi-tool-bridge-server.ts
+++ b/src/cursor-pi-tool-bridge-server.ts
@@ -7,7 +7,7 @@ import type {
 	CursorPiToolBridgeSnapshotApi,
 } from "./cursor-pi-tool-bridge-types.js";
 import { isRecord } from "./cursor-pi-tool-bridge-mcp.js";
-import { CursorPiToolBridgeRunImpl } from "./cursor-pi-tool-bridge-run.js";
+import type { CursorPiToolBridgeRunImpl } from "./cursor-pi-tool-bridge-run.js";
 import {
 	buildCursorPiToolBridgeSnapshot,
 	buildCursorPiToolBridgeSurfaceSignature,
@@ -54,6 +54,7 @@ export class CursorPiToolBridgeRegistry implements CursorPiToolBridge {
 				exposeOverlappingBuiltins: resolveCursorPiToolBridgeBuiltinsEnabled(this.env),
 			})
 			: createEmptySnapshot();
+		const { CursorPiToolBridgeRunImpl } = await import("./cursor-pi-tool-bridge-run.js");
 		const run = new CursorPiToolBridgeRunImpl(this, this.env, snapshot, bridgeEnabled && snapshot.tools.length > 0, options);
 		this.runs.add(run);
 		await run.start();

--- a/src/cursor-pi-tool-bridge.ts
+++ b/src/cursor-pi-tool-bridge.ts
@@ -13,8 +13,8 @@ import {
 	resolveCursorPiToolBridgeEnabled,
 } from "./cursor-pi-tool-bridge-snapshot.js";
 import { bridgeToolExecutionAbortTracker } from "./cursor-pi-tool-bridge-abort.js";
+import { MCP_SERVER_NAME } from "./cursor-pi-tool-bridge-constants.js";
 import { LOOPBACK_HOST, CursorPiToolBridgeRegistry } from "./cursor-pi-tool-bridge-server.js";
-import { MCP_SERVER_NAME } from "./cursor-pi-tool-bridge-run.js";
 import type {
 	CursorPiToolBridge,
 	CursorPiToolBridgeExtensionApi,

--- a/src/cursor-provider-turn-finalize.ts
+++ b/src/cursor-provider-turn-finalize.ts
@@ -1,4 +1,3 @@
-import { createAgentPlatform } from "@cursor/sdk";
 import type { SDKAgent } from "@cursor/sdk";
 import { loadCursorTranscriptWebToolCallsAfterOffset } from "./cursor-agent-message-web-tools.js";
 import { getCheckpointContextWindow, saveCachedContextWindow } from "./context-window-cache.js";
@@ -10,9 +9,11 @@ import {
 	type CursorRunOutcome,
 } from "./cursor-provider-run-outcome.js";
 import type { CursorProviderTurnPrepareResult } from "./cursor-provider-turn-types.js";
+import { loadCursorSdk } from "./cursor-sdk-runtime.js";
 
 export async function cacheSdkContextWindow(agentId: string, modelId: string): Promise<void> {
 	try {
+		const { createAgentPlatform } = await loadCursorSdk();
 		const platform = await createAgentPlatform();
 		const checkpoint = await platform.checkpointStore.loadLatest(agentId);
 		const contextWindow = getCheckpointContextWindow(checkpoint);

--- a/src/cursor-provider-turn-prepare.ts
+++ b/src/cursor-provider-turn-prepare.ts
@@ -1,5 +1,4 @@
 import type { SimpleStreamOptions } from "@earendil-works/pi-ai";
-import { Agent } from "@cursor/sdk";
 import { installCursorMcpToolTimeoutOverride } from "./cursor-mcp-timeout-override.js";
 import { installCursorSdkOutputFilter, suppressCursorSdkOutput } from "./cursor-sdk-output-filter.js";
 import {
@@ -26,6 +25,7 @@ import { isCursorNativeToolDisplayRuntimeEnabled } from "./cursor-native-tool-di
 import { MISSING_CURSOR_API_KEY_MESSAGE } from "./cursor-provider-errors.js";
 import { CursorSdkTurnCoordinator } from "./cursor-provider-turn-coordinator.js";
 import { resolveCursorApiKey } from "./cursor-provider-turn-api-key.js";
+import { loadCursorSdk } from "./cursor-sdk-runtime.js";
 import type {
 	CursorProviderTurnPrepareResult,
 	CursorProviderTurnRunnerParams,
@@ -56,6 +56,7 @@ export async function prepareCursorProviderTurn(
 		const agentMode = getEffectiveCursorAgentMode();
 		const selection = buildCursorModelSelection(model.id, options?.reasoning ?? "off", fastEnabled);
 		const settingSources = getEffectiveCursorSettingSources();
+		const { Agent } = await loadCursorSdk();
 
 		installCursorMcpToolTimeoutOverride();
 		restoreCursorSdkOutputFilter = installCursorSdkOutputFilter();

--- a/src/cursor-sdk-runtime.ts
+++ b/src/cursor-sdk-runtime.ts
@@ -1,0 +1,5 @@
+export type CursorSdkModule = typeof import("@cursor/sdk");
+
+export async function loadCursorSdk(): Promise<CursorSdkModule> {
+	return import("@cursor/sdk");
+}

--- a/src/cursor-session-agent.ts
+++ b/src/cursor-session-agent.ts
@@ -6,7 +6,6 @@ import type {
 	SessionTreeEvent,
 } from "@earendil-works/pi-coding-agent";
 import { createHash } from "node:crypto";
-import { Agent } from "@cursor/sdk";
 import type { AgentModeOption, ModelSelection, SDKAgent, SettingSource } from "@cursor/sdk";
 import type { Context } from "@earendil-works/pi-ai";
 import {
@@ -17,6 +16,7 @@ import {
 import { computeCursorContextFingerprint } from "./context.js";
 import { getCursorSessionScopeKey, onCursorSessionScopeKeyChange } from "./cursor-session-scope.js";
 import type { CursorSdkEventDebugRecorder } from "./cursor-sdk-event-debug.js";
+import { loadCursorSdk, type CursorSdkModule } from "./cursor-sdk-runtime.js";
 
 export interface SessionCursorAgentSendState {
 	bootstrapped: boolean;
@@ -109,7 +109,7 @@ interface SessionCursorAgentCreateParams {
 	settingSources?: SettingSource[];
 	onBridgeToolRequest?: (request: CursorPiBridgeToolRequest) => void;
 	debugRecorder?: CursorSdkEventDebugRecorder;
-	createAgent?: typeof Agent.create;
+	createAgent?: CursorSdkModule["Agent"]["create"];
 }
 
 interface CursorSessionAgentExtensionApi {
@@ -377,7 +377,7 @@ async function createSessionAgentEntry(
 	}
 
 	const resolvedPoolKey = buildSessionAgentPoolKey(scopeKey, params);
-	const createAgent = params.createAgent ?? Agent.create;
+	const createAgent = params.createAgent ?? (await loadCursorSdk()).Agent.create;
 	let agent: SDKAgent;
 	try {
 		agent = await createAgent({

--- a/src/model-discovery.ts
+++ b/src/model-discovery.ts
@@ -1,4 +1,3 @@
-import { Cursor } from "@cursor/sdk";
 import type {
 	ModelListItem,
 	ModelParameterDefinition,
@@ -8,6 +7,7 @@ import type {
 import { AuthStorage, type ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import type { ModelThinkingLevel, ThinkingLevelMap } from "@earendil-works/pi-ai";
 import { loadContextWindowCache } from "./context-window-cache.js";
+import { loadCursorSdk } from "./cursor-sdk-runtime.js";
 import { CURSOR_API_KEY_ENV_VAR, resolveCursorApiKey } from "./cursor-api-key.js";
 import { FALLBACK_MODEL_ITEMS } from "./cursor-fallback-models.generated.js";
 import {
@@ -462,6 +462,7 @@ export async function discoverModels(options: DiscoverModelsOptions = {}): Promi
 	}
 
 	try {
+		const { Cursor } = await loadCursorSdk();
 		const models = await Cursor.models.list({ apiKey });
 		if (models.length > 0) {
 			saveModelListCache(keyFingerprint, models);

--- a/test/cursor-sdk-lazy-import.test.ts
+++ b/test/cursor-sdk-lazy-import.test.ts
@@ -1,0 +1,103 @@
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, relative } from "node:path";
+import ts from "typescript";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fingerprintApiKey, saveModelListCache } from "../src/model-list-cache.js";
+import type { ModelListItem } from "@cursor/sdk";
+
+function sourceFiles(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) return sourceFiles(path);
+		return path.endsWith(".ts") ? [path] : [];
+	});
+}
+
+function moduleText(node: ts.ImportDeclaration | ts.ExportDeclaration): string | undefined {
+	return node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier) ? node.moduleSpecifier.text : undefined;
+}
+
+function isTypeOnlyExport(node: ts.ExportDeclaration): boolean {
+	return node.isTypeOnly || Boolean(node.exportClause && ts.isNamedExports(node.exportClause) && node.exportClause.elements.every((element) => element.isTypeOnly));
+}
+
+function collectRuntimeSdkEdges(): string[] {
+	const offenders: string[] = [];
+	for (const path of sourceFiles(join(process.cwd(), "src"))) {
+		const relativePath = relative(process.cwd(), path);
+		const source = ts.createSourceFile(path, readFileSync(path, "utf-8"), ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+		const visit = (node: ts.Node): void => {
+			if (ts.isImportDeclaration(node)) {
+				const specifier = moduleText(node);
+				if (specifier === "@cursor/sdk" && !node.importClause?.isTypeOnly && !relativePath.endsWith("src/cursor-sdk-runtime.ts")) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import @cursor/sdk`);
+				}
+				if (specifier?.startsWith("@modelcontextprotocol/sdk/") && !node.importClause?.isTypeOnly && !relativePath.endsWith("src/cursor-pi-tool-bridge-run.ts")) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import ${specifier}`);
+				}
+				if (specifier === "./cursor-pi-tool-bridge-run.js" && !node.importClause?.isTypeOnly) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import bridge run implementation`);
+				}
+			}
+			if (ts.isExportDeclaration(node)) {
+				const specifier = moduleText(node);
+				if (specifier === "@cursor/sdk" && !isTypeOnlyExport(node)) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime export @cursor/sdk`);
+				}
+				if (specifier?.startsWith("@modelcontextprotocol/sdk/") && !isTypeOnlyExport(node)) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime export ${specifier}`);
+				}
+			}
+			if (
+				ts.isCallExpression(node) &&
+				node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+				node.arguments.length === 1 &&
+				ts.isStringLiteral(node.arguments[0]) &&
+				node.arguments[0].text === "@cursor/sdk" &&
+				!relativePath.endsWith("src/cursor-sdk-runtime.ts")
+			) {
+				offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: dynamic import @cursor/sdk outside runtime loader`);
+			}
+			ts.forEachChild(node, visit);
+		};
+		visit(source);
+	}
+	return offenders;
+}
+
+describe("Cursor SDK lazy runtime imports", () => {
+	const originalEnv = process.env;
+	let tmpAgentDir: string | undefined;
+
+	afterEach(() => {
+		if (tmpAgentDir) rmSync(tmpAgentDir, { recursive: true, force: true });
+		tmpAgentDir = undefined;
+		process.env = originalEnv;
+		vi.doUnmock("@cursor/sdk");
+		vi.resetModules();
+	});
+
+	it("keeps heavy SDK value imports behind lazy runtime boundaries", () => {
+		expect(collectRuntimeSdkEdges()).toEqual([]);
+	});
+
+	it("serves a warm model catalog without evaluating @cursor/sdk", async () => {
+		tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-lazy-import-"));
+		process.env = { ...originalEnv, PI_CODING_AGENT_DIR: tmpAgentDir, CURSOR_API_KEY: "warm-cache-key" };
+		const model: ModelListItem = {
+			id: "composer-2",
+			displayName: "Composer 2",
+			variants: [{ params: [], displayName: "Composer 2", isDefault: true }],
+		};
+		expect(saveModelListCache(fingerprintApiKey("warm-cache-key"), [model])).toBe(true);
+		vi.doMock("@cursor/sdk", () => {
+			throw new Error("@cursor/sdk should not be evaluated on a warm cached discovery path");
+		});
+
+		const { discoverModels } = await import("../src/model-discovery.js");
+		const models = await discoverModels();
+
+		expect(models.map((entry) => entry.id)).toEqual(["composer-2"]);
+	});
+});


### PR DESCRIPTION
## Summary
- move `@cursor/sdk` value imports behind a tiny dynamic runtime loader
- keep warm startup/model-cache modules type-only against the Cursor SDK unless live discovery or a Cursor turn needs the runtime
- lazy-load Cursor transcript replay, context-window cache lookup, session agent creation, and live model discovery
- remove the MCP bridge run implementation from the activation graph; the `@modelcontextprotocol/sdk` runtime now loads only when a bridge run is created
- add structural regression coverage for SDK/MCP runtime imports plus a warm-cache test proving `@cursor/sdk` is not evaluated on cached discovery

Fixes #100.

## Validation
- `npm test -- --run test/cursor-sdk-lazy-import.test.ts test/cursor-pi-tool-bridge.test.ts test/cursor-provider-stream-auth.test.ts test/model-discovery.test.ts`
- `npm test`
- `npm run typecheck`
- `npm pack --dry-run`
- `npm run smoke:live`
- `npm run smoke:isolated`
- `git diff --check`
- thermo-nuclear reviewer: signed off with no findings after remediation
