### PR TITLE
Document optional cloud smoke lane

### DIFF
--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -448,7 +448,7 @@ Blockers before cloud implementation:
 - cloud auth/entitlement/repo preflight and error mapping strategy;
 - cloud `envVars` handling, including validated shell presence with redaction and the post-send `run.agentId` rule;
 - explicit cloud MCP policy: initial pi cloud runtime should not expose inline `mcpServers`; future support needs option-builder tests and new SDK/API evidence because live probes showed surprising persistence and replacement failure;
-- opt-in live cloud smoke matrix in `docs/platform-smoke.md` (**validated:** platform smoke currently has no cloud provider dependency).
+- opt-in live cloud smoke matrix in `docs/platform-smoke.md` — **documented as future optional lane**; the required `smoke:platform:all` gate still has no cloud provider dependency.
 
 Blockers before resume implementation:
 
@@ -524,7 +524,7 @@ Docs to update before landing behavior changes:
 - `CHANGELOG.md` for user-visible behavior and flag changes.
 - `docs/cursor-model-ux-spec.md` for runtime-aware model/status UX.
 - `docs/cursor-tool-surfaces.md` for MCP/customTools/cloud Pi-tool availability.
-- `docs/platform-smoke.md` for opt-in cloud smoke matrix (currently no cloud provider dependency).
+- `docs/platform-smoke.md` for opt-in cloud smoke matrix — **documented as a future optional lane; currently no cloud provider dependency**.
 - `docs/cursor-testing-lessons.md` for any new SDK/cloud contract lesson.
 - `docs/cursor-live-smoke-checklist.md` and `docs/cursor-dogfood-checklist.md` for user-visible smoke flows.
 

--- a/docs/platform-smoke.md
+++ b/docs/platform-smoke.md
@@ -137,6 +137,22 @@ Runtime budget is part of the contract:
 
 Ubuntu is covered as its own local-container target, and Windows native remains a full visual TUI target.
 
+## Optional cloud smoke lane
+
+Cloud validation is intentionally separate from `smoke:platform:all`. The required release gate keeps **no cloud provider dependency** until cloud runtime support is implemented and the project explicitly adopts a cloud lane.
+
+When cloud runtime work begins, add an opt-in cloud smoke command rather than folding cloud checks into the default platform matrix. The lane must fail closed when requested but unavailable:
+
+- missing cloud-capable credentials, repo access, or cloud entitlement → report **blocked**, not skipped-ready;
+- no non-interactive prompts; every needed cloud choice must come from CLI/env/config;
+- use a throwaway repo/branch and clean up remote agents/branches/PRs where the SDK/API allows;
+- do not expose inline cloud MCP in the first cloud runtime lane;
+- do not forward local env values unless the scenario explicitly allowlists names and verifies behavior without printing values;
+- assert local-only dirty/unpushed state warnings before a cloud send;
+- assert default cloud branch/PR behavior, explicit direct-push opt-in, missing-branch failure, cancel/archive/delete cleanup, and cloud artifact/usage reporting when SDK/API support is available.
+
+This lane is a future cloud-runtime release gate, not a substitute for the local macOS/Ubuntu/Windows `smoke:platform:all` gate.
+
 ## Files and scripts
 
 Files:


### PR DESCRIPTION
## Summary

- Document the future opt-in cloud smoke lane in `docs/platform-smoke.md`.
- Keep `smoke:platform:all` unchanged as the required macOS/Ubuntu/Windows local runtime gate with no cloud provider dependency.
- Mark the roadmap blocker as documented, without claiming cloud runtime implementation.

## Review gate

- Thermo-nuclear review before commit: no remaining material findings.
- Thermo-nuclear review before push: no remaining material findings.

## Validation

- `git diff --check` — passed.
- Docs-only change; no runtime code changed.

## Notes

No cloud runtime wiring, customTools migration, resume behavior, visual parser changes, or platform-smoke script changes.
