### PR TITLE
Add Cursor cloud preflight planner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `/cursor-refresh-config` to call the current pooled Cursor SDK agent's `agent.reload()` for filesystem Cursor config refreshes without recreating the agent.
 - Add explicit local Cursor safety controls: `--cursor-auto-review` / `PI_CURSOR_AUTO_REVIEW` and `--cursor-sandbox` / `PI_CURSOR_SANDBOX`, plus `local.autoReview` and `local.sandboxOptions.enabled` config. Defaults stay off.
 - Add one-shot manual local stuck-run recovery with `--cursor-local-force` / `PI_CURSOR_LOCAL_FORCE`, wired only to the next `Agent.send(..., { local: { force: true } })`; no persistent config default, retry loop, or automatic force recovery is added.
-- Add resolver/CLI/slash scaffolding for roadmap runtime/cloud/tool-transport config keys (`--cursor-runtime`, `/cursor-runtime`, cloud repo/branch/context/direct-push/local-state/env-name/env-file flags, and `--cursor-tool-transport`). Defaults stay local + loopback MCP, and explicit cloud runtime now fails closed with a cloud-not-implemented error instead of silently running local.
+- Add resolver/CLI/slash scaffolding for roadmap runtime/cloud/tool-transport config keys (`--cursor-runtime`, `/cursor-runtime`, cloud repo/branch/context/direct-push/local-state/env-name/env-file flags, and `--cursor-tool-transport`). Defaults stay local + loopback MCP, and explicit cloud runtime now fails closed with preflight remediation for missing repo/branch/context/local-state/env-file choices instead of silently running local.
 
 ### Fixed
 

--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -82,7 +82,7 @@ Impact numbers rank product/user risk, not implementation order; sequencing is i
 
 | Slice | Status | Notes |
 | ----- | ------ | ----- |
-| Config resolver foundation | **Implemented (partial)** | `src/cursor-config.ts` / `src/cursor-state.ts` — ordinary precedence, safety caps, fast-default migration, trust-gated project load, remaining cloud/tool-transport/env keys, CLI flags, and `/cursor-runtime`. Explicit cloud runtime fails closed; actual cloud `Agent.create({ cloud })` remains unwired. |
+| Config resolver foundation | **Implemented (partial)** | `src/cursor-config.ts` / `src/cursor-state.ts` — ordinary precedence, safety caps, fast-default migration, trust-gated project load, remaining cloud/tool-transport/env keys, CLI flags, and `/cursor-runtime`. Explicit cloud runtime fails closed after preflight remediation; actual cloud `Agent.create({ cloud })` remains unwired. |
 | `RunResult.usage` fallback | **Rejected for pi message usage** | Direct and live/native-replay drains use real `turn-ended` only when the counts fit the selected model window; otherwise they fall back to bounded pi estimates. `RunResult.usage` can describe full local agent context and must not feed compaction/context totals. |
 | `agent.reload()` refresh | **Implemented** | `/cursor-refresh-config` calls pooled `agent.reload()` without recreating the agent. |
 | Local safety controls | **Implemented** | `autoReview` and `sandboxOptions.enabled` via CLI/env/config; defaults stay off. |
@@ -445,7 +445,7 @@ Blockers before cloud implementation:
 - project/user/session persistence design and explicit save destinations;
 - runtime-aware cloud model availability UX using the single `cursor/*` provider with runtime annotations/filters;
 - repo/branch/direct-push policy, including validated `startingRef`, explicit direct push, missing/unpushed branch behavior, and protected-branch fallback; dirty local tree remains pi-owned detection;
-- cloud auth/entitlement/repo preflight and error mapping strategy;
+- cloud auth/entitlement/repo preflight and error mapping strategy — **partial:** fail-closed local preflight and cloud option builder exist; SDK cloud auth/model/repo API checks remain;
 - cloud `envVars` handling, including validated shell presence with redaction and the post-send `run.agentId` rule;
 - explicit cloud MCP policy: initial pi cloud runtime should not expose inline `mcpServers`; future support needs option-builder tests and new SDK/API evidence because live probes showed surprising persistence and replacement failure;
 - opt-in live cloud smoke matrix in `docs/platform-smoke.md` — **documented as future optional lane**; the required `smoke:platform:all` gate still has no cloud provider dependency.

