### PR TITLE
Bundle Cursor SDK with Node transport

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
 		"undici": "7.28.0"
 	},
 	"bundledDependencies": [
+		"@cursor/sdk",
 		"@connectrpc/connect-node",
 		"undici"
 	],

--- a/test/package-metadata.test.ts
+++ b/test/package-metadata.test.ts
@@ -51,7 +51,9 @@ describe("package metadata cutover baselines", () => {
 	it("bundles the audited Node transport dependency tree for package consumers", () => {
 		expect(packageJson.dependencies.undici).toBe("7.28.0");
 		expect(lockPackageVersion("undici")).toBe("7.28.0");
-		expect(packageJson.bundledDependencies).toEqual(expect.arrayContaining(["@connectrpc/connect-node", "undici"]));
+		expect(packageJson.bundledDependencies).toEqual(
+			expect.arrayContaining(["@cursor/sdk", "@connectrpc/connect-node", "undici"]),
+		);
 	});
 
 	it("removes the obsolete sqlite override", () => {


### PR DESCRIPTION
Ensure package consumers install @cursor/sdk alongside the bundled ConnectRPC Node transport so Cursor SDK imports resolve after npm hoisting.