### PR TITLE
docs: add Cursor Cloud environment setup notes to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,3 +181,15 @@ For multi-step or tool-heavy work, give short progress updates after meaningful 
 ## Updating this file
 
 Keep this file concise and repo-specific. Update it when commands, package layout, safety constraints, or validation expectations change. Put specialized subdirectory rules in a nested `AGENTS.md` only when that subtree has materially different commands or constraints.
+
+## Cursor Cloud specific instructions
+
+This is a `pi` provider extension (not a server/web app). "Running the app" means launching `pi` with this extension loaded. Standard commands live in `## Setup and commands`; only the non-obvious caveats are below.
+
+- Dependencies install with `npm install` (no build step; extension runs from `src/` via `pi -e .`).
+- Node: `engines` requires `>=22.19.0`. The VM's default `node` on `PATH` (`/exec-daemon/node`) is 22.14.0. Typecheck, tests, and live `pi` runs all work on it (engine check is advisory, not enforced), so no node switch is required. A compliant version is also available via `nvm use 22.22.2` if you want to match `engines` exactly.
+- `CURSOR_API_KEY` is provided as a cloud-agent secret, so live Cursor runs and full live model discovery work without `/login`. `npm test`, `npm run typecheck`, and `npm pack --dry-run` need no key.
+- Run the extension locally with `./node_modules/.bin/pi -e . --model cursor/composer-2-5` (the bare `pi` is not on `PATH`). Add `--approve` for interactive sessions; print-mode smoke: `./node_modules/.bin/pi -e . --model cursor/composer-2-5 --cursor-no-fast --no-session -p "..."`.
+- Cold-start gotcha: the *first* Cursor SDK run in a fresh VM can take several minutes (SDK/transport warm-up); subsequent runs complete in ~10s. Warm up with one throwaway run before any timing-sensitive or recorded demo, and don't treat a slow first run as a hang.
+- When capturing print-mode (`-p`) output, redirect stdout to a file rather than piping through `tail`/`head` — those pipes buffer until the process exits, hiding streaming progress.
+- The maintainer platform/live smoke gates (`npm run smoke:platform:all`, etc.) are heavy (Crabbox, PTY, Playwright) and are not needed to validate basic environment setup; use the unit/typecheck/print-mode flow above for that.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the cloud development environment for this `pi` provider extension and records durable, non-obvious setup caveats for future cloud agents in `AGENTS.md`.

No application/runtime code changed — the only repo edit is a new `## Cursor Cloud specific instructions` section in `AGENTS.md`. The update script for future VMs is `npm install`.

## What was verified

- `npm install` (deps install cleanly; no build step)
- `npm run typecheck` (src + tests + replay-compile) — pass
- `npm test` — 81 files, 806 tests pass
- `npm pack --dry-run` — pass (161 files)
- `pi -e . --list-models cursor` — 161 live Cursor models discovered using `CURSOR_API_KEY`
- Print-mode smoke run returns exactly `PI_CURSOR_MODEL_OK`
- Interactive TUI run of `cursor/composer-2-5` answered "The capital of France is Paris."

## Notable caveats captured in AGENTS.md

- The VM default `node` (`/exec-daemon/node` = 22.14.0) is below `engines >=22.19.0`, but everything works on it (advisory only); `nvm use 22.22.2` matches `engines` exactly.
- `CURSOR_API_KEY` is available as a cloud secret, so live runs/discovery work without `/login`.
- The first Cursor SDK run in a fresh VM can take minutes (cold start); subsequent runs are ~10s — warm up before timed/recorded demos.
- Print-mode (`-p`) output piped through `tail`/`head` buffers until exit; redirect to a file to watch progress.

## Demo

<a href="https://cursor.com/agents/bc-57b3b99b-40d9-4d41-a4bd-0a29f0eb5de9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpi_cursor_interactive_tui_demo.mp4"><img src="https://cursor.com/artifacts/c/art-7d1f3a49-845a-493c-b86e-60f0fb169890" alt="pi_cursor_interactive_tui_demo.mp4" /></a>

Interactive pi TUI running the Cursor `composer-2-5` model and answering a prompt.

![pi TUI showing the assistant answer](https://cursor.com/artifacts/c/art-27411f56-92ea-4f98-ada5-91b66dea462c)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57b3b99b-40d9-4d41-a4bd-0a29f0eb5de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57b3b99b-40d9-4d41-a4bd-0a29f0eb5de9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

