### PR TITLE
Add Cursor fast model aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.1.31 - 2026-06-01
+
+### Added
+
+- Add Cursor `:fast` and `:slow` virtual model aliases for models with a Cursor SDK `fast` parameter so subagents and workflow-spawned agents can choose fast/slow independently of saved `/cursor-fast` defaults (#112).
+
 ## 0.1.30 - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ pi --model cursor/gpt-5.5@272k:xhigh
 pi --model cursor/gpt-5.5@1m --thinking medium
 ```
 
-Cursor-only parameters are not encoded into pi model IDs. Cursor `context` becomes a pi-visible model variant because it changes pi's native `contextWindow`; Cursor `fast` and Cursor SDK conversation mode are extension state, not model identity. Alias model IDs use their selected SDK ID for Cursor-only state such as fast defaults, with read fallback for older defaults keyed by the underlying Cursor base model.
+Cursor `context` becomes a pi-visible model variant because it changes pi's native `contextWindow`. For models that expose Cursor's boolean `fast` parameter, the extension also registers virtual `:fast` and `:slow` model aliases such as `cursor/composer-2-5:slow` and `cursor/gpt-5.5@1m:fast`. Those aliases are selection-only controls for subagents and workflow-spawned agents: they send the same Cursor SDK model ID plus an explicit `fast=true` or `fast=false` param, and they take precedence over saved `/cursor-fast` session/global defaults. Cursor SDK conversation mode remains extension state, not model identity. Alias model IDs use their selected SDK ID for Cursor-only state such as fast defaults, with read fallback for older defaults keyed by the underlying Cursor base model.
 
 ## Thinking support
 
@@ -190,7 +190,7 @@ Some Cursor SDK models do not expose a `reasoning`, `effort`, or `thinking` para
 
 ## Fast mode
 
-Use `/cursor-fast` to persistently toggle fast mode for the selected Cursor model when the model supports Cursor's `fast` parameter.
+Use `/cursor-fast` to persistently toggle fast mode for the selected unsuffixed Cursor model when the model supports Cursor's `fast` parameter.
 
 Fast preferences are remembered per selected Cursor SDK model ID or alias and stored:
 
@@ -204,7 +204,16 @@ pi --model cursor/gpt-5.5@1m --cursor-fast -p "Say ok only"
 pi --model cursor/composer-2-5 --cursor-no-fast -p "Say ok only"
 ```
 
-Composer 2 and Composer 2.5 can default to fast. Use `--cursor-no-fast` for a one-shot no-fast Composer run. In print mode (`-p`), `--cursor-no-fast` is silent and does not write `~/.pi/agent/cursor-sdk.json`.
+For per-agent control, select the virtual model alias instead of mutating the shared saved default:
+
+```bash
+pi --model cursor/composer-2-5:slow -p "Say ok only"
+pi --model cursor/gpt-5.5@1m:fast -p "Say ok only"
+```
+
+The `:fast` and `:slow` aliases are available only for Cursor models whose catalog exposes a `fast` parameter. They override saved `/cursor-fast` session/global defaults while leaving `--cursor-fast` and `--cursor-no-fast` as explicit process-level force flags. `/cursor-fast` does not persist a new default while a virtual fast/slow alias is selected; switch to the unsuffixed model first.
+
+Composer 2 and Composer 2.5 can default to fast. Use `--cursor-no-fast` or a `:slow` virtual alias for a one-shot no-fast Composer run. In print mode (`-p`), `--cursor-no-fast` is silent and does not write `~/.pi/agent/cursor-sdk.json`.
 
 In interactive mode, the footer only shows fast mode when fast is enabled and Cursor mode when it is non-default. Fast and plan mode share one Cursor status value, so they do not overwrite each other:
 
@@ -218,7 +227,7 @@ If you do not see `cursor fast`, fast mode is off. If you do not see `cursor pla
 
 ## Cursor SDK mode
 
-Cursor SDK conversation mode is Cursor-only extension state. It is not a pi model variant, not pi thinking/reasoning, not Cursor `fast`, and not pi's separate read-only plan-mode extension.
+Cursor SDK conversation mode is Cursor-only extension state. It is not a pi model variant, not pi thinking/reasoning, not a `:fast`/`:slow` virtual fast alias, and not pi's separate read-only plan-mode extension.
 
 Default mode is `agent`. Start a one-shot run in a specific mode:
 

--- a/docs/cursor-model-ux-spec.md
+++ b/docs/cursor-model-ux-spec.md
@@ -10,7 +10,7 @@ Current implementation notes:
 
 - Cursor context variants use `base@context` pi model IDs.
 - Cursor `reasoning`, `effort`, and boolean `thinking` parameters are driven by pi native thinking when the Cursor SDK exposes those controls.
-- Cursor `fast` is extension state, not model identity.
+- Cursor `fast` is extension state by default; models that expose `fast` also get selection-only `:fast` / `:slow` virtual aliases for per-agent overrides.
 - Cursor SDK `mode` (`agent` or `plan`) is extension session state, not model identity, pi thinking, Cursor `fast`, or pi's separate plan-mode extension.
 - Cursor status uses one coordinated `ctx.ui.setStatus("cursor", ...)` value for fast and non-default plan mode; the default pi footer remains intact.
 - Installed `@cursor/sdk` user messages accept images, and Cursor models are treated as image-capable; registered input metadata is `text` plus `image`.
@@ -136,7 +136,7 @@ Use native pi abstractions wherever possible:
 | Cursor `reasoning` | pi native thinking via `thinkingLevelMap` |
 | Cursor `effort` | pi native thinking via `thinkingLevelMap` |
 | Cursor `thinking=false` | pi native `off` |
-| Cursor `fast` | extension state, not model identity |
+| Cursor `fast` | extension state plus `:fast` / `:slow` virtual aliases for per-agent overrides |
 | Cursor SDK `mode` | extension session state; `agent` by default, `plan` via SDK-native mode |
 | Footer | default pi footer plus optional extension status |
 
@@ -156,7 +156,7 @@ Rules:
 - Register one pi model for each Cursor base model and each unambiguous SDK alias when there is no Cursor `context` parameter.
 - Register one pi model per Cursor `context` value for each Cursor base model and each unambiguous SDK alias when the model exposes a `context` parameter.
 - Skip SDK aliases that collide with another base model ID or are shared by multiple base models; those aliases can resolve differently from the pi row metadata.
-- Do not encode `reasoning`, `effort`, `thinking`, `fast`, or Cursor SDK `mode` into pi model IDs.
+- Do not encode `reasoning`, `effort`, `thinking`, or Cursor SDK `mode` into pi model IDs. For models with a Cursor `fast` parameter, also register selection-only `:fast` and `:slow` virtual model aliases that do not change pi-native metadata.
 - Prefer stable, readable `@<context>` suffixes that do not conflict with pi's final `:<thinking>` suffix parser.
 - Sort Cursor models by base ID, then context value in Cursor SDK order before calling `pi.registerProvider()`. Registration order matters for `/model` display and model cycling; `--list-models` sorts output separately.
 
@@ -168,6 +168,9 @@ cursor/gpt-5.5@272k
 cursor/claude-opus-4-8@1m
 cursor/claude-opus-4-8@300k
 cursor/composer-2-5
+cursor/composer-2-5:fast
+cursor/composer-2-5:slow
+cursor/gpt-5.5@1m:fast
 ```
 
 Avoid colon-based context IDs in the first implementation unless this spec is intentionally changed:
@@ -190,7 +193,7 @@ Reason:
 
 - `@1m` keeps context visually separate from pi's native `:medium` thinking suffix.
 - Context variants make `contextWindow` accurate in `--list-models`, the native footer, context overflow checks, and compaction logic.
-- `fast` is intentionally not a model variant because it does not affect pi model metadata and would double list noise.
+- `:fast` / `:slow` are virtual aliases, not separate Cursor SDK base models: they keep the same context/thinking metadata and only force the outgoing Cursor `fast` param. They exist so subagents and workflow-spawned agents can choose fast/slow without mutating shared `/cursor-fast` defaults.
 
 ### Metadata Per Registered Model
 
@@ -362,17 +365,18 @@ fast=false <-> fast=true
 
 Rules:
 
-- `fast` is extension state, not pi model identity.
-- Toggle with `/cursor-fast`.
-- Store per-session and global per-base-model preferences.
-- When calling `Agent.create()`, include the selected `fast` value in Cursor model params.
+- Unsuffixed models use extension state from `/cursor-fast`, per-session entries, and global defaults.
+- `:fast` / `:slow` virtual model aliases force fast on/off for that selected agent and override saved defaults without writing state.
+- Toggle unsuffixed models with `/cursor-fast`; do not persist a new default while a virtual fast alias is selected.
+- Store per-session and global per-base-model preferences for unsuffixed models.
+- When calling `Agent.create()` or `agent.send()`, include the selected `fast` value in Cursor model params.
 - Show `fast` through `ctx.ui.setStatus()` when enabled.
-- Support a first-pass CLI flag, `--cursor-fast`, to force fast mode for one run when the selected model supports it.
+- Keep `--cursor-fast` and `--cursor-no-fast` as explicit process-level force flags.
 
 Reason:
 
 - `fast` does not affect pi `contextWindow`, thinking levels, or input support.
-- Registering fast/non-fast variants would make `--list-models` noisy without improving native pi behavior.
+- The virtual aliases trade small `--list-models` noise for per-agent selection that works with subagents and dynamic workflows, where mutating a shared global fast default is the wrong abstraction.
 
 Status example:
 
@@ -521,7 +525,7 @@ Reason:
 - pi supports one final `:<thinking>` suffix.
 - Cursor-only parameters are not generic pi CLI parameters.
 - Context is already represented by the registered pi model ID.
-- `fast` is controlled by saved extension defaults or the first-pass `--cursor-fast` extension flag.
+- `fast` is controlled by saved extension defaults, `:fast` / `:slow` virtual model aliases, or the `--cursor-fast` / `--cursor-no-fast` extension flags.
 - Cursor SDK `mode` is controlled by `/cursor-mode` session state or the first-pass `--cursor-mode` extension flag; it is never encoded in `--model`.
 
 For print mode:
@@ -529,7 +533,7 @@ For print mode:
 - no keybindings,
 - use selected context model variant,
 - use `--thinking` or `:medium` for reasoning/effort,
-- use saved global `fast` defaults unless `--cursor-fast` is present,
+- use saved global `fast` defaults unless a virtual `:fast` / `:slow` model alias or force flag is present,
 - use Cursor SDK `agent` mode unless `/cursor-mode` session state or `--cursor-mode` overrides it.
 
 Fast flag example:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-cursor-sdk",
-	"version": "0.1.30",
+	"version": "0.1.31",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-cursor-sdk",
-			"version": "0.1.30",
+			"version": "0.1.31",
 			"license": "MIT",
 			"dependencies": {
 				"@cursor/sdk": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-cursor-sdk",
-	"version": "0.1.30",
+	"version": "0.1.31",
 	"description": "pi provider extension backed by @cursor/sdk local agents",
 	"author": "Mitch Fultz (https://github.com/fitchmultz)",
 	"license": "MIT",

--- a/src/cursor-state.ts
+++ b/src/cursor-state.ts
@@ -138,6 +138,10 @@ function getFastPreferenceModelId(metadata: NonNullable<ReturnType<typeof getCur
 	return metadata.selectionModelId || metadata.baseModelId;
 }
 
+function getVirtualFastBaseModelId(modelId: string): string {
+	return modelId.replace(/:(?:fast|slow)$/, "");
+}
+
 function getStoredFastPreference(metadata: NonNullable<ReturnType<typeof getCursorModelMetadata>>): boolean | undefined {
 	const preferenceModelId = getFastPreferenceModelId(metadata);
 	return (
@@ -153,6 +157,7 @@ function getEffectiveFast(modelId: string): boolean | undefined {
 	if (!metadata?.supportsFast) return undefined;
 	if (cliForceNoFast) return false;
 	if (cliForceFast) return true;
+	if (metadata.fastOverride !== undefined) return metadata.fastOverride;
 	return getStoredFastPreference(metadata) ?? metadata.defaultFast;
 }
 
@@ -342,6 +347,14 @@ export function registerCursorRuntimeControls(pi: CursorRuntimeControlsExtension
 			}
 			if (cliForceFast) {
 				ctx.ui.notify("Cursor fast is forced by --cursor-fast", "info");
+				return;
+			}
+			if (metadata.fastOverride !== undefined) {
+				const state = metadata.fastOverride ? "enabled" : "disabled";
+				ctx.ui.notify(
+					`Cursor fast is fixed ${state} by selected model ${metadata.piModelId}; choose ${getVirtualFastBaseModelId(metadata.piModelId)} to use /cursor-fast preferences`,
+					"info",
+				);
 				return;
 			}
 

--- a/src/model-discovery.ts
+++ b/src/model-discovery.ts
@@ -88,6 +88,7 @@ export interface CursorModelMetadata {
 	contextWindow: number;
 	supportsFast: boolean;
 	defaultFast: boolean;
+	fastOverride?: boolean;
 	supportsReasoning: boolean;
 	thinkingLevelMap?: ThinkingLevelMap;
 	parameterIds: {
@@ -205,19 +206,35 @@ function getParamValue(params: ModelParameterValue[], id: string): string | unde
 	return params.find((param) => param.id === id)?.value;
 }
 
-function encodePiModelId(modelId: string, context?: string): string {
-	return context ? `${modelId}@${context}` : modelId;
+function encodePiModelId(modelId: string, context?: string, fastOverride?: boolean): string {
+	const contextQualified = context ? `${modelId}@${context}` : modelId;
+	if (fastOverride === true) return `${contextQualified}:fast`;
+	if (fastOverride === false) return `${contextQualified}:slow`;
+	return contextQualified;
 }
 
-function getModelName(item: ModelListItem, context?: string, alias?: string): string {
+function getModelName(item: ModelListItem, context?: string, alias?: string, fastOverride?: boolean): string {
 	const displayName = item.displayName || item.id;
-	const baseName = alias ? `${displayName} (${alias})` : displayName;
+	const qualifiers: string[] = [];
+	if (alias) qualifiers.push(alias);
+	if (fastOverride === true) qualifiers.push("fast");
+	if (fastOverride === false) qualifiers.push("slow");
+	const baseName = qualifiers.length > 0 ? `${displayName} (${qualifiers.join(", ")})` : displayName;
 	return context ? `${baseName} @ ${context}` : baseName;
 }
 
+function getFastOverrideBasePiModelId(piModelId: string): string {
+	return piModelId.replace(/:(?:fast|slow)$/, "");
+}
+
 function getContextWindow(contextWindowCache: Map<string, number>, piModelId: string, context?: string, baseModelId?: string): number {
-	return (
+	const fastOverrideBasePiModelId = getFastOverrideBasePiModelId(piModelId);
+	const contextWindowOverride =
 		contextWindowCache.get(piModelId) ??
+		(fastOverrideBasePiModelId !== piModelId ? contextWindowCache.get(fastOverrideBasePiModelId) : undefined);
+
+	return (
+		contextWindowOverride ??
 		(context ? parseContextWindow(context) : undefined) ??
 		(baseModelId ? contextWindowCache.get(baseModelId) : undefined) ??
 		contextWindowCache.get("default") ??
@@ -232,6 +249,7 @@ function toMetadata(
 	defaultParams: ModelParameterValue[],
 	context: string | undefined,
 	contextWindowCache: Map<string, number>,
+	fastOverride?: boolean,
 ): CursorModelMetadata {
 	const thinkingLevelMap = getThinkingLevelMap(item);
 	const fastValue = getParamValue(defaultParams, "fast")?.toLowerCase();
@@ -245,6 +263,7 @@ function toMetadata(
 		contextWindow: getContextWindow(contextWindowCache, piModelId, context, item.id),
 		supportsFast: getParameter(item, "fast") !== undefined,
 		defaultFast: fastValue === "true",
+		...(fastOverride !== undefined ? { fastOverride } : {}),
 		supportsReasoning: thinkingLevelMap !== undefined,
 		...(thinkingLevelMap ? { thinkingLevelMap } : {}),
 		parameterIds: {
@@ -310,16 +329,21 @@ function toModelConfigs(
 	const contexts = contextValues.length > 0 ? contextValues : [undefined];
 	const configs: ProviderModelConfig[] = [];
 
+	const fastOverrides = getParameter(item, "fast") === undefined ? [undefined] : [undefined, true, false];
+
 	for (const selectionModelId of getModelIds(item, reservedBaseModelIds, ambiguousAliases)) {
 		const alias = selectionModelId === item.id ? undefined : selectionModelId;
 		for (const context of contexts) {
-			const params = context ? replaceParam(defaultParams, "context", context) : defaultParams;
-			const piModelId = encodePiModelId(selectionModelId, context);
-			if (usedPiModelIds.has(piModelId)) continue;
-			usedPiModelIds.add(piModelId);
-			const metadata = toMetadata(item, piModelId, selectionModelId, params, context, contextWindowCache);
-			metadataByPiModelId.set(piModelId, metadata);
-			configs.push(toModelConfig(metadata, getModelName(item, context, alias)));
+			const contextParams = context ? replaceParam(defaultParams, "context", context) : defaultParams;
+			for (const fastOverride of fastOverrides) {
+				const params = fastOverride === undefined ? contextParams : replaceParam(contextParams, "fast", fastOverride ? "true" : "false");
+				const piModelId = encodePiModelId(selectionModelId, context, fastOverride);
+				if (usedPiModelIds.has(piModelId)) continue;
+				usedPiModelIds.add(piModelId);
+				const metadata = toMetadata(item, piModelId, selectionModelId, params, context, contextWindowCache, fastOverride);
+				metadataByPiModelId.set(piModelId, metadata);
+				configs.push(toModelConfig(metadata, getModelName(item, context, alias, fastOverride)));
+			}
 		}
 	}
 

--- a/test/cursor-state.test.ts
+++ b/test/cursor-state.test.ts
@@ -430,6 +430,40 @@ describe("Cursor runtime state", () => {
 		expect(getEffectiveFastForModelId("gpt-5.5@1m")).toBe(true);
 	});
 
+	it("lets virtual fast models override stored slow preferences", async () => {
+		writeFileSync(__testUtils.getConfigPath(), JSON.stringify({ fastDefaults: { "composer-2": false } }));
+		const { pi, ctx } = createCursorRuntimeHarness({ modelId: "composer-2:fast" });
+
+		await pi.invokeEventWithContext("session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", "cursor fast");
+		expect(getEffectiveFastForModelId("composer-2:fast")).toBe(true);
+	});
+
+	it("lets virtual slow models override stored fast preferences", async () => {
+		writeFileSync(__testUtils.getConfigPath(), JSON.stringify({ fastDefaults: { "composer-2": true } }));
+		const { pi, ctx } = createCursorRuntimeHarness({ modelId: "composer-2:slow" });
+
+		await pi.invokeEventWithContext("session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", undefined);
+		expect(getEffectiveFastForModelId("composer-2:slow")).toBe(false);
+	});
+
+	it("does not persist /cursor-fast while a virtual fast model is selected", async () => {
+		const { pi, ctx, commandCtx, commands } = createCursorRuntimeHarness({ modelId: "composer-2:slow" });
+		await pi.invokeEventWithContext("session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		await commands.get("cursor-fast")!.handler("", commandCtx);
+
+		expect(ctx.ui.notify).toHaveBeenCalledWith(
+			"Cursor fast is fixed disabled by selected model composer-2:slow; choose composer-2 to use /cursor-fast preferences",
+			"info",
+		);
+		expect(pi.appendEntry).not.toHaveBeenCalled();
+		expect(getEffectiveFastForModelId("composer-2:slow")).toBe(false);
+	});
+
 	it("forces fast with the CLI flag without writing session state", async () => {
 		const { pi, ctx } = createCursorRuntimeHarness({ modelId: "gpt-5.5@1m", cursorFastFlag: true });
 

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -383,10 +383,20 @@ describe("discoverModels", () => {
 			},
 		]);
 		const models = await discoverModels();
-		expect(models.map((model) => model.id)).toEqual(["gpt-5.4@272k", "gpt-5.4@1m"]);
+		expect(models.map((model) => model.id)).toEqual([
+			"gpt-5.4@272k",
+			"gpt-5.4@272k:fast",
+			"gpt-5.4@272k:slow",
+			"gpt-5.4@1m",
+			"gpt-5.4@1m:fast",
+			"gpt-5.4@1m:slow",
+		]);
 		expect(models[0].contextWindow).toBe(272000);
-		expect(models[1].contextWindow).toBe(1000000);
+		expect(models[1].contextWindow).toBe(272000);
+		expect(models[3].contextWindow).toBe(1000000);
 		expect(models[0].name).toBe("GPT-5.4 @ 272k");
+		expect(models[1].name).toBe("GPT-5.4 (fast) @ 272k");
+		expect(models[2].name).toBe("GPT-5.4 (slow) @ 272k");
 
 		const metadata = getCursorModelMetadata("gpt-5.4@272k");
 		expect(metadata).toMatchObject({
@@ -400,9 +410,39 @@ describe("discoverModels", () => {
 			{ id: "reasoning", value: "medium" },
 			{ id: "fast", value: "false" },
 		]);
+		expect(getCursorModelMetadata("gpt-5.4@272k:fast")).toMatchObject({
+			baseModelId: "gpt-5.4",
+			selectionModelId: "gpt-5.4",
+			context: "272k",
+			fastOverride: true,
+			defaultFast: true,
+		});
+		expect(getCursorModelMetadata("gpt-5.4@272k:slow")).toMatchObject({
+			baseModelId: "gpt-5.4",
+			selectionModelId: "gpt-5.4",
+			context: "272k",
+			fastOverride: false,
+			defaultFast: false,
+		});
+		expect(buildCursorModelSelection("gpt-5.4@272k:fast", "medium")).toEqual({
+			id: "gpt-5.4",
+			params: [
+				{ id: "context", value: "272k" },
+				{ id: "reasoning", value: "medium" },
+				{ id: "fast", value: "true" },
+			],
+		});
+		expect(buildCursorModelSelection("gpt-5.4@272k:slow", "medium")).toEqual({
+			id: "gpt-5.4",
+			params: [
+				{ id: "context", value: "272k" },
+				{ id: "reasoning", value: "medium" },
+				{ id: "fast", value: "false" },
+			],
+		});
 	});
 
-	it("does not encode reasoning, effort, thinking, or fast into pi model IDs", async () => {
+	it("does not encode reasoning, effort, or thinking into pi model IDs", async () => {
 		process.env.CURSOR_API_KEY = "test-key-123";
 		mockedList.mockResolvedValueOnce([
 			{
@@ -425,7 +465,7 @@ describe("discoverModels", () => {
 			},
 		]);
 		const models = await discoverModels();
-		expect(models[0].id).toBe("gpt-5.3-codex");
+		expect(models.map((model) => model.id)).toEqual(["gpt-5.3-codex", "gpt-5.3-codex:fast", "gpt-5.3-codex:slow"]);
 		expect(getCursorModelMetadata("gpt-5.3-codex")?.defaultParams).toEqual([
 			{ id: "reasoning", value: "high" },
 			{ id: "fast", value: "true" },
@@ -455,6 +495,8 @@ describe("discoverModels", () => {
 
 			expect(models.map((model) => [model.id, model.contextWindow])).toEqual([
 				["composer-2", 200000],
+				["composer-2:fast", 200000],
+				["composer-2:slow", 200000],
 				["new-sdk-model", 200000],
 			]);
 		} finally {
@@ -527,8 +569,11 @@ describe("discoverModels", () => {
 
 			const models = await discoverModels();
 
-			expect(models[0].id).toBe("composer-2");
-			expect(models[0].contextWindow).toBe(201000);
+			expect(models.map((model) => [model.id, model.contextWindow])).toEqual([
+				["composer-2", 201000],
+				["composer-2:fast", 201000],
+				["composer-2:slow", 201000],
+			]);
 		} finally {
 			rmSync(tmpAgentDir, { recursive: true, force: true });
 		}


### PR DESCRIPTION
## Summary

- Add virtual `:fast` and `:slow` Cursor model aliases for SDK models that expose a `fast` parameter.
- Make virtual aliases force the outgoing Cursor `fast=true/false` param without mutating shared `/cursor-fast` session/global defaults.
- Keep existing precedence: `--cursor-no-fast`, `--cursor-fast`, virtual alias override, saved session/global preference, SDK default.
- Preserve context/thinking metadata for virtual aliases, including context-window cache fallback from the unsuffixed model ID.
- Document the new per-agent/subagent selection path and bump package metadata to `0.1.31`.

Fixes #112.

## Validation

- `npx vitest run test/model-discovery.test.ts test/cursor-state.test.ts`
- `npm run typecheck`
- `npm run verify`
  - `npm run check:platform-smoke`
  - `npm run typecheck`
  - `npm test` — 78 files / 715 tests
- `npm pack --dry-run` — package `pi-cursor-sdk@0.1.31`
- `git diff --check`
- Direct runtime check:
  - `PI_CURSOR_SETTING_SOURCES=none PI_CURSOR_PI_TOOL_BRIDGE=0 pi -e . --model cursor/composer-2-5:slow --no-session -p 'Say ok only.'`
  - Result: `ok`
- Crabbox platform smoke:
  - `npm run smoke:platform:doctor` passed.
  - `npm run smoke:platform:all` passed after waiting for unrelated Parallels Windows smoke runs to finish.
  - Summary artifacts all `ok=true`:
    - macOS `run-1780351512661-o796ik`: platform-build, cursor-native-visual-matrix, cursor-bridge-visual-matrix, cursor-abort-cleanup, lease-cleanup
    - Ubuntu `run-1780351512662-x9razs`: platform-build, cursor-native-visual-matrix, cursor-bridge-visual-matrix, cursor-abort-cleanup, lease-cleanup
    - Windows native `run-1780351512664-nhefbq`: platform-build, cursor-native-visual-matrix, cursor-bridge-visual-matrix, cursor-abort-cleanup, lease-cleanup
- Subagent reviewer sign-off: `SIGN-OFF`; no blocking findings.

## Notes

- A first macOS platform-smoke attempt failed due an external `static_localhost` Crabbox lease held by another repo; rerunning macOS after reclaim passed.
- A later platform doctor attempt failed while other unrelated Parallels Windows smoke jobs were actively cloning/running. After those jobs completed, doctor and the full platform matrix passed.