--- a/src/cursor-cloud-options.ts
+++ b/src/cursor-cloud-options.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { AgentModeOption, AgentOptions, ModelSelection } from "@cursor/sdk";
+import type { CursorResolvedSdkConfig } from "./cursor-config.js";
+
+export interface CursorCloudLocalState {
+	insideGitRepo: boolean;
+	dirty: boolean;
+	unpushed: boolean;
+}
+
+export interface CursorCloudOptionsBuildResult {
+	options: AgentOptions;
+	forwardedEnvNames: string[];
+}
+
+export interface CursorCloudPreflightIssue {
+	code:
+		| "missing_repo"
+		| "missing_branch"
+		| "context_handoff_required"
+		| "local_state_not_allowed"
+		| "env_from_files_not_implemented";
+	message: string;
+}
+
+export interface CursorCloudPreflightResult {
+	ok: boolean;
+	issues: CursorCloudPreflightIssue[];
+}
+
+type GitRunner = (cwd: string, args: string[]) => string | undefined;
+
+function git(cwd: string, args: string[]): string | undefined {
+	try {
+		return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+	} catch {
+		return undefined;
+	}
+}
+
+function hasGitMetadata(cwd: string): boolean {
+	let current = cwd;
+	while (true) {
+		if (existsSync(join(current, ".git"))) return true;
+		const parent = dirname(current);
+		if (parent === current) return false;
+		current = parent;
+	}
+}
+
+export function inspectCursorCloudLocalState(cwd: string, runGit: GitRunner = git): CursorCloudLocalState {
+	const insideGitRepo = runGit(cwd, ["rev-parse", "--is-inside-work-tree"]);
+	if (insideGitRepo !== "true") {
+		return hasGitMetadata(cwd)
+			? { insideGitRepo: true, dirty: true, unpushed: true }
+			: { insideGitRepo: false, dirty: false, unpushed: false };
+	}
+	const status = runGit(cwd, ["status", "--porcelain=v1"]);
+	const dirty = status === undefined || status.length > 0;
+	const hasHead = runGit(cwd, ["rev-parse", "--verify", "HEAD"]) !== undefined;
+	const upstream = runGit(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]);
+	const ahead = upstream ? runGit(cwd, ["rev-list", "--count", "@{upstream}..HEAD"]) : undefined;
+	const aheadCount = ahead === undefined ? Number.NaN : Number(ahead);
+	const unpushed = hasHead && (!upstream || !Number.isFinite(aheadCount) || aheadCount > 0);
+	return { insideGitRepo: true, dirty, unpushed };
+}
+
+export function buildCursorCloudAgentOptions(options: {
+	apiKey: string;
+	modelSelection: ModelSelection;
+	agentMode: AgentModeOption;
+	resolvedConfig: CursorResolvedSdkConfig;
+	env?: Record<string, string | undefined>;
+	name?: string;
+}): CursorCloudOptionsBuildResult {
+	const { resolvedConfig } = options;
+	const env = options.env ?? process.env;
+	const envVars = Object.fromEntries(
+		resolvedConfig.cloud.envNames.value.flatMap((name) => {
+			const value = env[name];
+			return value === undefined ? [] : [[name, value]];
+		}),
+	);
+	const cloud = {
+		...(resolvedConfig.cloud.repo.value
+			? {
+					repos: [
+						{
+							url: resolvedConfig.cloud.repo.value,
+							...(resolvedConfig.cloud.branch.value ? { startingRef: resolvedConfig.cloud.branch.value } : {}),
+						},
+					],
+				}
+			: {}),
+		...(resolvedConfig.cloud.directPush.value ? { workOnCurrentBranch: true } : {}),
+		...(Object.keys(envVars).length > 0 ? { envVars } : {}),
+	};
+	return {
+		options: {
+			apiKey: options.apiKey,
+			model: options.modelSelection,
+			mode: options.agentMode,
+			...(options.name ? { name: options.name } : {}),
+			cloud,
+		},
+		forwardedEnvNames: Object.keys(envVars).sort(),
+	};
+}
+
+export function preflightCursorCloudRuntime(options: {
+	resolvedConfig: CursorResolvedSdkConfig;
+	localState?: CursorCloudLocalState;
+	hasPriorContext?: boolean;
+}): CursorCloudPreflightResult {
+	const { resolvedConfig } = options;
+	const issues: CursorCloudPreflightIssue[] = [];
+	if (!resolvedConfig.cloud.repo.value) {
+		issues.push({
+			code: "missing_repo",
+			message: "Cursor cloud runtime requires --cursor-cloud-repo or PI_CURSOR_CLOUD_REPO.",
+		});
+	}
+	if (!resolvedConfig.cloud.branch.value) {
+		issues.push({
+			code: "missing_branch",
+			message: "Cursor cloud runtime requires --cursor-cloud-branch or PI_CURSOR_CLOUD_BRANCH.",
+		});
+	}
+	if (options.hasPriorContext && resolvedConfig.cloud.contextHandoff.value === "never") {
+		issues.push({
+			code: "context_handoff_required",
+			message: "Cursor cloud runtime needs --cursor-cloud-context=fresh or --cursor-cloud-context=bootstrap for sessions with prior pi context.",
+		});
+	}
+	if (
+		options.localState?.insideGitRepo &&
+		(options.localState.dirty || options.localState.unpushed) &&
+		!resolvedConfig.cloud.allowLocalState.value
+	) {
+		issues.push({
+			code: "local_state_not_allowed",
+			message: "Cursor cloud runtime cannot see dirty or unpushed local state; pass --cursor-cloud-allow-local-state only after accepting that risk.",
+		});
+	}
+	if (resolvedConfig.cloud.envFromFiles.value) {
+		issues.push({
+			code: "env_from_files_not_implemented",
+			message: "Cursor cloud env file forwarding is not implemented; pass explicit --cursor-cloud-env names or use Cursor-native environment setup.",
+		});
+	}
+	return { ok: issues.length === 0, issues };
+}
+
+export function formatCursorCloudPreflightError(result: CursorCloudPreflightResult): string {
+	const details = result.issues.map((issue) => `- ${issue.message}`).join("\n");
+	return `Cursor cloud runtime is not ready to start.\n${details}\nUse --cursor-runtime local or /cursor-runtime local to run with the local Cursor SDK agent.`;
+}

