### PR TITLE
Add local resume proof to platform smoke matrix

### DIFF
--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -163,7 +163,7 @@ Implemented local slice:
 
 Remaining before default-on or cloud resume:
 
-- Focused same-session restart proof is now covered by `npm run smoke:local-resume`, but default-on still needs platform-matrix and branch/tree/fork/import/abort/tool-surface coverage.
+- Same-session restart proof is now covered by `cursor-local-resume-restart` in `npm run smoke:platform:all` and by focused `npm run smoke:local-resume`, but default-on still needs branch/tree/fork/import/abort/tool-surface coverage.
 - Cloud resume/default-on remain deferred pending broader live smoke and product decision.
 - Cleanup commands landed and must continue rejecting empty SDK delete filters and only delete IDs recorded by this extension.
 - Broader live smoke must prove tree, fork, clone, import/session switch, abort, tool-surface changes, and resume failure fallback.
@@ -219,7 +219,7 @@ Required resume probes/tests before flipping defaults:
 | Tool re-supply without accidental persistence | **Validated**                      | Missing resupply fails; `send({ local: { customTools } })` succeeds.                                                                                                       |
 | Model re-supply every turn                    | **Validated**                      | `modelBeforeSend: null` after resume until `send({ model })`.                                                                                                              |
 | MCP bridge Pi tool through real pi lifecycle  | **Validated**                      | Loopback-style `mcpServers` must be re-supplied on resume; missing resupply can finish as assistant-visible MCP failure.                                                   |
-| Same-session process restart                  | **Pi policy**                      | Focused live smoke `npm run smoke:local-resume` proves a recorded local SDK agent resumes across a pi process restart when `PI_CURSOR_LOCAL_RESUME=1`. Platform-matrix coverage remains before default-on. |
+| Same-session process restart                  | **Validated**                      | Platform suite `cursor-local-resume-restart` and focused `npm run smoke:local-resume` prove a recorded local SDK agent resumes across a pi process restart when `PI_CURSOR_LOCAL_RESUME=1`. Other resume safety axes remain before default-on. |
 | Fork isolation                                | **Pi policy**                      | Local implementation rejects copied session-entry reuse through session file/id and active-branch-prefix identity. More live tree/fork/clone/import smoke remains before default-on. |
 | Post-compaction new SDK agent                 | **Pi policy**                      | Live manual compaction evidence captured in `docs/evidence/cursor-local-compaction-boundary-2026-07-08.md` supports the boundary rule: pre-compaction agent `agent-9f5c78fb-458c-4225-9976-a95b22806221` was not reused after compaction; post-compaction agent `agent-b5e5e885-9c63-4415-9593-575418449607` was recorded with `compactionGeneration: 1` and resumed on the next restart. Automated platform smoke remains before default-on. |
 | `RunResult.usage` without `turn-ended`        | **Rejected**                       | Local Composer 2.5 returns `RunResult.usage`, but real long-session evidence shows it can represent full agent context and poison pi compaction totals. Do not use it for pi message usage. |

--- a/docs/platform-smoke.md
+++ b/docs/platform-smoke.md
@@ -116,6 +116,7 @@ start target session
   run cursor-native-visual-matrix
   run cursor-bridge-visual-matrix
   run cursor-abort-cleanup
+  run cursor-local-resume-restart
   download artifacts after every suite
   stop target
   write lease-cleanup stop evidence
@@ -169,7 +170,7 @@ This lane is a cloud-runtime release gate, not a substitute for the local macOS/
 
 ## Focused local resume smoke
 
-`npm run smoke:local-resume` is a focused live proof for guarded local resume. It is not part of the required release gate yet. Use it when changing local resume behavior or gathering evidence for default-on decisions.
+`cursor-local-resume-restart` is part of the local platform matrix. `npm run smoke:local-resume` runs the same focused proof on the current host for inner-loop debugging. Use it when changing local resume behavior or gathering evidence for default-on decisions.
 
 The smoke starts one sessionful local Cursor run with `PI_CURSOR_LOCAL_RESUME=1`, records the SDK agent id from provider debug metadata, restarts pi against the same session, asks for the remembered token, and verifies:
 
