### PR TITLE
Document Cursor tool surface runtime policy

### DIFF
--- a/docs/cursor-tool-surfaces.md
+++ b/docs/cursor-tool-surfaces.md
@@ -1,6 +1,6 @@
 # Cursor tool surfaces in pi
 
-pi-cursor-sdk runs Cursor models through the local `@cursor/sdk` agent runtime. A single pi session can expose **three related but different** tool namespaces. This page is the user-facing guide; maintainer replay details live in [Cursor native tool replay](./cursor-native-tool-replay.md).
+pi-cursor-sdk runs Cursor models through the local `@cursor/sdk` agent runtime by default. A local pi session can expose **three related but different** tool namespaces. This page is the user-facing guide; maintainer replay details live in [Cursor native tool replay](./cursor-native-tool-replay.md).
 
 ## The three surfaces
 
@@ -41,6 +41,16 @@ PI_CURSOR_EXPOSE_BUILTIN_TOOLS=1 pi --model cursor/composer-2-5
 # Disable bootstrap tool manifest
 PI_CURSOR_TOOL_MANIFEST=0 pi --model cursor/composer-2-5
 ```
+
+## Runtime and transport policy
+
+Current defaults:
+
+- Local runtime is the default and the only implemented runtime.
+- The pi bridge uses loopback MCP and remains the canonical Pi-tool transport.
+- `local.customTools` is a future opt-in spike path, not a replacement default, because cancellation/process cleanup parity is not proven.
+- Explicit cloud runtime selection currently fails closed. When cloud runtime support lands, cloud agents do **not** get local pi tools through loopback MCP or `local.customTools`; cloud Pi-tool access would require a separate secure remote bridge and a new product decision.
+- Inline cloud MCP is not exposed in the initial cloud runtime plan because live probes showed first-run/replacement/resume behavior was not deterministic enough.
 
 ## Cursor settings vs pi toggles
 

--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -523,7 +523,7 @@ Docs to update before landing behavior changes:
 - `AGENTS.md` for maintainer commands, validation gates, and agent constraints.
 - `CHANGELOG.md` for user-visible behavior and flag changes.
 - `docs/cursor-model-ux-spec.md` for runtime-aware model/status UX.
-- `docs/cursor-tool-surfaces.md` for MCP/customTools/cloud Pi-tool availability.
+- `docs/cursor-tool-surfaces.md` for MCP/customTools/cloud Pi-tool availability — **current policy documented: loopback MCP remains canonical, customTools is future opt-in, cloud gets no local Pi tools**.
 - `docs/platform-smoke.md` for opt-in cloud smoke matrix — **documented as a future optional lane; currently no cloud provider dependency**.
 - `docs/cursor-testing-lessons.md` for any new SDK/cloud contract lesson.
 - `docs/cursor-live-smoke-checklist.md` and `docs/cursor-dogfood-checklist.md` for user-visible smoke flows.


### PR DESCRIPTION
## Summary

- Document current Cursor tool-surface runtime policy:
  - local runtime is default and only implemented runtime;
  - loopback MCP remains the canonical Pi-tool transport;
  - `local.customTools` remains future opt-in, not a replacement default;
  - explicit cloud runtime currently fails closed;
  - cloud agents do not get local pi tools through loopback MCP or `local.customTools`;
  - inline cloud MCP remains out of the initial cloud runtime plan.
- Mark the roadmap doc item as covered for current policy.

## Review gate

- Thermo-nuclear review before commit: no remaining material findings.
- Thermo-nuclear review before push: no remaining material findings.

## Validation

- `git diff --check origin/main..HEAD` — passed.
- Docs-only change; no runtime code changed.

## Notes

No runtime wiring, cloud implementation, customTools migration, resume behavior, visual parser changes, or platform-smoke script changes.