--- a/src/cursor-provider-turn-prepare.ts
+++ b/src/cursor-provider-turn-prepare.ts
@@ -26,6 +26,11 @@ import {
 } from "./cursor-state.js";
 import { buildCursorModelSelection } from "./model-discovery.js";
 import { getEffectiveCursorSettingSources } from "./cursor-setting-sources.js";
+import {
+	formatCursorCloudPreflightError,
+	inspectCursorCloudLocalState,
+	preflightCursorCloudRuntime,
+} from "./cursor-cloud-options.js";
 import { loadCursorSdkConfig, resolveCursorSdkConfig } from "./cursor-config.js";
 import { getCursorSessionProjectTrusted } from "./cursor-session-scope.js";
 import { resolveCursorPiToolBridgeEnabled } from "./cursor-pi-tool-bridge-env.js";
@@ -76,6 +81,12 @@ export async function prepareCursorProviderTurn(
 			project: loadedConfig.project,
 		});
 		if (resolvedConfig.runtime.value === "cloud") {
+			const preflight = preflightCursorCloudRuntime({
+				resolvedConfig,
+				localState: inspectCursorCloudLocalState(cwd),
+				hasPriorContext: context.messages.length > 1,
+			});
+			if (!preflight.ok) throw new Error(formatCursorCloudPreflightError(preflight));
 			throw new Error(
 				"Cursor cloud runtime is not implemented yet. Use --cursor-runtime local or /cursor-runtime local to run with the local Cursor SDK agent.",
 			);

--- a/test/cursor-cloud-options.test.ts
+++ b/test/cursor-cloud-options.test.ts
@@ -1,0 +1,136 @@
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { resolveCursorSdkConfig } from "../src/cursor-config.js";
+import {
+	buildCursorCloudAgentOptions,
+	formatCursorCloudPreflightError,
+	inspectCursorCloudLocalState,
+	preflightCursorCloudRuntime,
+} from "../src/cursor-cloud-options.js";
+
+function git(cwd: string, args: string[]): void {
+	execFileSync("git", args, { cwd, stdio: "ignore" });
+}
+
+describe("Cursor cloud options", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "pi-cursor-cloud-options-"));
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("builds cloud Agent options without local tools, MCP servers, or agent ids", () => {
+		const resolvedConfig = resolveCursorSdkConfig({
+			cli: {
+				runtime: "cloud",
+				cloud: {
+					repo: "https://github.com/example/repo.git",
+					branch: "feature/demo",
+					directPush: true,
+					envNames: ["SAFE_FLAG", "MISSING_FLAG"],
+				},
+			},
+		});
+
+		const result = buildCursorCloudAgentOptions({
+			apiKey: "test-key",
+			modelSelection: { id: "composer-2.5" },
+			agentMode: "agent",
+			resolvedConfig,
+			env: { SAFE_FLAG: "enabled" },
+			name: "pi session",
+		});
+
+		expect(result.forwardedEnvNames).toEqual(["SAFE_FLAG"]);
+		expect(result.options).toEqual({
+			apiKey: "test-key",
+			model: { id: "composer-2.5" },
+			mode: "agent",
+			name: "pi session",
+			cloud: {
+				repos: [{ url: "https://github.com/example/repo.git", startingRef: "feature/demo" }],
+				workOnCurrentBranch: true,
+				envVars: { SAFE_FLAG: "enabled" },
+			},
+		});
+		expect(result.options).not.toHaveProperty("local");
+		expect(result.options).not.toHaveProperty("mcpServers");
+		expect(result.options).not.toHaveProperty("agentId");
+	});
+
+	it("fails closed with exact remediation for missing choices and unsafe local state", () => {
+		const result = preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({ cli: { runtime: "cloud", cloud: { envFromFiles: true } } }),
+			hasPriorContext: true,
+			localState: { insideGitRepo: true, dirty: true, unpushed: true },
+		});
+
+		expect(result.ok).toBe(false);
+		expect(result.issues.map((issue) => issue.code)).toEqual([
+			"missing_repo",
+			"missing_branch",
+			"context_handoff_required",
+			"local_state_not_allowed",
+			"env_from_files_not_implemented",
+		]);
+		expect(formatCursorCloudPreflightError(result)).toContain("--cursor-cloud-repo");
+		expect(formatCursorCloudPreflightError(result)).toContain("--cursor-runtime local");
+	});
+
+	it("treats no-upstream commits and dirty files as local-only cloud state", () => {
+		git(root, ["init"]);
+		git(root, ["config", "user.email", "test@example.com"]);
+		git(root, ["config", "user.name", "Test User"]);
+		mkdirSync(join(root, "src"));
+		writeFileSync(join(root, "src", "file.txt"), "base");
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "base"]);
+		appendFileSync(join(root, "src", "file.txt"), "dirty");
+
+		expect(inspectCursorCloudLocalState(root)).toMatchObject({ insideGitRepo: true, dirty: true, unpushed: true });
+	});
+
+	it("fails closed when git state inside a repo is unknown", () => {
+		const result = inspectCursorCloudLocalState(root, (_cwd, args) => {
+			const key = args.join(" ");
+			if (key === "rev-parse --is-inside-work-tree") return "true";
+			if (key === "rev-parse --verify HEAD") return "abc123";
+			if (key === "rev-parse --abbrev-ref --symbolic-full-name @{upstream}") return "origin/main";
+			return undefined;
+		});
+
+		expect(result).toEqual({ insideGitRepo: true, dirty: true, unpushed: true });
+	});
+
+	it("fails closed when git metadata exists but the root git probe fails", () => {
+		mkdirSync(join(root, ".git"));
+
+		expect(inspectCursorCloudLocalState(root, () => undefined)).toEqual({
+			insideGitRepo: true,
+			dirty: true,
+			unpushed: true,
+		});
+	});
+
+	it("does not require context handoff for a first cloud user prompt", () => {
+		const result = preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({
+				cli: {
+					runtime: "cloud",
+					cloud: { repo: "https://github.com/example/repo.git", branch: "main", allowLocalState: true },
+				},
+			}),
+			hasPriorContext: false,
+			localState: { insideGitRepo: true, dirty: true, unpushed: true },
+		});
+
+		expect(result).toEqual({ ok: true, issues: [] });
+	});
+});

