### PR TITLE
Fix #121: fitchmultz/pi-cursor-sdk

### DIFF
--- a/src/cursor-sdk-process-error-guard.ts
+++ b/src/cursor-sdk-process-error-guard.ts
@@ -35,7 +35,7 @@ function shouldSuppressProcessError(event: string | symbol, args: readonly unkno
 	const classification = classifyCursorConnectError(error);
 	if (!classification) return false;
 	if (classification.kind === "abort") return hasActiveAbortSuppression();
-	return activeProviderTurns.size > 0 && isCursorProvenance(classification.source);
+	return activeProviderTurns.size > 0 && (classification.kind === "network" || isCursorProvenance(classification.source));
 }
 
 function installProcessEmitPatch(): void {

--- a/test/cursor-sdk-process-error-guard.test.ts
+++ b/test/cursor-sdk-process-error-guard.test.ts
@@ -225,7 +225,7 @@ describe("Cursor SDK process error guard", () => {
 		}
 	});
 
-	it("does not suppress non-Cursor network ConnectErrors", () => {
+	it("suppresses generic connect-node network ConnectErrors while a provider turn is active", () => {
 		const suppression = installCursorSdkProcessErrorGuard();
 		let listenerCalled = false;
 		const listener = () => {
@@ -235,7 +235,7 @@ describe("Cursor SDK process error guard", () => {
 		try {
 			const emitted = process.emit("uncaughtException", makeNonCursorNetworkConnectError(), "uncaughtException");
 			expect(emitted).toBe(true);
-			expect(listenerCalled).toBe(true);
+			expect(listenerCalled).toBe(false);
 		} finally {
 			process.removeListener("uncaughtException", listener);
 			suppression.dispose();


### PR DESCRIPTION
Closes #121

## Evidence summary
# Root Cause

The process error guard has a provenance mismatch for Cursor provider network errors that surface from the generic ConnectRPC node stack.

`src/cursor-provider-errors.ts` correctly recognizes the issue error shape as a network `ConnectError` because the message/rawMessage/cause include `ECONNRESET`. For the production stack in issue #121, `getCursorConnectSource()` returns `"generic-connect"` because the stack contains `@connectrpc/connect-node` but does not include `@cursor/sdk`, does not include a local `pi-cursor-sdk` path, and does not carry `aiserver.*` backend details.

`src/cursor-sdk-process-error-guard.ts` then rejects that classified network error at suppression time. `shouldSuppressProcessError()` suppresses non-abort ConnectErrors only when a provider turn is acti…

## Validation
Not passed or incomplete (failed).

Warning reason: Auto-opened draft PR with validation warning. Human review is required before merge.

## Warnings
- Validation warning: failed

## Files changed
- src/cursor-sdk-process-error-guard.ts
- test/cursor-sdk-process-error-guard.test.ts

## Risks
Review the diff before merge. Reprodeck opened this draft PR automatically after an evidence-first automated run; it must not merge or mutate the default branch without human approval.

Generated by Reprodeck.