### PR TITLE
Add Cursor cloud acknowledgement scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `/cursor-refresh-config` to call the current pooled Cursor SDK agent's `agent.reload()` for filesystem Cursor config refreshes without recreating the agent.
 - Add explicit local Cursor safety controls: `--cursor-auto-review` / `PI_CURSOR_AUTO_REVIEW` and `--cursor-sandbox` / `PI_CURSOR_SANDBOX`, plus `local.autoReview` and `local.sandboxOptions.enabled` config. Defaults stay off.
 - Add one-shot manual local stuck-run recovery with `--cursor-local-force` / `PI_CURSOR_LOCAL_FORCE`, wired only to the next `Agent.send(..., { local: { force: true } })`; no persistent config default, retry loop, or automatic force recovery is added.
-- Add resolver/CLI/slash scaffolding for roadmap runtime/cloud/tool-transport config keys (`--cursor-runtime`, `/cursor-runtime`, cloud repo/branch/context/direct-push/local-state/env-name/env-file flags, and `--cursor-tool-transport`). Defaults stay local + loopback MCP, and explicit cloud runtime now fails closed with preflight remediation for missing repo/branch/context/local-state/env-file choices instead of silently running local.
+- Add resolver/CLI/slash scaffolding for roadmap runtime/cloud/tool-transport config keys (`--cursor-runtime`, `/cursor-runtime`, cloud repo/branch/context/direct-push/local-state/env-name/env-file/ack flags, and `--cursor-tool-transport`). Defaults stay local + loopback MCP, `/cursor-runtime cloud` records a session first-use acknowledgement, `--cursor-cloud-ack` / `PI_CURSOR_CLOUD_ACK=1` cover non-interactive acknowledgement, and explicit cloud runtime still fails closed with preflight remediation instead of silently running local.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Config can also set non-secret defaults in `~/.pi/agent/cursor-sdk.json` or trus
 }
 ```
 
-Cloud/runtime keys are resolver scaffolding only right now. Defaults stay local runtime, `toolTransport: "mcp"`, no inline cloud MCP, no local-state/env-file forwarding, and no customTools migration. If `runtime` is explicitly set to `cloud` with `--cursor-runtime cloud`, `PI_CURSOR_RUNTIME=cloud`, `/cursor-runtime cloud`, or config, the provider fails closed with a cloud-not-implemented error instead of silently running local. Cloud env config stores names only; names starting with `CURSOR_` are ignored.
+Cloud/runtime keys are resolver scaffolding only right now. Defaults stay local runtime, `toolTransport: "mcp"`, no inline cloud MCP, no local-state/env-file forwarding, and no customTools migration. If `runtime` is explicitly set to `cloud` with `--cursor-runtime cloud`, `PI_CURSOR_RUNTIME=cloud`, `/cursor-runtime cloud`, or config, the provider fails closed with cloud preflight remediation instead of silently running local. `/cursor-runtime cloud` records session acknowledgement; use `/cursor-runtime cloud --save-user` for a persistent personal acknowledgement or `--cursor-cloud-ack` / `PI_CURSOR_CLOUD_ACK=1` for non-interactive runs. Project config may save a cloud runtime default but not first-use acknowledgement. Cloud env config stores names only; names starting with `CURSOR_` are ignored.
 
 Only enabled local safety values are passed to `Agent.create({ local })`; false/default values are omitted to preserve the current local-agent behavior. Local force is one-shot/manual-only through CLI/env and is passed only to the next `Agent.send({ local: { force: true } })`.
 

--- a/docs/cursor-tool-surfaces.md
+++ b/docs/cursor-tool-surfaces.md
@@ -49,7 +49,7 @@ Current defaults:
 - Local runtime is the default and the only implemented runtime.
 - The pi bridge uses loopback MCP and remains the canonical Pi-tool transport.
 - `local.customTools` is a future opt-in spike path, not a replacement default, because cancellation/process cleanup parity is not proven.
-- Explicit cloud runtime selection currently fails closed. When cloud runtime support lands, cloud agents do **not** get local pi tools through loopback MCP or `local.customTools`; cloud Pi-tool access would require a separate secure remote bridge and a new product decision.
+- Explicit cloud runtime selection currently fails closed and requires first-use acknowledgement (`/cursor-runtime cloud`, `/cursor-runtime cloud --save-user`, `--cursor-cloud-ack`, or `PI_CURSOR_CLOUD_ACK=1`). Project config may save a cloud runtime default but not the acknowledgement. When cloud runtime support lands, cloud agents do **not** get local pi tools through loopback MCP or `local.customTools`; cloud Pi-tool access would require a separate secure remote bridge and a new product decision.
 - Inline cloud MCP is not exposed in the initial cloud runtime plan because live probes showed first-run/replacement/resume behavior was not deterministic enough.
 
 ## Cursor settings vs pi toggles

--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -26,7 +26,7 @@ Use these labels when this roadmap states SDK/runtime behavior or pi product int
 
 New behavior should start behind feature flags/config while current behavior remains the default. Use feature flags for maintainer validation and user/project config when the behavior is a real preference. After validation, defaults may flip, but keep an opt-out/fallback for a few releases when the behavior replaces a proven path such as MCP.
 
-**Implemented (partial):** `src/cursor-config.ts` provides the effective-config resolver with ordinary precedence, safety caps, fast-default migration, cloud/runtime/tool-transport/env scaffolding, and trust-gated project config loading. Runtime CLI/env/config/slash selection is wired only far enough to fail closed when cloud is selected; `Agent.create({ cloud })` is intentionally not wired. Remaining work: interactive cloud setup, persistence/save destinations, and actual cloud runtime option building.
+**Implemented (partial):** `src/cursor-config.ts` provides the effective-config resolver with ordinary precedence, safety caps, fast-default migration, cloud/runtime/tool-transport/env scaffolding, first-use cloud acknowledgement, explicit save destinations, and trust-gated project config loading. Runtime CLI/env/config/slash selection is wired only far enough to fail closed when cloud is selected; `Agent.create({ cloud })` is intentionally not wired. Remaining work: full interactive cloud setup and actual cloud runtime execution.
 
 **Pi policy — target ordinary precedence** (enforced by `src/cursor-config.ts` and tests):
 
@@ -47,6 +47,7 @@ Minimum config contract before implementation:
 | Setting group        | CLI / env                                                                                | Config key                          | Class                             | Notes                                                                                                                                                                  |
 | -------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------- | --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Runtime              | `--cursor-runtime`, `PI_CURSOR_RUNTIME`                                                  | `runtime`                           | ordinary + first-cloud safety ack | `local` remains built-in default.                                                                                                                                      |
+| First cloud ack      | `--cursor-cloud-ack`, `PI_CURSOR_CLOUD_ACK`; `/cursor-runtime cloud`                     | `cloud.acknowledged`                | user/session/CLI/env only         | Project config cannot provide first-use acknowledgement.                                                                                                               |
 | Cloud repo           | `--cursor-cloud-repo`, `PI_CURSOR_CLOUD_REPO`                                            | `cloud.repo`                        | ordinary                          | Repo URL only, no credentials.                                                                                                                                         |
 | Cloud branch/ref     | `--cursor-cloud-branch`, `PI_CURSOR_CLOUD_BRANCH`                                        | `cloud.branch`                      | ordinary unless direct push       | Per-work-item by default; project save must be explicit.                                                                                                               |
 | Direct push          | `--cursor-cloud-direct-push`, `PI_CURSOR_CLOUD_DIRECT_PUSH`                              | `cloud.directPush`                  | safety-sensitive                  | Maps to `workOnCurrentBranch`; default false.                                                                                                                          |
@@ -82,7 +83,7 @@ Impact numbers rank product/user risk, not implementation order; sequencing is i
 
 | Slice | Status | Notes |
 | ----- | ------ | ----- |
-| Config resolver foundation | **Implemented (partial)** | `src/cursor-config.ts` / `src/cursor-state.ts` — ordinary precedence, safety caps, fast-default migration, trust-gated project load, remaining cloud/tool-transport/env keys, CLI flags, and `/cursor-runtime`. Explicit cloud runtime fails closed after preflight remediation; actual cloud `Agent.create({ cloud })` remains unwired. |
+| Config resolver foundation | **Implemented (partial)** | `src/cursor-config.ts` / `src/cursor-state.ts` — ordinary precedence, safety caps, fast-default migration, trust-gated project load, remaining cloud/tool-transport/env keys, CLI flags, first-use acknowledgement, save destinations, and `/cursor-runtime`. Explicit cloud runtime fails closed after preflight remediation; actual cloud `Agent.create({ cloud })` remains unwired. |
 | `RunResult.usage` fallback | **Rejected for pi message usage** | Direct and live/native-replay drains use real `turn-ended` only when the counts fit the selected model window; otherwise they fall back to bounded pi estimates. `RunResult.usage` can describe full local agent context and must not feed compaction/context totals. |
 | `agent.reload()` refresh | **Implemented** | `/cursor-refresh-config` calls pooled `agent.reload()` without recreating the agent. |
 | Local safety controls | **Implemented** | `autoReview` and `sandboxOptions.enabled` via CLI/env/config; defaults stay off. |
@@ -299,7 +300,7 @@ The error should name the missing decision and show the shortest safe command to
 
 - Built-in default is local runtime.
 - Cloud can be selected with CLI flag, env var, slash command, project config, or user config using the target precedence above once the resolver exists.
-- Project config may propose cloud runtime defaults, but first use by a user must still require TUI acknowledgement or an explicit user/CLI/env non-interactive allow.
+- Project config may propose cloud runtime defaults, but first use by a user must still require TUI acknowledgement or an explicit user/CLI/env non-interactive allow. **Implemented scaffold:** `/cursor-runtime cloud` records session acknowledgement, `/cursor-runtime cloud --save-user` persists a personal acknowledgement, `--cursor-cloud-ack` / `PI_CURSOR_CLOUD_ACK=1` cover non-interactive acknowledgement, and project config cannot supply `cloud.acknowledged`.
 - Runtime slash commands apply to the current session immediately. Saving a project default requires an explicit save flag/subcommand and is the only path that writes project config.
 - Cloud mode notes that Pi-local tools are unavailable as part of the first-run cloud setup flow. If future recurring warnings are added because cloud output references unavailable Pi tools, that recurring warning may be permanently silenced in user config.
 
@@ -445,7 +446,7 @@ Blockers before cloud implementation:
 - project/user/session persistence design and explicit save destinations;
 - runtime-aware cloud model availability UX using the single `cursor/*` provider with runtime annotations/filters;
 - repo/branch/direct-push policy, including validated `startingRef`, explicit direct push, missing/unpushed branch behavior, and protected-branch fallback; dirty local tree remains pi-owned detection;
-- cloud auth/entitlement/repo preflight and error mapping strategy — **partial:** fail-closed local preflight and cloud option builder exist; SDK cloud auth/model/repo API checks remain;
+- cloud auth/entitlement/repo preflight and error mapping strategy — **partial:** fail-closed local preflight, first-use acknowledgement scaffold, and cloud option builder exist; SDK cloud auth/model/repo API checks remain;
 - cloud `envVars` handling, including validated shell presence with redaction and the post-send `run.agentId` rule;
 - explicit cloud MCP policy: initial pi cloud runtime should not expose inline `mcpServers`; future support needs option-builder tests and new SDK/API evidence because live probes showed surprising persistence and replacement failure;
 - opt-in live cloud smoke matrix in `docs/platform-smoke.md` — **documented as future optional lane**; the required `smoke:platform:all` gate still has no cloud provider dependency.

--- a/src/cursor-cloud-options.ts
+++ b/src/cursor-cloud-options.ts
@@ -19,6 +19,7 @@ export interface CursorCloudPreflightIssue {
 	code:
 		| "missing_repo"
 		| "missing_branch"
+		| "cloud_ack_required"
 		| "context_handoff_required"
 		| "local_state_not_allowed"
 		| "env_from_files_not_implemented";
@@ -116,6 +117,12 @@ export function preflightCursorCloudRuntime(options: {
 }): CursorCloudPreflightResult {
 	const { resolvedConfig } = options;
 	const issues: CursorCloudPreflightIssue[] = [];
+	if (!resolvedConfig.cloud.acknowledged.value) {
+		issues.push({
+			code: "cloud_ack_required",
+			message: "Cursor cloud runtime requires first-use acknowledgement; run /cursor-runtime cloud in an interactive session or pass --cursor-cloud-ack / PI_CURSOR_CLOUD_ACK=1.",
+		});
+	}
 	if (!resolvedConfig.cloud.repo.value) {
 		issues.push({
 			code: "missing_repo",

--- a/src/cursor-config.ts
+++ b/src/cursor-config.ts
@@ -13,6 +13,7 @@ export const CURSOR_CLOUD_DIRECT_PUSH_ENV = "PI_CURSOR_CLOUD_DIRECT_PUSH";
 export const CURSOR_CLOUD_ALLOW_LOCAL_STATE_ENV = "PI_CURSOR_CLOUD_ALLOW_LOCAL_STATE";
 export const CURSOR_CLOUD_ENV_ENV = "PI_CURSOR_CLOUD_ENV";
 export const CURSOR_CLOUD_ENV_FROM_FILES_ENV = "PI_CURSOR_CLOUD_ENV_FROM_FILES";
+export const CURSOR_CLOUD_ACK_ENV = "PI_CURSOR_CLOUD_ACK";
 export const CURSOR_AUTO_REVIEW_ENV = "PI_CURSOR_AUTO_REVIEW";
 export const CURSOR_SANDBOX_ENV = "PI_CURSOR_SANDBOX";
 export const CURSOR_LOCAL_FORCE_ENV = "PI_CURSOR_LOCAL_FORCE";
@@ -35,6 +36,7 @@ export interface CursorSdkConfig {
 		allowLocalState?: boolean;
 		envNames?: string[];
 		envFromFiles?: boolean;
+		acknowledged?: boolean;
 	};
 	local?: {
 		autoReview?: boolean;
@@ -73,6 +75,7 @@ export interface CursorResolvedSdkConfig {
 		allowLocalState: CursorResolvedSetting<boolean>;
 		envNames: CursorResolvedSetting<string[]>;
 		envFromFiles: CursorResolvedSetting<boolean>;
+		acknowledged: CursorResolvedSetting<boolean>;
 	};
 	local: {
 		autoReview: CursorResolvedSetting<boolean>;
@@ -119,6 +122,7 @@ const BUILT_IN_CURSOR_CONFIG: Required<Pick<CursorSdkConfig, "runtime" | "toolTr
 		allowLocalState: false,
 		envNames: [],
 		envFromFiles: false,
+		acknowledged: false,
 	},
 };
 
@@ -195,6 +199,7 @@ export function parseCursorSdkConfig(value: unknown): CursorSdkConfig | undefine
 		if (typeof cloud.allowLocalState === "boolean") parsedCloud.allowLocalState = cloud.allowLocalState;
 		if (envNames) parsedCloud.envNames = envNames;
 		if (typeof cloud.envFromFiles === "boolean") parsedCloud.envFromFiles = cloud.envFromFiles;
+		if (typeof cloud.acknowledged === "boolean") parsedCloud.acknowledged = cloud.acknowledged;
 		if (Object.keys(parsedCloud).length > 0) config.cloud = parsedCloud;
 	}
 
@@ -248,6 +253,31 @@ export function loadCursorSdkConfig(options: LoadCursorSdkConfigOptions = {}): {
 export function saveCursorSdkUserConfig(config: CursorSdkConfig, path = getCursorSdkUserConfigPath()): void {
 	mkdirSync(dirname(path), { recursive: true });
 	writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`, { mode: 0o600 });
+}
+
+export function saveCursorSdkProjectConfig(cwd: string, config: CursorSdkConfig, configDirName = CONFIG_DIR_NAME): void {
+	const path = getCursorSdkProjectConfigPath(cwd, configDirName);
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(config, null, 2)}\n`);
+}
+
+export function mergeCursorSdkConfig(base: CursorSdkConfig, patch: CursorSdkConfig): CursorSdkConfig {
+	return {
+		...base,
+		...patch,
+		...(base.cloud || patch.cloud ? { cloud: { ...base.cloud, ...patch.cloud } } : {}),
+		...(base.local || patch.local
+			? {
+					local: {
+						...base.local,
+						...patch.local,
+						...(base.local?.sandboxOptions || patch.local?.sandboxOptions
+							? { sandboxOptions: { ...base.local?.sandboxOptions, ...patch.local?.sandboxOptions } }
+							: {}),
+					},
+				}
+			: {}),
+	};
 }
 
 export function cursorFastDefaultsFromConfig(config: CursorSdkConfig | undefined): Map<string, boolean> {
@@ -331,6 +361,7 @@ export function cursorSdkConfigFromEnv(env: Record<string, string | undefined> =
 	const allowLocalState = parseEnvBoolean(env[CURSOR_CLOUD_ALLOW_LOCAL_STATE_ENV]);
 	const envNames = parseEnvNames(env[CURSOR_CLOUD_ENV_ENV]);
 	const envFromFiles = parseEnvBoolean(env[CURSOR_CLOUD_ENV_FROM_FILES_ENV]);
+	const acknowledged = parseEnvBoolean(env[CURSOR_CLOUD_ACK_ENV]);
 	if (
 		repo !== undefined ||
 		branch !== undefined ||
@@ -338,7 +369,8 @@ export function cursorSdkConfigFromEnv(env: Record<string, string | undefined> =
 		directPush !== undefined ||
 		allowLocalState !== undefined ||
 		envNames !== undefined ||
-		envFromFiles !== undefined
+		envFromFiles !== undefined ||
+		acknowledged !== undefined
 	) {
 		config.cloud = {
 			...(repo !== undefined ? { repo } : {}),
@@ -348,6 +380,7 @@ export function cursorSdkConfigFromEnv(env: Record<string, string | undefined> =
 			...(allowLocalState !== undefined ? { allowLocalState } : {}),
 			...(envNames !== undefined ? { envNames } : {}),
 			...(envFromFiles !== undefined ? { envFromFiles } : {}),
+			...(acknowledged !== undefined ? { acknowledged } : {}),
 		};
 	}
 	const autoReview = parseEnvBoolean(env[CURSOR_AUTO_REVIEW_ENV]);
@@ -471,6 +504,13 @@ export function resolveCursorSdkConfig(options: ResolveCursorSdkConfigOptions = 
 				[valueFrom("user", user?.cloud?.envFromFiles)],
 				(value) => (value ? 1 : 0),
 			),
+			acknowledged: resolveOrdinary([
+				valueFrom("cli", cli?.cloud?.acknowledged),
+				valueFrom("environment", env.cloud?.acknowledged),
+				valueFrom("session", session?.cloud?.acknowledged),
+				valueFrom("user", user?.cloud?.acknowledged),
+				valueFrom("builtin", builtIn.cloud.acknowledged),
+			]),
 		},
 		local: {
 			autoReview: resolveOrdinary([

--- a/src/cursor-state.ts
+++ b/src/cursor-state.ts
@@ -32,13 +32,17 @@ import {
 	CURSOR_CLOUD_DIRECT_PUSH_ENV,
 	CURSOR_CLOUD_ENV_ENV,
 	CURSOR_CLOUD_ENV_FROM_FILES_ENV,
+	CURSOR_CLOUD_ACK_ENV,
 	CURSOR_CLOUD_REPO_ENV,
 	CURSOR_RUNTIME_ENV,
 	CURSOR_SANDBOX_ENV,
 	CURSOR_TOOL_TRANSPORT_ENV,
 	parseCursorSdkConfig,
+	loadCursorSdkProjectConfig,
 	loadCursorSdkUserConfig,
+	mergeCursorSdkConfig,
 	resolveCursorFastDefault,
+	saveCursorSdkProjectConfig,
 	saveCursorSdkUserConfig,
 	withCursorFastDefaults,
 	type CursorSdkConfig,
@@ -64,6 +68,7 @@ interface CursorModeEntryData {
 
 interface CursorRuntimeEntryData {
 	runtime: "local" | "cloud";
+	cloudAcknowledged?: boolean;
 }
 
 type CursorRuntimeControlsExtensionApi = Pick<
@@ -93,8 +98,10 @@ let cliCursorCloudDirectPush = false;
 let cliCursorCloudAllowLocalState = false;
 let cliCursorCloudEnv: string | undefined;
 let cliCursorCloudEnvFromFiles = false;
+let cliCursorCloudAck = false;
 let sessionCursorAgentMode: AgentModeOption | undefined;
 let sessionCursorRuntime: "local" | "cloud" | undefined;
+let sessionCursorCloudAcknowledged = false;
 let cliCursorModeState: CursorCliModeState = { kind: "unset" };
 const invalidCursorModeNotifiedSessionScopeKeys = new Set<string>();
 
@@ -123,8 +130,10 @@ function isCursorModeEntryData(value: unknown): value is CursorModeEntryData {
 }
 
 function isCursorRuntimeEntryData(value: unknown): value is CursorRuntimeEntryData {
-	const runtime = asRecord(value)?.runtime;
-	return runtime === "local" || runtime === "cloud";
+	const record = asRecord(value);
+	if (!record) return false;
+	const runtime = record.runtime;
+	return (runtime === "local" || runtime === "cloud") && (record.cloudAcknowledged === undefined || typeof record.cloudAcknowledged === "boolean");
 }
 
 function getConfigPath(): string {
@@ -163,10 +172,12 @@ function restoreSessionCursorMode(ctx: { sessionManager: Pick<ExtensionContext["
 
 function restoreSessionCursorRuntime(ctx: { sessionManager: Pick<ExtensionContext["sessionManager"], "getBranch"> }): void {
 	sessionCursorRuntime = undefined;
+	sessionCursorCloudAcknowledged = false;
 	for (const entry of ctx.sessionManager.getBranch()) {
 		if (entry.type !== "custom" || entry.customType !== RUNTIME_ENTRY_TYPE) continue;
 		if (isCursorRuntimeEntryData(entry.data)) {
 			sessionCursorRuntime = entry.data.runtime;
+			sessionCursorCloudAcknowledged = entry.data.cloudAcknowledged === true;
 		}
 	}
 }
@@ -249,6 +260,7 @@ export function getCursorCliConfig(): CursorSdkConfig {
 			...(cliCursorCloudAllowLocalState ? { allowLocalState: true } : {}),
 			envNames: splitCliEnvNames(cliCursorCloudEnv),
 			...(cliCursorCloudEnvFromFiles ? { envFromFiles: true } : {}),
+			...(cliCursorCloudAck ? { acknowledged: true } : {}),
 		},
 		local: {
 			...(cliAutoReview ? { autoReview: true } : {}),
@@ -259,7 +271,12 @@ export function getCursorCliConfig(): CursorSdkConfig {
 }
 
 export function getCursorSessionConfig(): CursorSdkConfig {
-	return sessionCursorRuntime ? { runtime: sessionCursorRuntime } : {};
+	return sessionCursorRuntime
+		? {
+				runtime: sessionCursorRuntime,
+				...(sessionCursorCloudAcknowledged ? { cloud: { acknowledged: true } } : {}),
+			}
+		: {};
 }
 
 export function consumeCursorLocalForceOverride(resolved: { value: boolean; source: string }): boolean {
@@ -349,13 +366,16 @@ function persistCursorModePreference(pi: Pick<ExtensionAPI, "appendEntry">, mode
 	}
 }
 
-function persistCursorRuntimePreference(pi: Pick<ExtensionAPI, "appendEntry">, runtime: "local" | "cloud"): void {
+function persistCursorRuntimePreference(pi: Pick<ExtensionAPI, "appendEntry">, runtime: "local" | "cloud", cloudAcknowledged = false): void {
 	const previousRuntime = sessionCursorRuntime;
+	const previousCloudAcknowledged = sessionCursorCloudAcknowledged;
 	sessionCursorRuntime = runtime;
+	sessionCursorCloudAcknowledged = cloudAcknowledged;
 	try {
-		pi.appendEntry<CursorRuntimeEntryData>(RUNTIME_ENTRY_TYPE, { runtime });
+		pi.appendEntry<CursorRuntimeEntryData>(RUNTIME_ENTRY_TYPE, { runtime, ...(cloudAcknowledged ? { cloudAcknowledged } : {}) });
 	} catch (error) {
 		sessionCursorRuntime = previousRuntime;
+		sessionCursorCloudAcknowledged = previousCloudAcknowledged;
 		throw error;
 	}
 }
@@ -504,6 +524,12 @@ export function registerCursorRuntimeControls(pi: CursorRuntimeControlsExtension
 		default: false,
 	});
 
+	pi.registerFlag("cursor-cloud-ack", {
+		description: `Acknowledge first-use Cursor cloud runtime risks for this run (or set ${CURSOR_CLOUD_ACK_ENV}=1)`,
+		type: "boolean",
+		default: false,
+	});
+
 	pi.registerFlag("cursor-auto-review", {
 		description: `Enable Cursor SDK local Auto-review for this run (or set ${CURSOR_AUTO_REVIEW_ENV}=1)`,
 		type: "boolean",
@@ -566,26 +592,39 @@ export function registerCursorRuntimeControls(pi: CursorRuntimeControlsExtension
 	pi.registerCommand("cursor-runtime", {
 		description: "Set Cursor runtime for this session: local or cloud",
 		handler: async (args, ctx) => {
-			const usage = "Usage: /cursor-runtime local|cloud";
-			const raw = args.trim();
+			const usage = "Usage: /cursor-runtime local|cloud [--save-user|--save-project]";
+			const tokens = args.trim().split(/\s+/).filter(Boolean);
+			const raw = tokens[0];
+			const saveUser = tokens.includes("--save-user");
+			const saveProject = tokens.includes("--save-project");
+			const extra = tokens.slice(1).filter((token) => token !== "--save-user" && token !== "--save-project");
 			if (!raw) {
 				ctx.ui.notify(`Cursor runtime is ${sessionCursorRuntime ?? "local"}. ${usage}`, "info");
 				return;
 			}
-			if (raw !== "local" && raw !== "cloud") {
-				ctx.ui.notify(`Invalid Cursor runtime "${raw}". ${usage}`, "error");
+			if ((raw !== "local" && raw !== "cloud") || extra.length > 0 || (saveUser && saveProject)) {
+				ctx.ui.notify(`Invalid Cursor runtime arguments. ${usage}`, "error");
 				return;
 			}
 			try {
-				persistCursorRuntimePreference(pi, raw);
+				persistCursorRuntimePreference(pi, raw, raw === "cloud");
+				if (saveUser) {
+					const current = loadCursorSdkUserConfig();
+					saveCursorSdkUserConfig(mergeCursorSdkConfig(current, { runtime: raw, ...(raw === "cloud" ? { cloud: { acknowledged: true } } : {}) }));
+				}
+				if (saveProject) {
+					const current = loadCursorSdkProjectConfig(ctx.cwd, true) ?? {};
+					saveCursorSdkProjectConfig(ctx.cwd, mergeCursorSdkConfig(current, { runtime: raw }));
+				}
 			} catch (error) {
 				ctx.ui.notify(`Failed to save Cursor runtime preference: ${error instanceof Error ? error.message : String(error)}`, "error");
 				return;
 			}
+			const saved = saveUser ? " Saved to user config." : saveProject ? " Saved to project config; cloud acknowledgement remains session/user-scoped." : "";
 			ctx.ui.notify(
 				raw === "cloud"
-					? "Cursor runtime set to cloud for this session. Cloud runtime is not implemented yet; Cursor runs fail closed until cloud support lands."
-					: "Cursor runtime set to local for this session.",
+					? `Cursor runtime set to cloud for this session and first-use cloud risk acknowledged. Cloud runtime is not implemented yet; Cursor runs fail closed until cloud support lands.${saved}`
+					: `Cursor runtime set to local for this session.${saved}`,
 				"info",
 			);
 		},
@@ -678,6 +717,7 @@ export function registerCursorRuntimeControls(pi: CursorRuntimeControlsExtension
 			cliCursorCloudAllowLocalState = pi.getFlag("cursor-cloud-allow-local-state") === true;
 			cliCursorCloudEnv = stringFlagValue(pi.getFlag("cursor-cloud-env"));
 			cliCursorCloudEnvFromFiles = pi.getFlag("cursor-cloud-env-from-files") === true;
+			cliCursorCloudAck = pi.getFlag("cursor-cloud-ack") === true;
 			restoreSessionFastPreferences(ctx);
 			restoreSessionCursorMode(ctx);
 			restoreSessionCursorRuntime(ctx);
@@ -693,6 +733,7 @@ export function registerCursorRuntimeControls(pi: CursorRuntimeControlsExtension
 function resetCursorModeStateForTests(): void {
 	sessionCursorAgentMode = undefined;
 	sessionCursorRuntime = undefined;
+	sessionCursorCloudAcknowledged = false;
 	cliCursorModeState = { kind: "unset" };
 	cliAutoReview = false;
 	cliSandbox = false;
@@ -707,6 +748,7 @@ function resetCursorModeStateForTests(): void {
 	cliCursorCloudAllowLocalState = false;
 	cliCursorCloudEnv = undefined;
 	cliCursorCloudEnvFromFiles = false;
+	cliCursorCloudAck = false;
 	invalidCursorModeNotifiedSessionScopeKeys.clear();
 }
 

--- a/test/cursor-cloud-options.test.ts
+++ b/test/cursor-cloud-options.test.ts
@@ -74,6 +74,7 @@ describe("Cursor cloud options", () => {
 
 		expect(result.ok).toBe(false);
 		expect(result.issues.map((issue) => issue.code)).toEqual([
+			"cloud_ack_required",
 			"missing_repo",
 			"missing_branch",
 			"context_handoff_required",
@@ -124,7 +125,7 @@ describe("Cursor cloud options", () => {
 			resolvedConfig: resolveCursorSdkConfig({
 				cli: {
 					runtime: "cloud",
-					cloud: { repo: "https://github.com/example/repo.git", branch: "main", allowLocalState: true },
+					cloud: { repo: "https://github.com/example/repo.git", branch: "main", allowLocalState: true, acknowledged: true },
 				},
 			}),
 			hasPriorContext: false,

--- a/test/cursor-config.test.ts
+++ b/test/cursor-config.test.ts
@@ -10,6 +10,7 @@ import {
 	CURSOR_CLOUD_DIRECT_PUSH_ENV,
 	CURSOR_CLOUD_ENV_ENV,
 	CURSOR_CLOUD_ENV_FROM_FILES_ENV,
+	CURSOR_CLOUD_ACK_ENV,
 	CURSOR_CLOUD_REPO_ENV,
 	CURSOR_RUNTIME_ENV,
 	CURSOR_SANDBOX_ENV,
@@ -19,6 +20,7 @@ import {
 	getCursorSdkUserConfigPath,
 	loadCursorSdkConfig,
 	loadCursorSdkUserConfig,
+	mergeCursorSdkConfig,
 	resolveCursorFastDefault,
 	resolveCursorSdkConfig,
 	saveCursorSdkUserConfig,
@@ -173,6 +175,10 @@ describe("Cursor SDK config resolver", () => {
 			cappedSource: "project",
 			cappedValue: ["GH_TOKEN", "NODE_ENV", "NPM_TOKEN"],
 		});
+		expect(resolveCursorSdkConfig({ project: { cloud: { acknowledged: true } } }).cloud.acknowledged).toMatchObject({
+			value: false,
+			source: "builtin",
+		});
 	});
 
 	it("lets explicit one-shot CLI safety allows override user denials", () => {
@@ -216,6 +222,7 @@ describe("Cursor SDK config resolver", () => {
 				[CURSOR_CLOUD_ALLOW_LOCAL_STATE_ENV]: "true",
 				[CURSOR_CLOUD_ENV_ENV]: "GH_TOKEN,CURSOR_SECRET,bad-name, NODE_ENV ,GH_TOKEN",
 				[CURSOR_CLOUD_ENV_FROM_FILES_ENV]: "1",
+				[CURSOR_CLOUD_ACK_ENV]: "1",
 			},
 			project: { cloud: { repo: "project-repo", branch: "project-branch" } },
 		}).cloud;
@@ -225,6 +232,20 @@ describe("Cursor SDK config resolver", () => {
 		expect(resolved.allowLocalState).toMatchObject({ value: true, source: "environment" });
 		expect(resolved.envNames).toMatchObject({ value: ["GH_TOKEN", "NODE_ENV"], source: "environment" });
 		expect(resolved.envFromFiles).toMatchObject({ value: true, source: "environment" });
+		expect(resolved.acknowledged).toMatchObject({ value: true, source: "environment" });
+	});
+
+	it("merges nested cursor sdk config", () => {
+		expect(
+			mergeCursorSdkConfig(
+				{ runtime: "local", cloud: { repo: "repo", acknowledged: false }, local: { sandboxOptions: { enabled: true } } },
+				{ runtime: "cloud", cloud: { acknowledged: true }, local: { autoReview: true } },
+			),
+		).toEqual({
+			runtime: "cloud",
+			cloud: { repo: "repo", acknowledged: true },
+			local: { sandboxOptions: { enabled: true }, autoReview: true },
+		});
 	});
 
 	it("lets session runtime override config but not CLI or env", () => {

--- a/test/cursor-provider-stream-config.test.ts
+++ b/test/cursor-provider-stream-config.test.ts
@@ -199,6 +199,7 @@ describe("streamCursor prompt and model config", () => {
 		process.env.PI_CURSOR_CLOUD_REPO = "https://github.com/example/repo.git";
 		process.env.PI_CURSOR_CLOUD_BRANCH = "main";
 		process.env.PI_CURSOR_CLOUD_ALLOW_LOCAL_STATE = "1";
+		process.env.PI_CURSOR_CLOUD_ACK = "1";
 
 		const events = await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
 

--- a/test/cursor-state.test.ts
+++ b/test/cursor-state.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -87,6 +87,7 @@ function createCursorRuntimeHarness(options: {
 	cursorModeFlag?: boolean | string;
 	mode?: ExtensionContext["mode"];
 	hasUI?: boolean;
+	cwd?: string;
 } = {}) {
 	const pi = createPiHarness({
 		flagValues: {
@@ -96,6 +97,7 @@ function createCursorRuntimeHarness(options: {
 		},
 	});
 	const ctx = createExtensionTestContext({
+		cwd: options.cwd,
 		mode: options.mode ?? "tui",
 		hasUI: options.hasUI ?? true,
 		model: options.modelId
@@ -111,6 +113,7 @@ function createCursorRuntimeHarness(options: {
 	});
 	registerCursorRuntimeControls(pi);
 	const commandCtx = createExtensionCommandContext({
+		cwd: ctx.cwd,
 		model: ctx.model,
 		ui: ctx.ui,
 		sessionManager: ctx.sessionManager,
@@ -761,8 +764,8 @@ describe("Cursor runtime state", () => {
 
 		await commands.get("cursor-runtime")!.handler("cloud", commandCtx);
 
-		expect(pi.appendEntry).toHaveBeenCalledWith(__testUtils.RUNTIME_ENTRY_TYPE, { runtime: "cloud" });
-		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("Cloud runtime is not implemented yet"), "info");
+		expect(pi.appendEntry).toHaveBeenCalledWith(__testUtils.RUNTIME_ENTRY_TYPE, { runtime: "cloud", cloudAcknowledged: true });
+		expect(ctx.ui.notify).toHaveBeenCalledWith(expect.stringContaining("first-use cloud risk acknowledged"), "info");
 	});
 
 	it("reports /cursor-runtime usage and rejects invalid values", async () => {
@@ -772,9 +775,34 @@ describe("Cursor runtime state", () => {
 		await commands.get("cursor-runtime")!.handler("", commandCtx);
 		await commands.get("cursor-runtime")!.handler("remote", commandCtx);
 
-		expect(ctx.ui.notify).toHaveBeenCalledWith("Cursor runtime is local. Usage: /cursor-runtime local|cloud", "info");
-		expect(ctx.ui.notify).toHaveBeenCalledWith('Invalid Cursor runtime "remote". Usage: /cursor-runtime local|cloud', "error");
+		expect(ctx.ui.notify).toHaveBeenCalledWith("Cursor runtime is local. Usage: /cursor-runtime local|cloud [--save-user|--save-project]", "info");
+		expect(ctx.ui.notify).toHaveBeenCalledWith("Invalid Cursor runtime arguments. Usage: /cursor-runtime local|cloud [--save-user|--save-project]", "error");
 		expect(pi.appendEntry).not.toHaveBeenCalled();
+	});
+
+	it("saves /cursor-runtime cloud acknowledgement only to user or session state", async () => {
+		const cwd = join(tmpAgentDir, "project");
+		mkdirSync(cwd, { recursive: true });
+		const { pi, commandCtx, commands } = createCursorRuntimeHarness({ modelId: "gpt-5.5@1m", cwd });
+		await pi.invokeEventWithContext("session_start", { type: "session_start", reason: "startup" }, commandCtx);
+
+		await commands.get("cursor-runtime")!.handler("cloud --save-user", commandCtx);
+
+		expect(JSON.parse(readFileSync(join(tmpAgentDir, "cursor-sdk.json"), "utf-8"))).toEqual({
+			runtime: "cloud",
+			cloud: { acknowledged: true },
+		});
+	});
+
+	it("saves /cursor-runtime project default without project-level cloud acknowledgement", async () => {
+		const cwd = join(tmpAgentDir, "project");
+		mkdirSync(cwd, { recursive: true });
+		const { pi, commandCtx, commands } = createCursorRuntimeHarness({ modelId: "gpt-5.5@1m", cwd });
+		await pi.invokeEventWithContext("session_start", { type: "session_start", reason: "startup" }, commandCtx);
+
+		await commands.get("cursor-runtime")!.handler("cloud --save-project", commandCtx);
+
+		expect(JSON.parse(readFileSync(join(cwd, ".pi", "cursor-sdk.json"), "utf-8"))).toEqual({ runtime: "cloud" });
 	});
 
 	it("registers /cursor-tools and reports bridge and setting sources", async () => {


### PR DESCRIPTION
## Summary

- Add `cloud.acknowledged` scaffolding plus `--cursor-cloud-ack` / `PI_CURSOR_CLOUD_ACK=1` for non-interactive first-use acknowledgement.
- Require cloud acknowledgement in fail-closed preflight before cloud runtime can proceed.
- Make `/cursor-runtime cloud` record a session acknowledgement; `--save-user` persists personal acknowledgement; `--save-project` writes only the runtime default, not first-use acknowledgement.
- Update docs/tests/roadmap. Cloud runtime still fails closed; no `Agent.create({ cloud })` is enabled.

## Safety

- Local runtime remains the default.
- Project config cannot provide first-use cloud acknowledgement.
- No env values are persisted; cloud env config remains names-only.
- No local Pi tools are exposed to cloud.
- No platform-smoke or visual parser changes.

## Validation

- `npx vitest run test/cursor-config.test.ts test/cursor-state.test.ts test/cursor-cloud-options.test.ts test/cursor-provider-stream-config.test.ts` — 4 files / 96 tests passed.
- `npm test` — 84 files / 861 tests passed.
- `npm run typecheck` — passed.
- `npm run typecheck:tests` — passed.
- `npm pack --dry-run` — passed.
- `git diff --check` — passed.
- `npm run smoke:platform:all` — passed on macOS, Ubuntu, Windows.

## Review gate

- Thermo review before commit: no remaining material findings.
- Thermo review before push: no remaining material findings.