--- a/test/cursor-provider-stream-config.test.ts
+++ b/test/cursor-provider-stream-config.test.ts
@@ -183,13 +183,27 @@ describe("streamCursor prompt and model config", () => {
 		expect(mockedCreate.mock.calls[0][0].local).toMatchObject({ autoReview: true, sandboxOptions: { enabled: true } });
 	});
 
-	it("fails closed when cloud runtime is selected before cloud implementation exists", async () => {
+	it("fails closed with cloud preflight remediation before cloud implementation exists", async () => {
 		process.env.PI_CURSOR_RUNTIME = "cloud";
 		process.env.PI_CURSOR_LOCAL_FORCE = "1";
 
 		const events = await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
 
+		expect(getErrorEvent(events).error.errorMessage).toContain("Cursor cloud runtime is not ready to start");
+		expect(getErrorEvent(events).error.errorMessage).toContain("--cursor-cloud-repo");
+		expect(mockedCreate).not.toHaveBeenCalled();
+	});
+
+	it("does not treat the first user prompt as prior cloud context", async () => {
+		process.env.PI_CURSOR_RUNTIME = "cloud";
+		process.env.PI_CURSOR_CLOUD_REPO = "https://github.com/example/repo.git";
+		process.env.PI_CURSOR_CLOUD_BRANCH = "main";
+		process.env.PI_CURSOR_CLOUD_ALLOW_LOCAL_STATE = "1";
+
+		const events = await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+
 		expect(getErrorEvent(events).error.errorMessage).toContain("Cursor cloud runtime is not implemented yet");
+		expect(getErrorEvent(events).error.errorMessage).not.toContain("--cursor-cloud-context");
 		expect(mockedCreate).not.toHaveBeenCalled();
 	});
 


### PR DESCRIPTION
## Summary

- Add a pure Cursor cloud preflight/option planner:
  - builds cloud `AgentOptions` from resolved config without local tools, MCP servers, or agent IDs;
  - forwards only explicitly allowlisted env names with present values;
  - detects dirty, no-upstream/unpushed, and unknown/unreadable local git state as local-only risk;
  - formats fail-closed remediation for missing repo/branch/context/local-state/env-file choices.
- Keep cloud runtime fail-closed before SDK `Agent.create` while replacing the generic error with actionable preflight remediation.
- Update tests, changelog, and roadmap status.

## Safety

- Local runtime remains default.
- No `Agent.create({ cloud })` execution path is enabled.
- No local Pi tools are exposed to cloud.
- No env values are shown in errors.
- No platform-smoke or visual parser changes.

## Review gate

- Thermo review before commit found two material issues: no-upstream local branches failed open, and first user prompt was misclassified as prior context.
- Fixed both and re-reviewed: no remaining material findings.
- Thermo review before push found one test portability issue: shell `sh` in tests.
- Fixed with Node fs writes and re-reviewed: no remaining material findings.
- Merge review found two fail-closed Git inspection gaps; fixed unknown status/ahead and root-probe failures with regression tests.
- Final review: no remaining material findings.

## Validation

- `npx vitest run test/cursor-cloud-options.test.ts test/cursor-provider-stream-config.test.ts` — 2 files / 31 tests passed.
- `npm test` — 84 files / 858 tests passed.
- `npm run typecheck` — passed.
- `npm run typecheck:tests` — passed.
- `npm pack --dry-run` — passed.
- `git diff --check` — passed.
- `npm run smoke:platform:all` — passed on macOS, Ubuntu, Windows after final root-probe fix.
