### PR TITLE
Stop NGHTTP2_ENHANCE_YOUR_CALM crashes by treating HTTP/2 stream resets as retryable

### DIFF
--- a/src/cursor-provider-errors.ts
+++ b/src/cursor-provider-errors.ts
@@ -119,7 +119,9 @@ export function classifyCursorConnectError(error: unknown): CursorConnectErrorCl
 
 	const causeCode = getErrorStringField(cause, "code");
 	const causeSyscall = getErrorStringField(cause, "syscall");
-	if (isLikelyNetworkTimeout(`${message}\n${rawMessage}\n${causeCode ?? ""}\n${causeSyscall ?? ""}`)) {
+	const causeMessage = getErrorStringField(cause, "rawMessage") ?? getErrorStringField(cause, "message") ?? "";
+	const networkProbe = `${message}\n${rawMessage}\n${causeCode ?? ""}\n${causeSyscall ?? ""}\n${causeMessage}`;
+	if (isLikelyNetworkTimeout(networkProbe) || isLikelyHttp2StreamError(networkProbe)) {
 		return { kind: "network", source: getCursorConnectSource(error, record) };
 	}
 
@@ -140,6 +142,13 @@ function isLikelyNetworkTimeout(message: string): boolean {
 		/\bConnectError\b.*\b(unavailable|deadline|timeout|timed out)\b/i.test(message) ||
 		/\bread ETIMEDOUT\b/i.test(message)
 	);
+}
+
+// HTTP/2 stream resets (ENHANCE_YOUR_CALM = server backpressure/rate limit, GOAWAY,
+// REFUSED_STREAM). The local Cursor SDK surfaces these as ConnectErrors that otherwise
+// crash pi as uncaught exceptions. They are transient — classify as network so pi retries.
+function isLikelyHttp2StreamError(message: string): boolean {
+	return /(ENHANCE_YOUR_CALM|ERR_HTTP2_STREAM_ERROR|NGHTTP2_REFUSED_STREAM|NGHTTP2_INTERNAL_ERROR|ERR_HTTP2_GOAWAY_SESSION)/i.test(message);
 }
 
 function shortRunId(runId: string): string {
@@ -198,7 +207,8 @@ export function sanitizeCursorProviderError(error: unknown, apiKey?: string): st
 	const scrubbed = scrubSensitiveText(message, apiKey).trim();
 	const connectClassification = classifyCursorConnectError(error);
 	if (connectClassification?.kind === "unauthenticated" || isLikelyAuthError(scrubbed)) return AUTH_CURSOR_SDK_ERROR_MESSAGE;
-	if (connectClassification?.kind === "network" || isLikelyNetworkTimeout(scrubbed)) return NETWORK_CURSOR_SDK_ERROR_MESSAGE;
+	if (connectClassification?.kind === "network" || isLikelyNetworkTimeout(scrubbed) || isLikelyHttp2StreamError(scrubbed))
+		return NETWORK_CURSOR_SDK_ERROR_MESSAGE;
 	if (isGenericCursorRunFailureMessage(scrubbed)) return RETRYABLE_CURSOR_RUN_FAILURE_PREFIX;
 	if (isGenericErrorMessage(scrubbed)) return GENERIC_CURSOR_SDK_ERROR_MESSAGE;
 	return scrubbed || GENERIC_CURSOR_SDK_ERROR_MESSAGE;

--- a/test/cursor-provider-errors.test.ts
+++ b/test/cursor-provider-errors.test.ts
@@ -63,6 +63,27 @@ function makeProvenanceFreeNetworkConnectError(): Error & { rawMessage: string; 
 	return error;
 }
 
+function makeCursorSdkHttp2EnhanceYourCalmError(): Error & { rawMessage: string; code: number; cause: unknown } {
+	const error = new Error("[unknown] [internal] Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM") as Error & {
+		rawMessage: string;
+		code: number;
+		cause: unknown;
+	};
+	error.name = "ConnectError";
+	error.rawMessage = "[internal] Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM";
+	error.code = 2;
+	error.cause = Object.assign(new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM"), {
+		name: "ConnectError",
+		rawMessage: "Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM",
+		code: 13,
+		cause: Object.assign(new Error("Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM"), { code: "ERR_HTTP2_STREAM_ERROR" }),
+	});
+	error.stack =
+		"ConnectError: [unknown] [internal] Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM\n" +
+		"    at file:///Users/example/.pi/agent/npm/node_modules/@cursor/sdk/dist/esm/index.js:1:1125976";
+	return error;
+}
+
 function makeCursorBackendUnavailableConnectError(): Error & {
 	rawMessage: string;
 	code: number;
@@ -188,6 +209,17 @@ describe("cursor-provider-errors", () => {
 		expect(message).toContain("failed during network or service I/O");
 		expect(message).toContain("pi will retry automatically");
 		expect(message).not.toContain("ECONNRESET");
+	});
+
+	it("classifies HTTP/2 ENHANCE_YOUR_CALM stream resets as retryable network errors", () => {
+		const error = makeCursorSdkHttp2EnhanceYourCalmError();
+		const classification = classifyCursorConnectError(error);
+		const message = sanitizeCursorProviderError(error, "test-key");
+
+		expect(classification).toEqual({ kind: "network", source: "cursor-sdk-stack" });
+		expect(message).toContain("Network error");
+		expect(message).toContain("pi will retry automatically");
+		expect(message).not.toContain("ENHANCE_YOUR_CALM");
 	});
 
 	it("classifies Cursor backend unavailable ConnectErrors by code and details", () => {


### PR DESCRIPTION
## Issue

Every so often pi just dies mid-run with this:

```
pi exiting due to uncaughtException:
ConnectError: [internal] Stream closed with error code NGHTTP2_ENHANCE_YOUR_CALM
```

`NGHTTP2_ENHANCE_YOUR_CALM` is HTTP/2 for "you're sending too much, back off" — server-side backpressure/rate limiting. It's transient and totally recoverable, but right now it takes the whole process down.

## Why it crashes

The local Cursor SDK surfaces these as `ConnectError`s. We already have a process error guard that suppresses SDK ConnectErrors during active turns so pi can retry instead of crashing, but it only acts on errors that `classifyCursorConnectError` recognizes. This one slipped through: top-level code is `2` (unknown), so it missed the unauth/unavailable branches, and the network-timeout matcher had no HTTP/2 patterns. Unclassified → not suppressed → uncaught exception → dead pi.

## The fix

Classify the HTTP/2 stream-reset family (`ENHANCE_YOUR_CALM`, `ERR_HTTP2_STREAM_ERROR`, and friends) as `network` errors. The guard then suppresses them during active turns and pi's existing auto-retry kicks in, same as it already does for `ECONNRESET`/`ETIMEDOUT`. The user-facing message becomes the standard retryable "Network error" one instead of leaking raw HTTP/2 codes.

## Testing

Added a test that reproduces the exact error shape from the crash report and asserts it classifies as a retryable network error. Existing error/guard suites still pass.