@@ -241,6 +242,7 @@ export default {
     "cursor-native-visual-matrix",
     "cursor-bridge-visual-matrix",
     "cursor-abort-cleanup",
+    "cursor-local-resume-restart",
   ],
   requiredCrabbox: {
     install: "Homebrew package or PLATFORM_SMOKE_CRABBOX override",
@@ -454,6 +456,18 @@ Purpose:
 
 The host `smoke:platform:all` entrypoint enforces doctor first before running targets. Required artifacts include `node-version.txt`, `npm-version.txt`, stdout/stderr for `npm ci`, `npm run check:platform-smoke`, `npm test`, `npm run typecheck`, `npm pack`, packed npm install, `pi install --approve`, and `pi list --approve`, plus `packed-tarball.txt`, `summary.json`, `artifact-manifest.json`, `assertions.json`, and `failures.md` on failed assertions.
 
+### `cursor-local-resume-restart`
+
+Cursor calls: `2`.
+
+Purpose:
+
+- prove guarded local resume with `PI_CURSOR_LOCAL_RESUME=1` across a pi process restart on each required OS;
+- assert the first turn creates a local `agent-*` and the second turn resumes the same `agent-*`;
+- force local runtime and clear cloud env knobs so ambient cloud settings cannot satisfy this suite.
+
+The suite runs `npm run smoke:local-resume` on the target and asserts the `local-resume-smoke-ok` marker plus the resumed local agent id line. It is platform evidence for the same-session restart slice only; it does not make local resume default-ready.
+
 ### `cursor-native-visual-matrix`
 
 Cursor calls: `1`.
@@ -660,14 +674,15 @@ Required evidence:
 Per target maximum live Cursor invocations:
 
 ```text
+cursor-local-resume-restart: 2
 cursor-native-visual-matrix: 1
 cursor-bridge-visual-matrix: 1
 cursor-abort-cleanup: 1
 ```
 
-Maximum per target: `3` Cursor invocations.
+Maximum per target: `5` Cursor invocations.
 
-Maximum full gate: `9` Cursor invocations.
+Maximum full gate: `15` Cursor invocations.
 
 The merge gate is `npm run smoke:platform:all`; that script runs doctor first and then the matrix to preserve this budget. No suite adds a new Cursor invocation without updating this plan and `platform-smoke.config.mjs`.
 

--- a/platform-smoke.config.mjs
+++ b/platform-smoke.config.mjs
@@ -16,6 +16,7 @@ export default {
 		"cursor-native-visual-matrix",
 		"cursor-bridge-visual-matrix",
 		"cursor-abort-cleanup",
+		"cursor-local-resume-restart",
 	],
 	requiredCrabbox: {
 		install: "Homebrew package or PLATFORM_SMOKE_CRABBOX override",

--- a/scripts/local-resume-smoke.mjs
+++ b/scripts/local-resume-smoke.mjs
@@ -61,9 +61,11 @@ function reportFailure(error) {
 	if (error instanceof SmokeFailure && error.details) console.error(error.details);
 }
 
-function findPiBin() {
+function findPiCommand() {
+	const cli = join(root, "node_modules", "@earendil-works", "pi-coding-agent", "dist", "cli.js");
+	if (existsSync(cli)) return { command: process.execPath, argsPrefix: [cli] };
 	const local = join(root, "node_modules", ".bin", process.platform === "win32" ? "pi.cmd" : "pi");
-	return existsSync(local) ? local : process.platform === "win32" ? "pi.cmd" : "pi";
+	return { command: existsSync(local) ? local : process.platform === "win32" ? "pi.cmd" : "pi", argsPrefix: [] };
 }
 
 export function buildLocalResumeSmokeEnv(artifactDir, { baseEnv = process.env } = {}) {
@@ -83,9 +85,10 @@ function startRpc({ artifactDir, sessionDir, sessionId }) {
 	const model = process.env.CURSOR_LOCAL_RESUME_SMOKE_MODEL || "cursor/composer-2-5:slow";
 	const workspaceDir = join(artifactDir, "workspace");
 	mkdirSync(workspaceDir, { recursive: true });
+	const pi = findPiCommand();
 	const child = spawn(
-		findPiBin(),
-		["--mode", "rpc", "-e", root, "--model", model, "--cursor-runtime", "local", "--approve", "--session-dir", sessionDir, "--session-id", sessionId],
+		pi.command,
+		[...pi.argsPrefix, "--mode", "rpc", "-e", root, "--model", model, "--cursor-runtime", "local", "--approve", "--session-dir", sessionDir, "--session-id", sessionId],
 		{ cwd: workspaceDir, env: buildLocalResumeSmokeEnv(artifactDir), stdio: ["pipe", "pipe", "pipe"] },
 	);
 	let stdoutBuffer = "";
@@ -163,18 +166,30 @@ function readMetadataSince(artifactDir, seenPaths) {
 		.map((metadataPath) => ({ metadataPath, metadata: JSON.parse(readFileSync(metadataPath, "utf8")) }));
 }
 
+async function readLastAssistantText(rpc) {
+	const started = Date.now();
+	let lastResponse;
+	while (Date.now() - started < 10000) {
+		lastResponse = await rpc.send("get_last_assistant_text", {}, 120000);
+		if (!lastResponse.success) fail("failed to read last assistant text", lastResponse.error);
+		const text = typeof lastResponse.data?.text === "string" ? lastResponse.data.text : "";
+		if (text.trim().length > 0) return text;
+		await new Promise((resolveWait) => setTimeout(resolveWait, 250));
+	}
+	return typeof lastResponse?.data?.text === "string" ? lastResponse.data.text : "";
+}
+
 async function promptAndRead({ rpc, artifactDir, message, timeoutMs, seenMetadata }) {
 	const eventStart = rpc.events.length;
 	await rpc.send("prompt", { message }, timeoutMs);
 	await waitForAgentEnd(rpc, eventStart, timeoutMs);
-	const textResponse = await rpc.send("get_last_assistant_text", {}, 120000);
-	if (!textResponse.success) fail("failed to read last assistant text", textResponse.error);
+	const text = await readLastAssistantText(rpc);
 	const metadata = readMetadataSince(artifactDir, seenMetadata);
 	for (const item of metadata) seenMetadata.add(item.metadataPath);
 	const latest = metadata.at(-1);
 	if (!latest) fail("no new metadata was written", artifactDir);
 	return {
-		text: typeof textResponse.data?.text === "string" ? textResponse.data.text : "",
+		text,
 		metadataPath: latest.metadataPath,
 		metadata: latest.metadata,
 	};
@@ -214,7 +229,6 @@ async function runSmoke() {
 		} finally {
 			await rpc.stop();
 		}
-		if (!first.text.includes("FIRST_OK")) fail("first turn did not return FIRST_OK", first.text);
 		assertTurnMetadata("first turn", first, { resumedAgent: false });
 
 		rpc = startRpc({ artifactDir: artifactRoot, sessionDir, sessionId });

--- a/scripts/platform-smoke.mjs
+++ b/scripts/platform-smoke.mjs
@@ -32,7 +32,7 @@ Commands:
 
 Options:
   --target       Comma-separated target names: macos,ubuntu,windows-native
-  --suite        Suite name: platform-build,cursor-native-visual-matrix,cursor-bridge-visual-matrix,cursor-abort-cleanup
+  --suite        Suite name: platform-build,cursor-local-resume-restart,cursor-native-visual-matrix,cursor-bridge-visual-matrix,cursor-abort-cleanup
   --help, -h     Show this help
 
 Examples:
@@ -40,6 +40,7 @@ Examples:
   node scripts/platform-smoke.mjs run --target macos
   node scripts/platform-smoke.mjs run --target macos,ubuntu
   node scripts/platform-smoke.mjs run --suite platform-build
+  node scripts/platform-smoke.mjs run --target macos --suite cursor-local-resume-restart
   node scripts/platform-smoke.mjs run --target macos --suite cursor-native-visual-matrix
 
 Environment:

--- a/scripts/platform-smoke/live-suite-runner.mjs
+++ b/scripts/platform-smoke/live-suite-runner.mjs
@@ -477,7 +477,7 @@ function writeProcessSnapshot(logDir, name, platform) {
 		? spawnSync("powershell.exe", [
 			"-NoLogo", "-NoProfile", "-ExecutionPolicy", "Bypass", "-Command",
 			"Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Json -Compress",
-		], { encoding: "utf8", timeout: 30_000 })
+		], { encoding: "utf8", timeout: 90_000 })
 		: spawnSync("sh", ["-lc", "ps -axo pid,ppid,comm,args"], { encoding: "utf8", timeout: 30_000 });
 	writeRedactedTextFile(join(logDir, `${name}.stdout.txt`), result.stdout ?? "");
 	writeRedactedTextFile(join(logDir, `${name}.stderr.txt`), result.stderr ?? "");

--- a/scripts/platform-smoke/scenarios.mjs
+++ b/scripts/platform-smoke/scenarios.mjs
@@ -19,6 +19,11 @@ export const SCENARIOS = {
 		},
 	},
 
+	"cursor-local-resume-restart": {
+		description: "Prove guarded local resume across a pi process restart.",
+		cursorCalls: 2,
+	},
+
 	"cursor-native-visual-matrix": {
 		description: "Prove provider reality, native tool replay, card rendering, JSONL correctness.",
 		cursorCalls: 1,

--- a/scripts/platform-smoke/targets.mjs
+++ b/scripts/platform-smoke/targets.mjs
@@ -135,6 +135,8 @@ export async function runTargetSuite(config, targetName, suiteName, leaseSession
 	switch (suiteName) {
 		case "platform-build":
 			return await executePlatformBuild(config, targetName, suiteDir, slug, platform, leaseSession);
+		case "cursor-local-resume-restart":
+			return await executeLocalResumeSuite(config, targetName, suiteName, suiteDir, slug, leaseSession);
 		case "cursor-native-visual-matrix":
 		case "cursor-bridge-visual-matrix":
 		case "cursor-abort-cleanup":
@@ -490,6 +492,89 @@ export function buildPlatformBuildCommand(targetName, packageName = "pi-cursor-s
 		lines.push(`powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\\scripts\\platform-smoke\\platform-build-windows.ps1 -PackageName ${packageName} -NodeValidationMajor ${nodeValidationMajor}`);
 	}
 	return lines.join("\n");
+}
+
+async function executeLocalResumeSuite(config, targetName, suiteName, suiteDir, slug, leaseSession) {
+	const startedAt = Date.now();
+	let warmup = leaseSession;
+	const ownsLease = !warmup;
+	const command = buildLocalResumeSuiteCommand(targetName, ownsLease);
+	writeCommand(suiteDir, command);
+
+	if (!warmup) {
+		console.log(`  warmup ${targetName}...`);
+		warmup = await warmupLease(targetName, slug, config);
+		if (!warmup.ok) {
+			writeExitCode(suiteDir, warmup.code, warmup.signal);
+			writeRedactedFile(resolve(suiteDir, "crabbox.warmup.stdout.txt"), warmup.stdout);
+			writeRedactedFile(resolve(suiteDir, "crabbox.warmup.stderr.txt"), warmup.stderr);
+			return failSuite(suiteDir, targetName, suiteName, `Crabbox warmup failed (exit ${warmup.code}): ${warmup.stderr.slice(-500)}`);
+		}
+	}
+
+	console.log(`  executing local resume smoke on ${targetName}...`);
+	const result = await runOnLeaseWithTransientRetry(suiteDir, targetName, warmup.leaseId, command, {
+		shell: true,
+		timeout: 900_000,
+		allowEnv: ["CURSOR_API_KEY"],
+		sync: leaseSession?.sync,
+		config,
+	});
+	const elapsed = Date.now() - startedAt;
+	writeRedactedFile(resolve(suiteDir, "crabbox.stdout.txt"), result.stdout);
+	writeRedactedFile(resolve(suiteDir, "crabbox.stderr.txt"), result.stderr);
+	writeFileSync(resolve(suiteDir, "crabbox.timing.json"), JSON.stringify({
+		startedAt: new Date(startedAt).toISOString(),
+		elapsedMs: elapsed,
+		code: result.code,
+		signal: result.signal,
+	}, null, 2));
+	writeExitCode(suiteDir, result.code, result.signal);
+
+	let stopResult;
+	if (ownsLease) {
+		console.log(`  stopping lease ${warmup.leaseId}...`);
+		stopResult = await stopLease(targetName, warmup.leaseId, config);
+		writeStopLeaseArtifacts(suiteDir, stopResult);
+	}
+
+	const violations = [
+		...scanForSecrets(`${result.stdout}\n${result.stderr}`).map((violation) => ({ file: "process-output", violation })),
+		...scanArtifacts(suiteDir),
+	];
+	if (violations.length > 0) writeFileSync(resolve(suiteDir, "redaction-violations.json"), JSON.stringify(violations, null, 2));
+
+	const checks = [
+		{ id: "local-resume-exit-zero", fn: () => result.code === 0 },
+		{ id: "local-resume-marker", fn: () => result.stdout.includes("local-resume-smoke-ok") },
+		{ id: "local-resume-agent-id", fn: () => /agent-[0-9a-f-]{36}\s+resumed across restart/i.test(result.stderr) },
+		{ id: "no-secrets", fn: () => violations.length === 0 },
+	];
+	if (stopResult) checks.push(stopLeaseCheck(stopResult));
+	const expectedFiles = [
+		"summary.json", "target.json", "suite.json", "command.txt", "exit-code.txt",
+		"crabbox.stdout.txt", "crabbox.stderr.txt", "crabbox.timing.json", "assertions.json",
+	];
+	if (stopResult) expectedFiles.push("crabbox.stop.stdout.txt", "crabbox.stop.stderr.txt", "crabbox.stop.exit-code.txt");
+	const { assertions } = finalizeSuiteArtifacts(suiteDir, checks, {
+		target: targetName,
+		suite: suiteName,
+		exitCode: result.code,
+		signal: result.signal,
+		elapsedMs: elapsed,
+	}, expectedFiles);
+	console.log(`  ${assertions.ok ? "PASS" : "FAIL"} ${suiteName} on ${targetName} (${elapsed}ms)`);
+	return { ok: assertions.ok, suiteDir, assertions };
+}
+
+function buildLocalResumeSuiteCommand(targetName, ensureDeps = false) {
+	if (platformFor(targetName) === "powershell") {
+		const command = ensureDeps
+			? "npm ci; if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }; npm run smoke:local-resume"
+			: "npm run smoke:local-resume";
+		return `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -Command "${command}"`;
+	}
+	return ensureDeps ? "npm ci && npm run smoke:local-resume" : "npm run smoke:local-resume";
 }
 
 async function executeLiveSuite(config, targetName, suiteName, suiteDir, slug, leaseSession) {


### PR DESCRIPTION
## Summary
- add required `cursor-local-resume-restart` platform suite after existing live suites
- make the focused local-resume smoke robust for Windows and standalone platform-suite runs
- harden Windows abort process snapshot timeout observed during platform gate
- update platform smoke docs and roadmap evidence status for same-session restart only

## Validation
- `npm run check:platform-smoke`
- `npm run smoke:local-resume`
- `npm run smoke:platform:macos`
- `npm run smoke:platform:macos -- --suite cursor-local-resume-restart`
- `npm run smoke:platform:windows-native -- --suite cursor-local-resume-restart`
- `npm run smoke:platform:windows-native`
- `npm run smoke:platform:all` (final green; latest artifacts under `.artifacts/platform-smoke/latest.json`)
- `npm test`
- `npm run typecheck`
- `npm pack --dry-run`
- independent reviewer: no findings

## Behavior
No default user behavior changed. Local resume remains opt-in/default-off; this only expands proof coverage.