### PR TITLE
Document Cursor usage compaction testing lesson

### DIFF
--- a/docs/cursor-testing-lessons.md
+++ b/docs/cursor-testing-lessons.md
@@ -159,6 +159,17 @@ The scan fails only on **persisted error messages**, not arbitrary substring mat
 
 Successful tool results are ignored even when file contents mention those strings (for example a `read` of `docs/cursor-testing-lessons.md` during plan-strip smoke).
 
+## Usage and compaction JSONL lessons
+
+Session summaries can hide per-message usage bugs. When investigating token or compaction regressions, inspect assistant message `usage` rows directly:
+
+- `usage.input`, `usage.output`, `usage.cacheRead`, and `usage.cacheWrite` are additive spend-style counters for the assistant turn.
+- `usage.totalTokens` is pi context occupancy for that turn, not a value to sum across all assistant messages.
+- No single assistant message should persist SDK/full-agent-context-sized usage outside the selected model window.
+- Real bad-session evidence should be reduced to a sanitized fixture, like `test/fixtures/cursor-run-usage-compaction-poison.jsonl`, instead of committing raw session JSONL.
+
+The compaction poison fixture mirrors the observed failure shape: one assistant message with `RunResult`-sized input/cache-read counts near 1M immediately before compaction. Regression coverage should prove that such usage falls back to bounded pi estimates before it reaches `AssistantMessage.usage`.
+
 ### False-positive edge case (2026-05-23)
 
 Plan-strip live smoke can make Cursor `read` testing docs that *document* replay failure strings. A naive whole-record JSON scan reported four failures from one successful `read` toolResult (`isError: false`).

--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -525,7 +525,7 @@ Docs to update before landing behavior changes:
 - `docs/cursor-model-ux-spec.md` for runtime-aware model/status UX.
 - `docs/cursor-tool-surfaces.md` for MCP/customTools/cloud Pi-tool availability — **current policy documented: loopback MCP remains canonical, customTools is future opt-in, cloud gets no local Pi tools**.
 - `docs/platform-smoke.md` for opt-in cloud smoke matrix — **documented as a future optional lane; currently no cloud provider dependency**.
-- `docs/cursor-testing-lessons.md` for any new SDK/cloud contract lesson.
+- `docs/cursor-testing-lessons.md` for any new SDK/cloud contract lesson — **usage/compaction JSONL fixture lesson documented**.
 - `docs/cursor-live-smoke-checklist.md` and `docs/cursor-dogfood-checklist.md` for user-visible smoke flows.
 
 ## Evidence anchors


### PR DESCRIPTION
## Summary

- Add the usage/compaction JSONL testing lesson:
  - inspect per-message usage rows for token/compaction bugs;
  - `usage.totalTokens` is context occupancy for a turn, not additive session spend;
  - no assistant message should persist SDK/full-agent-context-sized usage outside the selected model window;
  - reduce real bad sessions to sanitized fixtures instead of committing raw session JSONL.
- Mark the roadmap testing-lessons doc item as covered.

## Review gate

- Thermo-nuclear review before commit: no remaining material findings.
- Thermo-nuclear review before push: no remaining material findings.

## Validation

- `git diff --check origin/main..HEAD` — passed.
- Docs-only change; no runtime code changed.

## Notes

No raw session JSONL, secrets, runtime code, visual parser, or platform-smoke script changes.
