### PR TITLE
Use relative path in compaction evidence report

### DIFF
--- a/docs/evidence/cursor-local-compaction-boundary-2026-07-08.report.json
+++ b/docs/evidence/cursor-local-compaction-boundary-2026-07-08.report.json
@@ -1,6 +1,6 @@
 {
   "capturedAt": "2026-07-08T04:17:07Z",
-  "sourceArtifactDir": "/Users/mitchfultz/Projects/AI/pi-cursor-sdk/.artifacts/compaction-boundary-three-turn-2026-07-08T04-17-07-848Z",
+  "sourceArtifactDir": ".artifacts/compaction-boundary-three-turn-2026-07-08T04-17-07-848Z",
   "sourceArtifactSha256": {
     "report": "b8c1c81c550711251dd352d7ed531ce497eaab10a72d0948e49559695dce7756",
     "beforeCompactSession": "77249acb3523ec101f94fbf91f9e50493a57ffb5d946892f82dfef21d68c6c4b",


### PR DESCRIPTION
## Summary
- replace machine-local absolute artifact path in the committed compaction evidence report with a repo-relative `.artifacts/...` path

## Validation
- `jq . docs/evidence/cursor-local-compaction-boundary-2026-07-08.report.json`
- `git diff --check origin/main..HEAD`
- independent reviewer: no findings; verified hashes still match local artifacts

## Behavior
Docs only. No default user behavior changed.