### PR TITLE
Harden typing safety checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## 0.1.32 - 2026-06-02
+
+### Added
+
+- Add a production typing-safety regression test that blocks broad TypeScript escape hatches such as `as unknown as`, `as any`, `as never`, explicit `any`, and production `@ts-ignore` / `@ts-expect-error` usage.
+
+### Changed
+
+- Replace repeated native replay render-test `as never` casts with typed test render fixture helpers.
+
+### Fixed
+
+- Harden local Cursor cache/config JSON parsing so model-list, context-window, and fast-default files are validated from `unknown` before trusted values are used.
+
 ## 0.1.31 - 2026-06-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "pi-cursor-sdk",
-	"version": "0.1.31",
+	"version": "0.1.32",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "pi-cursor-sdk",
-			"version": "0.1.31",
+			"version": "0.1.32",
 			"license": "MIT",
 			"dependencies": {
 				"@cursor/sdk": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pi-cursor-sdk",
-	"version": "0.1.31",
+	"version": "0.1.32",
 	"description": "pi provider extension backed by @cursor/sdk local agents",
 	"author": "Mitch Fultz (https://github.com/fitchmultz)",
 	"license": "MIT",

--- a/src/context-window-cache.ts
+++ b/src/context-window-cache.ts
@@ -18,15 +18,31 @@ function isPositiveInteger(value: unknown): value is number {
 	return typeof value === "number" && Number.isInteger(value) && value > 0;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function parseContextWindowCacheFile(value: unknown): ContextWindowCacheFile | undefined {
+	if (!isRecord(value)) return undefined;
+	const { contextWindows } = value;
+	if (contextWindows === undefined) return {};
+	if (!isRecord(contextWindows)) return undefined;
+	return {
+		contextWindows: Object.fromEntries(
+			Object.entries(contextWindows).filter((entry): entry is [string, number] => isPositiveInteger(entry[1])),
+		),
+	};
+}
+
 function loadUserContextWindowOverrides(): Map<string, number> {
 	userContextWindowOverrideLoadCount += 1;
 	const path = getCachePath();
 	const overrides = new Map<string, number>();
 	if (!existsSync(path)) return overrides;
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf-8")) as ContextWindowCacheFile;
-		for (const [modelId, contextWindow] of Object.entries(parsed.contextWindows ?? {})) {
-			if (isPositiveInteger(contextWindow)) overrides.set(modelId, contextWindow);
+		const parsed = parseContextWindowCacheFile(JSON.parse(readFileSync(path, "utf-8")));
+		for (const [modelId, contextWindow] of Object.entries(parsed?.contextWindows ?? {})) {
+			overrides.set(modelId, contextWindow);
 		}
 	} catch {
 		return overrides;
@@ -52,10 +68,10 @@ export function getCachedContextWindow(modelId: string): number | undefined {
 }
 
 export function getCheckpointContextWindow(checkpoint: unknown): number | undefined {
-	if (checkpoint === null || typeof checkpoint !== "object") return undefined;
-	const tokenDetails = (checkpoint as Record<PropertyKey, unknown>).tokenDetails;
-	if (tokenDetails === null || typeof tokenDetails !== "object") return undefined;
-	const maxTokens = (tokenDetails as Record<PropertyKey, unknown>).maxTokens;
+	if (!isRecord(checkpoint)) return undefined;
+	const { tokenDetails } = checkpoint;
+	if (!isRecord(tokenDetails)) return undefined;
+	const { maxTokens } = tokenDetails;
 	if (!isPositiveInteger(maxTokens)) return undefined;
 	return maxTokens;
 }

--- a/src/cursor-state.ts
+++ b/src/cursor-state.ts
@@ -69,10 +69,13 @@ export function parseCursorAgentMode(raw: unknown): AgentModeOption | undefined 
 	return isCursorAgentMode(mode) ? mode : undefined;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
 function isCursorFastEntryData(value: unknown): value is CursorFastEntryData {
-	if (!value || typeof value !== "object") return false;
-	const data = value as Record<string, unknown>;
-	return (typeof data.modelId === "string" || typeof data.baseModelId === "string") && typeof data.fast === "boolean";
+	if (!isRecord(value)) return false;
+	return (typeof value.modelId === "string" || typeof value.baseModelId === "string") && typeof value.fast === "boolean";
 }
 
 function getCursorFastEntryModelId(data: CursorFastEntryData): string {
@@ -80,9 +83,19 @@ function getCursorFastEntryModelId(data: CursorFastEntryData): string {
 }
 
 function isCursorModeEntryData(value: unknown): value is CursorModeEntryData {
-	if (!value || typeof value !== "object") return false;
-	const data = value as Record<string, unknown>;
-	return isCursorAgentMode(data.mode);
+	return isRecord(value) && isCursorAgentMode(value.mode);
+}
+
+function parseCursorGlobalConfig(value: unknown): CursorGlobalConfig | undefined {
+	if (!isRecord(value)) return undefined;
+	const { fastDefaults } = value;
+	if (fastDefaults === undefined) return {};
+	if (!isRecord(fastDefaults)) return undefined;
+	return {
+		fastDefaults: Object.fromEntries(
+			Object.entries(fastDefaults).filter((entry): entry is [string, boolean] => typeof entry[1] === "boolean"),
+		),
+	};
 }
 
 function getConfigPath(): string {
@@ -93,12 +106,8 @@ function loadGlobalFastPreferences(): Map<string, boolean> {
 	const path = getConfigPath();
 	if (!existsSync(path)) return new Map();
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf-8")) as CursorGlobalConfig;
-		return new Map(
-			Object.entries(parsed.fastDefaults ?? {}).filter(
-				(entry): entry is [string, boolean] => typeof entry[1] === "boolean",
-			),
-		);
+		const parsed = parseCursorGlobalConfig(JSON.parse(readFileSync(path, "utf-8")));
+		return new Map(Object.entries(parsed?.fastDefaults ?? {}));
 	} catch {
 		return new Map();
 	}

--- a/src/model-list-cache.ts
+++ b/src/model-list-cache.ts
@@ -8,6 +8,7 @@ import { parseEnvBoolean } from "./cursor-env-boolean.js";
 const MODEL_LIST_CACHE_FILE = "cursor-sdk-model-list.json";
 const MODEL_LIST_CACHE_VERSION = 1;
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+const MAX_CACHE_CLOCK_SKEW_MS = 5 * 60 * 1000;
 const DISABLE_ENV_VAR = "PI_CURSOR_SDK_DISABLE_MODEL_CACHE";
 const TTL_ENV_VAR = "PI_CURSOR_SDK_MODEL_CACHE_TTL_MS";
 
@@ -45,20 +46,83 @@ export function fingerprintApiKey(apiKey: string): string {
 	return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+	return Array.isArray(value) && value.every((entry) => typeof entry === "string");
+}
+
+function isModelParameterValue(value: unknown): value is NonNullable<ModelListItem["variants"]>[number]["params"][number] {
+	return isRecord(value) && typeof value.id === "string" && typeof value.value === "string";
+}
+
+function isModelParameterDefinitionValue(value: unknown): value is NonNullable<ModelListItem["parameters"]>[number]["values"][number] {
+	return isRecord(value) && typeof value.value === "string" && (value.displayName === undefined || typeof value.displayName === "string");
+}
+
+function isModelParameterDefinition(value: unknown): value is NonNullable<ModelListItem["parameters"]>[number] {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === "string" &&
+		(value.displayName === undefined || typeof value.displayName === "string") &&
+		Array.isArray(value.values) &&
+		value.values.every(isModelParameterDefinitionValue)
+	);
+}
+
+function isModelVariant(value: unknown): value is NonNullable<ModelListItem["variants"]>[number] {
+	if (!isRecord(value)) return false;
+	return (
+		Array.isArray(value.params) &&
+		value.params.every(isModelParameterValue) &&
+		typeof value.displayName === "string" &&
+		(value.description === undefined || typeof value.description === "string") &&
+		(value.isDefault === undefined || typeof value.isDefault === "boolean")
+	);
+}
+
+function isModelListItem(value: unknown): value is ModelListItem {
+	if (!isRecord(value)) return false;
+	return (
+		typeof value.id === "string" &&
+		typeof value.displayName === "string" &&
+		(value.description === undefined || typeof value.description === "string") &&
+		(value.aliases === undefined || isStringArray(value.aliases)) &&
+		(value.parameters === undefined || (Array.isArray(value.parameters) && value.parameters.every(isModelParameterDefinition))) &&
+		(value.variants === undefined || (Array.isArray(value.variants) && value.variants.every(isModelVariant)))
+	);
+}
+
+function isValidFetchedAt(value: unknown): value is number {
+	return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 && value <= Date.now() + MAX_CACHE_CLOCK_SKEW_MS;
+}
+
+function parseModelListCacheFile(value: unknown): ModelListCacheFile | undefined {
+	if (!isRecord(value)) return undefined;
+	if (
+		value.version !== MODEL_LIST_CACHE_VERSION ||
+		!isValidFetchedAt(value.fetchedAt) ||
+		typeof value.keyFingerprint !== "string" ||
+		!Array.isArray(value.models) ||
+		!value.models.every(isModelListItem)
+	) {
+		return undefined;
+	}
+	return {
+		version: value.version,
+		fetchedAt: value.fetchedAt,
+		keyFingerprint: value.keyFingerprint,
+		models: value.models,
+	};
+}
+
 function readCacheFile(): ModelListCacheFile | undefined {
 	const path = getCachePath();
 	if (!existsSync(path)) return undefined;
 	try {
-		const parsed = JSON.parse(readFileSync(path, "utf-8")) as ModelListCacheFile;
-		if (
-			parsed.version !== MODEL_LIST_CACHE_VERSION ||
-			typeof parsed.fetchedAt !== "number" ||
-			typeof parsed.keyFingerprint !== "string" ||
-			!Array.isArray(parsed.models)
-		) {
-			return undefined;
-		}
-		return parsed;
+		return parseModelListCacheFile(JSON.parse(readFileSync(path, "utf-8")));
 	} catch {
 		return undefined;
 	}

--- a/test/cursor-native-tool-display-replay.test.ts
+++ b/test/cursor-native-tool-display-replay.test.ts
@@ -8,27 +8,23 @@ import {
 	renderCursorReplayCall,
 	renderCursorReplayResult,
 	renderNativeLookingCursorReadReplayResult,
-	type CursorReplayRenderTheme,
 } from "../src/cursor-native-tool-display-replay.js";
 import { LOCAL_READ_PREVIEW_NOTICE } from "../src/cursor-transcript-utils.js";
 import { Text } from "@earendil-works/pi-tui";
+import { createRenderContext, createRenderTheme } from "./helpers/render-fixtures.js";
 
-const theme = {
-	fg: (_name: string, value: string) => value,
-	bold: (value: string) => value,
-} as CursorReplayRenderTheme;
+const theme = createRenderTheme();
 
-const taggedTheme = {
+const taggedTheme = createRenderTheme({
 	fg: (name: string, value: string) => `<${name}>${value}</${name}>`,
-	bold: (value: string) => value,
-} as CursorReplayRenderTheme;
+});
 
 function renderReplayResultWithDetails(details: unknown): string {
 	return renderCursorReplayResult(
 		{ content: [{ type: "text", text: "ok" }], details },
 		{ expanded: false, isPartial: false },
 		taggedTheme,
-		{ isError: false, showImages: false } as never,
+		createRenderContext({ isError: false, showImages: false }),
 		false,
 	)
 		.render(240)
@@ -170,9 +166,7 @@ describe("cursor native replay rendering", () => {
 			result,
 			{ expanded: false, isPartial: false },
 			theme,
-			{ isError: false, args: { path: "README.md", localReadPreview: true } } as Parameters<
-				typeof renderNativeLookingCursorReadReplayResult
-			>[3],
+			createRenderContext({ isError: false, args: { path: "README.md", localReadPreview: true } }),
 			() => new Text("", 0, 0),
 		)
 			.render(120)

--- a/test/cursor-native-tool-display-tools.test.ts
+++ b/test/cursor-native-tool-display-tools.test.ts
@@ -4,20 +4,24 @@ import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import * as replay from "../src/cursor-native-tool-display-replay.js";
 import { wrapNativeCursorTool } from "../src/cursor-native-tool-display-tools.js";
+import { createRenderContext, createRenderOptions, createRenderTheme } from "./helpers/render-fixtures.js";
 
 describe("wrapNativeCursorTool", () => {
 	it("does not use Cursor replay rendering for ordinary pi edit toolCallIds", () => {
 		const replaySpy = vi.spyOn(replay, "renderCursorReplayResult").mockReturnValue(new Text("", 0, 0));
-		const delegateRenderResult = vi.fn().mockReturnValue(new Text("pi edit", 0, 0));
-		const definition = {
+		const parameters = Type.Object({});
+		type EditToolDefinition = ToolDefinition<typeof parameters, unknown, unknown>;
+		const delegateRenderResult = vi.fn<NonNullable<EditToolDefinition["renderResult"]>>(() => new Text("pi edit", 0, 0));
+		const definition: EditToolDefinition = {
 			name: "edit",
+			label: "edit",
 			description: "edit",
-			parameters: Type.Object({}),
-			execute: vi.fn(),
+			parameters,
+			execute: vi.fn(async () => ({ content: [], details: undefined })),
 			renderResult: delegateRenderResult,
-		} as unknown as ToolDefinition<typeof Type.Object, unknown, unknown>;
+		};
 		const wrapped = wrapNativeCursorTool(definition, () => definition);
-		const theme = { fg: (_style: string, text: string) => text, bold: (text: string) => text } as never;
+		const theme = createRenderTheme();
 
 		wrapped.renderResult?.(
 			{
@@ -29,9 +33,9 @@ describe("wrapNativeCursorTool", () => {
 					linesRemoved: 1,
 				},
 			},
-			{ expanded: false, isPartial: false } as never,
+			createRenderOptions(),
 			theme,
-			{ isError: false, toolCallId: "ordinary-edit-1" } as never,
+			createRenderContext({ isError: false, toolCallId: "ordinary-edit-1" }),
 		);
 
 		expect(replaySpy).not.toHaveBeenCalled();

--- a/test/cursor-provider-turn-shell-output.test.ts
+++ b/test/cursor-provider-turn-shell-output.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { InteractionUpdate } from "@cursor/sdk";
 import {
 	CursorShellOutputTracker,
 	getCursorShellOutputDelta,
@@ -60,11 +61,11 @@ describe("mergeShellOutputDeltasIntoCursorToolCall", () => {
 
 describe("getCursorShellOutputDelta", () => {
 	it("parses stdout shell-output-delta updates", () => {
-		expect(
-			getCursorShellOutputDelta({
-				type: "shell-output-delta",
-				event: { case: "stdout", value: { data: "ok\n" } },
-			} as never),
-		).toEqual({ stream: "stdout", data: "ok\n" });
+		const update = {
+			type: "shell-output-delta",
+			event: { case: "stdout", value: { data: "ok\n" } },
+		} as InteractionUpdate;
+
+		expect(getCursorShellOutputDelta(update)).toEqual({ stream: "stdout", data: "ok\n" });
 	});
 });

--- a/test/cursor-replay-tool-details.test.ts
+++ b/test/cursor-replay-tool-details.test.ts
@@ -6,22 +6,17 @@ import {
 	parseCursorReplayToolDetails,
 	parseStrictCurrentCursorReplayToolDetails,
 } from "../src/cursor-replay-tool-details.js";
-import {
-	renderCursorReplayResult,
-	type CursorReplayRenderTheme,
-} from "../src/cursor-native-tool-display-replay.js";
+import { renderCursorReplayResult } from "../src/cursor-native-tool-display-replay.js";
+import { createRenderContext, createRenderTheme } from "./helpers/render-fixtures.js";
 
-const theme = {
-	fg: (_name: string, value: string) => value,
-	bold: (value: string) => value,
-} as CursorReplayRenderTheme;
+const theme = createRenderTheme();
 
 function renderReplayResult(details: unknown, text = "ok", isError = false): string {
 	return renderCursorReplayResult(
 		{ content: [{ type: "text", text }], details },
 		{ expanded: false, isPartial: false },
 		theme,
-		{ isError, showImages: false } as never,
+		createRenderContext({ isError, showImages: false }),
 		isError,
 	)
 		.render(120)
@@ -310,7 +305,7 @@ describe("cursor replay tool details contract", () => {
 			},
 			{ expanded: false, isPartial: false },
 			theme,
-			{ isError: true, showImages: false } as never,
+			createRenderContext({ isError: true, showImages: false }),
 			true,
 		)
 			.render(120)

--- a/test/cursor-state.test.ts
+++ b/test/cursor-state.test.ts
@@ -588,6 +588,17 @@ describe("Cursor runtime state", () => {
 		expect(getEffectiveFastForModelId("gpt-5.5@1m")).toBe(false);
 	});
 
+	it("filters global config entries with invalid fast default values", async () => {
+		writeFileSync(__testUtils.getConfigPath(), JSON.stringify({ fastDefaults: { "gpt-5.5": true, "composer-2": "true" } }));
+		expect(__testUtils.loadGlobalFastPreferences()).toEqual(new Map([["gpt-5.5", true]]));
+		const { pi, ctx } = createCursorRuntimeHarness({ modelId: "gpt-5.5@1m" });
+
+		await pi.invokeEventWithContext("session_start", { type: "session_start", reason: "startup" }, ctx);
+
+		expect(ctx.ui.setStatus).toHaveBeenLastCalledWith("cursor", "cursor fast");
+		expect(getEffectiveFastForModelId("gpt-5.5@1m")).toBe(true);
+	});
+
 	it("does not apply or persist --cursor-fast for unsupported Cursor models", async () => {
 		const { pi, ctx } = createCursorRuntimeHarness({ modelId: "gemini-3.1-pro", cursorFastFlag: true });
 

--- a/test/helpers/context-fixtures.ts
+++ b/test/helpers/context-fixtures.ts
@@ -59,7 +59,7 @@ function createMinimalExtensionUi(): ExtensionContext["ui"] {
 		setFooter: vi.fn(),
 		setHeader: vi.fn(),
 		setTitle: vi.fn(),
-		custom: vi.fn(async () => undefined as never),
+		custom: vi.fn(<T>() => Promise.resolve(undefined as T)) as ExtensionContext["ui"]["custom"],
 		pasteToEditor: vi.fn(),
 		setEditorText: vi.fn(),
 		getEditorText: vi.fn(() => ""),

--- a/test/helpers/render-fixtures.ts
+++ b/test/helpers/render-fixtures.ts
@@ -1,0 +1,43 @@
+import type { RegisteredTool } from "./pi-harness-types.js";
+
+type ToolRenderCall = NonNullable<RegisteredTool["renderCall"]>;
+type ToolRenderResult = NonNullable<RegisteredTool["renderResult"]>;
+
+export type HarnessRenderTheme = Parameters<ToolRenderCall>[1];
+export type HarnessRenderContext = Parameters<ToolRenderCall>[2];
+type HarnessRenderContextWithObjectArgs = Omit<HarnessRenderContext, "args"> & { args: object };
+export type HarnessRenderResultOptions = Parameters<ToolRenderResult>[1];
+
+export function createRenderTheme(overrides: Partial<HarnessRenderTheme> = {}): HarnessRenderTheme {
+	return {
+		fg: (_style: string, text: string) => text,
+		bold: (text: string) => text,
+		...overrides,
+	} as HarnessRenderTheme;
+}
+
+export function createRenderOptions(overrides: Partial<HarnessRenderResultOptions> = {}): HarnessRenderResultOptions {
+	return {
+		expanded: false,
+		isPartial: false,
+		...overrides,
+	};
+}
+
+export function createRenderContext(overrides: Partial<HarnessRenderContext> & { args?: object } = {}): HarnessRenderContextWithObjectArgs {
+	return {
+		args: {},
+		toolCallId: "test-tool-call",
+		invalidate: () => {},
+		lastComponent: undefined,
+		state: undefined,
+		cwd: process.cwd(),
+		executionStarted: true,
+		argsComplete: true,
+		isPartial: false,
+		expanded: false,
+		showImages: false,
+		isError: false,
+		...overrides,
+	};
+}

--- a/test/index-native-tools.test.ts
+++ b/test/index-native-tools.test.ts
@@ -13,6 +13,7 @@ import {
 	makeModel,
 } from "./helpers/pi-harness.js";
 import { createExtensionPi, resetIndexExtensionTestState } from "./helpers/index-extension-test-kit.js";
+import { createRenderContext, createRenderOptions, createRenderTheme } from "./helpers/render-fixtures.js";
 
 vi.mock("../src/model-discovery.js", () => ({
 	discoverModels: vi.fn(),
@@ -164,17 +165,16 @@ describe("extension native Cursor tool replay", () => {
 
 			const readTool = getHarnessRegisteredTool(pi._tools, "read");
 			expect(readTool).toBeDefined();
-			const theme = {
+			const theme = createRenderTheme({
 				fg: (style: string, text: string) => (style === "warning" || style === "muted" ? `<${style}>${text}</${style}>` : text),
-				bold: (text: string) => text,
-			} as never;
-			const replayContext = {
+			});
+			const replayContext = createRenderContext({
 				isError: false,
 				toolCallId: "cursor-replay-1-1-tool-1",
 				args: { path: "README.md", localReadPreview: true },
 				expanded: false,
-			} as never;
-			const options = { expanded: false, isPartial: false } as never;
+			});
+			const options = createRenderOptions();
 
 			const callRendered = readTool!.renderCall?.({ path: "README.md", localReadPreview: true }, theme, replayContext)?.render(120).join("\n") ?? "";
 			const resultRendered =
@@ -224,9 +224,9 @@ describe("extension native Cursor tool replay", () => {
 						expandedText: `generateImage Small badge\n\nSaved image: ${imagePath}`,
 					},
 				},
-				{ expanded: false, isPartial: false } as never,
-				{ fg: (_style: string, text: string) => text, bold: (text: string) => text } as never,
-				{ isError: false, showImages: true } as never,
+				createRenderOptions(),
+				createRenderTheme(),
+				createRenderContext({ isError: false, showImages: true }),
 			);
 
 			const rendered = component?.render(120).join("\n") ?? "";
@@ -244,13 +244,13 @@ describe("extension native Cursor tool replay", () => {
 		const pi = createExtensionPi();
 		await extensionFactory(pi);
 		await pi.runSessionStart();
-		const theme = { fg: (_style: string, text: string) => text, bold: (text: string) => text } as never;
+		const theme = createRenderTheme();
 		const cursorTool = getHarnessRegisteredTool(pi._tools, "cursor");
 
 		const rendered = [
-			cursorTool.renderCall?.({ activityTitle: "Cursor plan", activitySummary: "2 items", totalCount: 2 }, theme, { isPartial: true } as never)?.render(120).join("\n"),
-			cursorTool.renderCall?.({ activityTitle: "Cursor todos", activitySummary: "1/2 completed, 1 pending", totalCount: 2 }, theme, { isPartial: true } as never)?.render(120).join("\n"),
-			cursorTool.renderCall?.({ activityTitle: "Cursor MCP", activitySummary: "external_search", toolName: "external_search" }, theme, { isPartial: true } as never)?.render(120).join("\n"),
+			cursorTool.renderCall?.({ activityTitle: "Cursor plan", activitySummary: "2 items", totalCount: 2 }, theme, createRenderContext({ isPartial: true }))?.render(120).join("\n"),
+			cursorTool.renderCall?.({ activityTitle: "Cursor todos", activitySummary: "1/2 completed, 1 pending", totalCount: 2 }, theme, createRenderContext({ isPartial: true }))?.render(120).join("\n"),
+			cursorTool.renderCall?.({ activityTitle: "Cursor MCP", activitySummary: "external_search", toolName: "external_search" }, theme, createRenderContext({ isPartial: true }))?.render(120).join("\n"),
 		]
 			.filter((entry): entry is string => Boolean(entry))
 			.join("\n");
@@ -270,8 +270,8 @@ describe("extension native Cursor tool replay", () => {
 		const pi = createExtensionPi();
 		await extensionFactory(pi);
 		await pi.runSessionStart();
-		const theme = { fg: (_style: string, text: string) => text, bold: (text: string) => text } as never;
-		const context = { isError: false, showImages: false } as never;
+		const theme = createRenderTheme();
+		const context = createRenderContext({ isError: false, showImages: false });
 		const cursorTool = getHarnessRegisteredTool(pi._tools, "cursor");
 		const result = {
 			content: [{ type: "text" as const, text: "web search azure-functions python\n\nLinks:\n1. [Release](https://example.com)" }],
@@ -284,8 +284,8 @@ describe("extension native Cursor tool replay", () => {
 			},
 		};
 
-		const collapsed = cursorTool!.renderResult?.(result, { expanded: false, isPartial: false } as never, theme, context)?.render(120).join("\n").trimEnd() ?? "";
-		const expanded = cursorTool!.renderResult?.(result, { expanded: true, isPartial: false } as never, theme, context)?.render(120).join("\n") ?? "";
+		const collapsed = cursorTool!.renderResult?.(result, createRenderOptions(), theme, context)?.render(120).join("\n").trimEnd() ?? "";
+		const expanded = cursorTool!.renderResult?.(result, createRenderOptions({ expanded: true }), theme, context)?.render(120).join("\n") ?? "";
 
 		expect(collapsed).toBe("Cursor web search web search azure-functions python");
 		expect(collapsed).not.toContain("Links:");
@@ -300,9 +300,9 @@ describe("extension native Cursor tool replay", () => {
 		const pi = createExtensionPi();
 		await extensionFactory(pi);
 		await pi.runSessionStart();
-		const theme = { fg: (_style: string, text: string) => text, bold: (text: string) => text } as never;
-		const options = { expanded: false, isPartial: false } as never;
-		const context = { isError: false, showImages: false } as never;
+		const theme = createRenderTheme();
+		const options = createRenderOptions();
+		const context = createRenderContext({ isError: false, showImages: false });
 
 		const editTool = getHarnessRegisteredTool(pi._tools, "cursor_edit");
 		const writeTool = getHarnessRegisteredTool(pi._tools, "cursor_write");
@@ -313,7 +313,7 @@ describe("extension native Cursor tool replay", () => {
 		expect(mcpTool.renderShell).toBeUndefined();
 
 		const rendered = [
-			editTool.renderCall?.({ path: "src/index.ts" }, theme, { isPartial: true } as never)?.render(120).join("\n"),
+			editTool.renderCall?.({ path: "src/index.ts" }, theme, createRenderContext({ isPartial: true }))?.render(120).join("\n"),
 			writeTool.renderResult?.(
 				{
 					content: [{ type: "text", text: "write new.txt\n\nCreated 1 lines" }],
@@ -352,18 +352,17 @@ describe("extension native Cursor tool replay", () => {
 		const pi = createExtensionPi();
 		await extensionFactory(pi);
 		await pi.runSessionStart();
-		const theme = {
+		const theme = createRenderTheme({
 			fg: (style: string, text: string) =>
 				["toolDiffAdded", "toolDiffRemoved", "toolDiffContext", "toolOutput"].includes(style) ? `<${style}>${text}</${style}>` : text,
-			bold: (text: string) => text,
-		} as never;
-		const options = { expanded: false, isPartial: false } as never;
-		const replayContext = { isError: false, showImages: false, toolCallId: "cursor-replay-1-1-tool-1" } as never;
+		});
+		const options = createRenderOptions();
+		const replayContext = createRenderContext({ isError: false, showImages: false, toolCallId: "cursor-replay-1-1-tool-1" });
 
 		const editTool = getHarnessRegisteredTool(pi._tools, "edit");
 		const writeTool = getHarnessRegisteredTool(pi._tools, "write");
 		const rendered = [
-			editTool.renderCall?.({ path: "src/index.ts" }, theme, { isPartial: true, toolCallId: "cursor-replay-1-1-tool-1" } as never)?.render(120).join("\n"),
+			editTool.renderCall?.({ path: "src/index.ts" }, theme, createRenderContext({ isPartial: true, toolCallId: "cursor-replay-1-1-tool-1" }))?.render(120).join("\n"),
 			editTool.renderResult?.(
 				{
 					content: [{ type: "text", text: "edit src/index.ts\n\n+1 -1" }],
@@ -379,7 +378,7 @@ describe("extension native Cursor tool replay", () => {
 				theme,
 				replayContext,
 			)?.render(120).join("\n"),
-			writeTool!.renderCall?.({ path: "new.txt", content: "hello\n" }, theme, { isPartial: true, toolCallId: "cursor-replay-1-1-tool-2" } as never)?.render(120).join("\n"),
+			writeTool!.renderCall?.({ path: "new.txt", content: "hello\n" }, theme, createRenderContext({ isPartial: true, toolCallId: "cursor-replay-1-1-tool-2" }))?.render(120).join("\n"),
 			writeTool!.renderResult?.(
 				{
 					content: [{ type: "text", text: "write new.txt\n\nCreated 3 lines\n\n# Title\n\nBody" }],
@@ -412,13 +411,12 @@ describe("extension native Cursor tool replay", () => {
 		const pi = createExtensionPi();
 		await extensionFactory(pi);
 		await pi.runSessionStart();
-		const theme = {
+		const theme = createRenderTheme({
 			fg: (style: string, text: string) =>
 				["toolDiffAdded", "toolDiffRemoved", "toolDiffContext"].includes(style) ? `<${style}>${text}</${style}>` : text,
-			bold: (text: string) => text,
-		} as never;
-		const options = { expanded: false, isPartial: false } as never;
-		const context = { isError: false, showImages: false } as never;
+		});
+		const options = createRenderOptions();
+		const context = createRenderContext({ isError: false, showImages: false });
 
 		const todosTool = getHarnessRegisteredTool(pi._tools, "cursor_update_todos");
 		const todosRendered = todosTool.renderResult?.(

--- a/test/index-registration.test.ts
+++ b/test/index-registration.test.ts
@@ -208,7 +208,7 @@ describe("extension registration and discovery", () => {
 			},
 			undefined,
 			undefined,
-			createExtensionTestContext({ ui: { notify: vi.fn(), setStatus: vi.fn(), select, input } }) as never,
+			createExtensionTestContext({ ui: { notify: vi.fn(), setStatus: vi.fn(), select, input } }),
 		);
 
 		expect(select).toHaveBeenCalledWith("What kind of calculator should Cursor plan?", ["Web app", "CLI"]);

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -579,6 +579,28 @@ describe("discoverModels", () => {
 		}
 	});
 
+	it("ignores malformed context-window cache values", async () => {
+		const tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-context-window-malformed-"));
+		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
+		try {
+			writeFileSync(contextWindowCacheTestUtils.getCachePath(), JSON.stringify({ contextWindows: { "composer-2": "201000" } }));
+			process.env.CURSOR_API_KEY = "test-key-123";
+			mockedList.mockResolvedValueOnce([
+				{
+					id: "composer-2",
+					displayName: "Composer 2",
+					variants: [{ params: [], displayName: "Composer 2", isDefault: true }],
+				},
+			]);
+
+			const models = await discoverModels();
+
+			expect(models.find((model) => model.id === "composer-2")?.contextWindow).toBe(200000);
+		} finally {
+			rmSync(tmpAgentDir, { recursive: true, force: true });
+		}
+	});
+
 	it("sets reasoning false for models without thinking controls", async () => {
 		process.env.CURSOR_API_KEY = "test-key-123";
 		mockedList.mockResolvedValueOnce([

--- a/test/model-list-cache.test.ts
+++ b/test/model-list-cache.test.ts
@@ -80,6 +80,47 @@ describe("model-list-cache", () => {
 		expect(loadAnyCachedModels(fp)).toBeUndefined();
 	});
 
+	it.each([
+		["non-finite", "1e309"],
+		["negative", "-1"],
+		["finite Date-invalid", "1e100"],
+		["far-future", `${Date.now() + __testUtils.DEFAULT_TTL_MS + 1}`],
+	])("ignores cache files with %s timestamps", (_label, fetchedAt) => {
+		writeFileSync(
+			__testUtils.getCachePath(),
+			`{"version":1,"fetchedAt":${fetchedAt},"keyFingerprint":${JSON.stringify(fp)},"models":${JSON.stringify(MODELS)}}`,
+		);
+
+		expect(loadFreshCachedModels(fp)).toBeUndefined();
+		expect(loadAnyCachedModels(fp)).toBeUndefined();
+	});
+
+	it.each([
+		["missing displayName", { id: "missing-display-name" }],
+		["parameter without values", { id: "raw-id", displayName: "Raw", parameters: [{ id: "context" }] }],
+		[
+			"parameter value without string value",
+			{ id: "raw-id", displayName: "Raw", parameters: [{ id: "context", values: [{ displayName: "1M" }] }] },
+		],
+		[
+			"variant param without string id/value",
+			{ id: "raw-id", displayName: "Raw", variants: [{ params: [{ id: "context" }], displayName: "Raw", isDefault: true }] },
+		],
+	])("ignores cache files with invalid model shapes: %s", (_label, model) => {
+		writeFileSync(
+			__testUtils.getCachePath(),
+			JSON.stringify({
+				version: 1,
+				fetchedAt: Date.now(),
+				keyFingerprint: fp,
+				models: [model],
+			}),
+		);
+
+		expect(loadFreshCachedModels(fp)).toBeUndefined();
+		expect(loadAnyCachedModels(fp)).toBeUndefined();
+	});
+
 	it("disables read and write when the disable env flag is set", () => {
 		process.env[__testUtils.DISABLE_ENV_VAR] = "1";
 		saveModelListCache(fp, MODELS);

--- a/test/typing-safety.test.ts
+++ b/test/typing-safety.test.ts
@@ -1,0 +1,53 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const PRODUCTION_DIRS = ["src", "scripts", "shared"] as const;
+const SOURCE_FILE_EXTENSIONS = new Set([".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"]);
+const IGNORED_FILES = new Set(["src/cursor-fallback-models.generated.ts"]);
+
+const FORBIDDEN_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+	{ label: "double assertion through unknown", pattern: /\bas\s+unknown\s+as\b/ },
+	{ label: "any assertion", pattern: /\bas\s+any\b/ },
+	{ label: "never assertion", pattern: /\bas\s+never\b/ },
+	{ label: "explicit any annotation", pattern: /:\s*any\b/ },
+	{ label: "Record<string, any>", pattern: /\bRecord\s*<\s*string\s*,\s*any\s*>/ },
+	{ label: "ts-ignore", pattern: /@ts-ignore\b/ },
+	{ label: "production ts-expect-error", pattern: /@ts-expect-error\b/ },
+];
+
+function extension(path: string): string {
+	const index = path.lastIndexOf(".");
+	return index === -1 ? "" : path.slice(index);
+}
+
+function listSourceFiles(dir: string): string[] {
+	const files: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const path = join(dir, entry);
+		if (path.includes("node_modules") || path.includes("dist")) continue;
+		const stats = statSync(path);
+		if (stats.isDirectory()) {
+			files.push(...listSourceFiles(path));
+		} else if (SOURCE_FILE_EXTENSIONS.has(extension(path)) && !path.match(/\.d\.[cm]?ts$/) && !IGNORED_FILES.has(path)) {
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+describe("production typing safety", () => {
+	it("does not use broad unsafe TypeScript escape hatches in production code", () => {
+		const violations: string[] = [];
+		for (const file of PRODUCTION_DIRS.flatMap((dir) => listSourceFiles(dir))) {
+			const lines = readFileSync(file, "utf8").split(/\r?\n/);
+			for (const [index, line] of lines.entries()) {
+				for (const { label, pattern } of FORBIDDEN_PATTERNS) {
+					if (pattern.test(line)) violations.push(`${file}:${index + 1}: ${label}: ${line.trim()}`);
+				}
+			}
+		}
+
+		expect(violations).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Summary

- add a production typing-safety regression test that blocks broad TypeScript escape hatches in `src/`, `scripts/`, and `shared/`
- replace repeated native replay render-test `as never` casts with typed render fixture helpers
- validate local model-list, context-window, and Cursor fast-default JSON cache/config files from `unknown` before using trusted values
- bump package/changelog to `0.1.32` for this new PR

## Validation

- `npm test -- --run test/cursor-state.test.ts test/typing-safety.test.ts`
- `npm run verify`
- `git diff --check`
- `npm pack --dry-run`
