### PR TITLE
Verify cloud smoke archive cleanup

### DIFF
--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -489,7 +489,7 @@ Current minimal live cloud smoke lane:
 - requires `CURSOR_API_KEY`;
 - starts one non-interactive cloud request with explicit acknowledgement and fresh context;
 - asserts cloud runtime metadata, no pi bridge, no native replay live-run mode, and cloud agent id shape;
-- archives the throwaway cloud agent when an id is available;
+- archives the throwaway cloud agent when an id is available and verifies `archived: true` before passing;
 - keeps branch/PR/direct-push/artifact/usage scenarios out of the default local platform gate.
 
 Expanded cloud smoke matrix when product scope requires it:

--- a/docs/platform-smoke.md
+++ b/docs/platform-smoke.md
@@ -153,13 +153,13 @@ Run:
 npm run smoke:cloud
 ```
 
-The current lane is intentionally minimal: it starts one non-interactive cloud run with explicit acknowledgement, fresh context, no pi bridge, no env forwarding, SDK event-debug contract checks, bounded stream-only cloud report shape checks, and cloud-agent archival cleanup. Raw usage/artifact presence is account-dependent, so display-only accounting and artifact formatting contracts stay covered by unit/provider tests. It must fail closed when requested but unavailable:
+The current lane is intentionally minimal: it starts one non-interactive cloud run with explicit acknowledgement, fresh context, no pi bridge, no env forwarding, SDK event-debug contract checks, bounded stream-only cloud report shape checks, and cloud-agent archival cleanup with post-archive `archived: true` verification. Raw usage/artifact presence is account-dependent, so display-only accounting and artifact formatting contracts stay covered by unit/provider tests. It must fail closed when requested but unavailable:
 
 - missing cloud-capable credentials, repo access, or cloud entitlement → report **blocked**, not skipped-ready;
 - no non-interactive prompts; every needed cloud choice must come from CLI/env/config;
 - do not expose inline cloud MCP in the first cloud runtime lane;
 - do not forward local env values;
-- archive the throwaway cloud agent when the SDK/API returns an agent id.
+- archive the throwaway cloud agent when the SDK/API returns an agent id and verify the archived metadata before passing.
 
 Future expanded cloud smoke work should add throwaway repo/branch coverage, dirty/unpushed warning assertions, branch/PR behavior, explicit direct-push opt-in, missing-branch failure, cancel/delete cleanup, and account-backed artifact/raw-usage fixtures when those contracts need live proof beyond the current report-shape smoke.
 

--- a/scripts/cloud-runtime-smoke.mjs
+++ b/scripts/cloud-runtime-smoke.mjs
@@ -165,6 +165,10 @@ async function archiveCloudAgent(agentId) {
 	if (!agentId) return;
 	const { Agent } = await import("@cursor/sdk");
 	await Agent.archive(agentId, {});
+	const archived = await Agent.get(agentId, {});
+	if (archived.archived !== true) {
+		fail(`cloud agent ${agentId} did not report archived after cleanup`, JSON.stringify(archived, null, 2));
+	}
 	console.error(`[cloud-smoke] archived agent ${agentId}`);
 }
 


### PR DESCRIPTION
## Summary
- make `npm run smoke:cloud` verify the throwaway cloud agent reports `archived: true` after cleanup
- update platform smoke docs and roadmap smoke-lane notes

## Proof / validation
- `npm run check:platform-smoke`
- `npm run smoke:cloud` → archived `bc-d3bdc2ca-95d6-40cc-b9ef-22be817015e3`, printed `cloud-smoke-ok`
- independent push-gate reviewer: no findings, signed off

## Behavior
Smoke/docs only. No default user behavior changed.