### PR TITLE
Validate Cursor Cloud target local state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,8 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-tool-transcript.ts` owns the raw `unknown toolCall -> transcript/display` façade; `src/cursor-transcript-tool-specs.ts`, `src/cursor-transcript-utils.ts`, and `src/cursor-transcript-tool-formatters.ts` implement spec dispatch and formatting.
 - `src/cursor-mcp-timeout-override.ts` owns Cursor SDK MCP timeout overrides: 3600s default for `callTool`, 10s default for verified initialize/listTools paths on first send, and SDK-default behavior for unknown MCP protocol stacks.
 - `src/cursor-config.ts` owns Cursor SDK config loading, parsing, source precedence, safety-cap resolution, cloud environment selection, and legacy fast-default config persistence.
+- `src/cursor-cloud-options.ts` owns cloud SDK option mapping and fail-closed preflight.
+- `src/cursor-cloud-local-state.ts` owns canonical cloud starting-ref normalization, hermetic Git probes, remote identity/refspec validation, and reasoned local-state inspection.
 - `src/cursor-cloud-lifecycle.ts` owns session-branch cloud lifecycle ledger entries and explicit `/cursor-cloud` list/archive/delete command behavior.
 - `src/cursor-durable-fs.ts` owns the canonical no-follow regular-file open (`openExistingRegularFileNoFollow`) and read-write fsync (`fsyncExistingRegularFile`) helpers used to durably fsync session/journal files without following an attacker-replaced symlink; `src/cursor-cloud-lifecycle.ts` and `src/cursor-session-agent-cleanup.ts` consume it instead of duplicating the identity-check logic.
 - `src/cursor-state.ts` owns Cursor fast/mode controls, `/cursor-tools`, local config refresh/cleanup wiring, and stable state re-exports.

--- a/README.md
+++ b/README.md
@@ -322,7 +322,59 @@ Config can also set non-secret defaults in `~/.pi/agent/cursor-sdk.json` or trus
 }
 ```
 
-Cloud/runtime keys are minimal and explicit. Defaults stay local runtime with the loopback MCP bridge as the sole Pi-tool transport, no inline cloud MCP, and no local-state/env-file forwarding. SDK `customTools` remains deferred pending SDK cancellation/deadline support. Invalid non-empty `--cursor-runtime`, `--cursor-cloud-context`, `PI_CURSOR_RUNTIME`, or `PI_CURSOR_CLOUD_CONTEXT` values fail closed instead of falling through to lower-precedence config. If `runtime` is explicitly set to `cloud` with `--cursor-runtime cloud`, `PI_CURSOR_RUNTIME=cloud`, `/cursor-runtime cloud`, or config, the provider starts a Cursor cloud agent after preflight instead of silently running local. On first interactive use, `/cursor-runtime cloud` shows one confirmation covering remote execution, fresh context by default (explicit bootstrap opt-in), unavailable Pi-local tools/bridge and Pi env forwarding, Cursor's ability to branch/commit/push/open PRs, retained cloud agents, and Max Mode billing at Cursor API pricing (including possible spend-limit setup). Cancelling that first-use confirmation writes no session or config state. Use `/cursor-runtime cloud --save-user` for a persistent personal acknowledgement or `--cursor-cloud-ack` / `PI_CURSOR_CLOUD_ACK=1` for non-interactive runs; acknowledged CLI, environment, session, or user state is not prompted again. Project config may save a cloud runtime default but not first-use acknowledgement or repo/branch/env/context/direct-push/local-state preferences. An explicit `--cursor-cloud-branch` / `PI_CURSOR_CLOUD_BRANCH` requires an explicit `--cursor-cloud-repo` / `PI_CURSOR_CLOUD_REPO` because the SDK exposes `startingRef` only on `cloud.repos` entries. Repository values must be HTTPS repository URLs without userinfo, query parameters, or fragments; invalid values fail before `Agent.create()`, and error scrubbing removes URL/SCP-style userinfo. Cloud runs use fresh context by default; pass `--cursor-cloud-context=bootstrap` / `PI_CURSOR_CLOUD_CONTEXT=bootstrap` to include prior pi context. Pass `--cursor-cloud-env-type=cloud|pool|machine` plus optional `--cursor-cloud-env-name=<name>` (or `PI_CURSOR_CLOUD_ENV_TYPE` / `PI_CURSOR_CLOUD_ENV_NAME`) to select a Cursor-managed cloud environment without forwarding local env values. Named `cloud` environments fail closed when combined with `--cursor-cloud-repo`; omit the repo or use a pool/machine environment. When a pi session has a title, cloud agents are created with that title for easier dashboard/list matching. At cloud run completion, pi streams display-only cloud telemetry when Cursor reports it: agent/run IDs, pushed branch, repository and PR URL, passive artifact paths, and raw cloud usage. Cloud runtime requires a persisted pi session and rejects `--no-session` before `Agent.send()`. Immediately after `Agent.create()` returns—and before debug work or abort checks—Pi appends a branch-local lifecycle entry, fsyncs the existing Pi session JSONL anchor through a read-write descriptor, and then fsyncs a newline-framed sidecar keyed by the stable pi session ID (POSIX mode `0600`; Windows inherits the user session directory ACL) in the session directory. Existing session files use the exact lifecycle entry ID as the branch anchor; a fileless first turn uses an orphan marker so a restart with the same session ID can claim the record onto exactly one matching or replacement branch after its new timestamped JSONL is created. That durable claim then restores normal sibling-branch isolation. It adds the returned run ID before post-send abort handling or waiting and enriches successful runs with branch/PR metadata. Readers skip individually truncated records so one interrupted append cannot hide later valid cleanup IDs. If the agent intent cannot be persisted, pi does not send; if the returned run cannot be persisted, pi requests bounded cancellation. Both paths fail closed and direct you to the Cursor Cloud dashboard for manual cleanup. `/cursor-cloud list`, `/cursor-cloud archive <bc-agentId>`, and `/cursor-cloud delete <bc-agentId> --yes` only accept exact recorded `bc-` cloud IDs. Archive/delete require resolved Cursor auth, fsync a durable intent before the SDK mutation, and fsync a durable success result afterward; an unresolved intent blocks retries and directs manual dashboard inspection instead of guessing whether an irreversible request completed. Raw cloud usage is not copied into pi message usage, context occupancy, compaction, or cost totals. The pi bridge is local-only, and pi env forwarding is not implemented yet, so `--cursor-cloud-env` forwarding-name config fails closed with Cursor-native environment setup guidance.
+### Cloud runtime and acknowledgement
+
+Cloud/runtime keys are minimal and explicit. Defaults stay local runtime with the loopback MCP bridge as the sole Pi-tool transport, no inline cloud MCP, and no local-state/env-file forwarding. SDK `customTools` remains deferred pending SDK cancellation/deadline support. Invalid non-empty `--cursor-runtime`, `--cursor-cloud-context`, `PI_CURSOR_RUNTIME`, or `PI_CURSOR_CLOUD_CONTEXT` values fail closed instead of falling through to lower-precedence config.
+
+If `runtime` is explicitly set to `cloud` with `--cursor-runtime cloud`, `PI_CURSOR_RUNTIME=cloud`, `/cursor-runtime cloud`, or config, the provider starts a Cursor cloud agent after preflight instead of silently running local.
+
+On first interactive use, `/cursor-runtime cloud` shows one confirmation covering remote execution, fresh context by default (explicit bootstrap opt-in), unavailable Pi-local tools/bridge and Pi env forwarding, Cursor's ability to branch/commit/push/open PRs, retained cloud agents, and Max Mode billing at Cursor API pricing (including possible spend-limit setup). Cancelling that first-use confirmation writes no session or config state.
+
+Use `/cursor-runtime cloud --save-user` for a persistent personal acknowledgement or `--cursor-cloud-ack` / `PI_CURSOR_CLOUD_ACK=1` for non-interactive runs; acknowledged CLI, environment, session, or user state is not prompted again.
+
+Project config may save a cloud runtime default but not first-use acknowledgement or repo/branch/env/context/direct-push/local-state preferences.
+
+### Cloud repository and local-state validation
+
+An explicit `--cursor-cloud-branch` / `PI_CURSOR_CLOUD_BRANCH` requires an explicit `--cursor-cloud-repo` / `PI_CURSOR_CLOUD_REPO` because the SDK exposes `startingRef` only on `cloud.repos` entries. Repository values must be HTTPS repository URLs without userinfo, query parameters, or fragments; invalid values fail before `Agent.create()`, and error scrubbing removes URL/SCP-style userinfo.
+
+When an explicit cloud repo matches local Git state, preflight requires exactly one remote whose effective fetch and push URLs identify that target plus a locally observable, non-symbolic remote-tracking ref uniquely covered by that remote's fetch refspec for the requested branch. Local HTTPS remotes can match the same HTTPS identity; equivalent GitHub SSH and scp-style remotes can also match. Other hosts retain transport-specific identity, and host/path matching remains conservative with GitHub-specific case and lowercase `.git` normalization.
+
+`refs/heads/<branch>` is normalized to `<branch>` for both inspection and SDK options; invalid Git branch names and other `refs/*` forms are rejected. An explicit repo without `startingRef` is unverifiable locally because the server default is unknown. Inside a Git worktree, full commit SHAs remain unverified and require the explicit local-state override because local tracking refs do not prove which matching remote contains that commit.
+
+Mismatch, ambiguity, missing refs, or Git errors fail closed. This is local tracking evidence rather than a fetch, so fetch before starting cloud work when remote state may have changed.
+
+Inspection ignores ambient Git repository/index/config environment redirection; ordinary user/system URL and refspec config may veto, but never authorize, a target match. It disables replacement-object ancestry and fails closed when local replacement or graft metadata makes ancestry ambiguous. File-mode forcing is POSIX-only. Sparse checkouts intentionally fail closed because skip-worktree entries require `--cursor-cloud-allow-local-state`. Stashes are intentionally outside validation because they are not active worktree, index, or `HEAD` state.
+
+Without an explicit repo, the current branch's locally observable remote-tracking upstream remains the comparison ref only when that remote's effective fetch and push URLs identify one repository and its fetch refspec uniquely owns that tracking ref. `--cursor-cloud-allow-local-state` / `PI_CURSOR_CLOUD_ALLOW_LOCAL_STATE=1` is the explicit override for accepting unverifiable, dirty, or unpushed local state; when active, launch skips local Git inspection while still validating the configured cloud repo/ref.
+
+### Cloud context and managed environments
+
+Cloud runs use fresh context by default; pass `--cursor-cloud-context=bootstrap` / `PI_CURSOR_CLOUD_CONTEXT=bootstrap` to include prior pi context.
+
+Pass `--cursor-cloud-env-type=cloud|pool|machine` plus optional `--cursor-cloud-env-name=<name>` (or `PI_CURSOR_CLOUD_ENV_TYPE` / `PI_CURSOR_CLOUD_ENV_NAME`) to select a Cursor-managed cloud environment without forwarding local env values. Named `cloud` environments fail closed when combined with `--cursor-cloud-repo`; omit the repo or use a pool/machine environment.
+
+### Cloud reporting and durable lifecycle
+
+When a pi session has a title, cloud agents are created with that title for easier dashboard/list matching.
+
+At cloud run completion, pi streams display-only cloud telemetry when Cursor reports it: agent/run IDs, pushed branch, repository and PR URL, passive artifact paths, and raw cloud usage.
+
+Cloud runtime requires a persisted pi session and rejects `--no-session` before `Agent.send()`.
+
+Immediately after `Agent.create()` returns—and before debug work or abort checks—Pi appends a branch-local lifecycle entry, fsyncs the existing Pi session JSONL anchor through a read-write descriptor, and then fsyncs a newline-framed sidecar keyed by the stable pi session ID (POSIX mode `0600`; Windows inherits the user session directory ACL) in the session directory.
+
+Existing session files use the exact lifecycle entry ID as the branch anchor; a fileless first turn uses an orphan marker so a restart with the same session ID can claim the record onto exactly one matching or replacement branch after its new timestamped JSONL is created. That durable claim then restores normal sibling-branch isolation. It adds the returned run ID before post-send abort handling or waiting and enriches successful runs with branch/PR metadata. Readers skip individually truncated records so one interrupted append cannot hide later valid cleanup IDs.
+
+If the agent intent cannot be persisted, pi does not send; if the returned run cannot be persisted, pi requests bounded cancellation. Both paths fail closed and direct you to the Cursor Cloud dashboard for manual cleanup.
+
+`/cursor-cloud list`, `/cursor-cloud archive <bc-agentId>`, and `/cursor-cloud delete <bc-agentId> --yes` only accept exact recorded `bc-` cloud IDs.
+
+Archive/delete require resolved Cursor auth, fsync a durable intent before the SDK mutation, and fsync a durable success result afterward; an unresolved intent blocks retries and directs manual dashboard inspection instead of guessing whether an irreversible request completed.
+
+### Cloud boundaries
+
+Raw cloud usage is not copied into pi message usage, context occupancy, compaction, or cost totals. The pi bridge is local-only, and pi env forwarding is not implemented yet, so `--cursor-cloud-env` forwarding-name config fails closed with Cursor-native environment setup guidance.
 
 Cloud lifecycle commands are explicit and session-branch scoped:
 

--- a/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
+++ b/docs/plans/cursor-sdk-capability-roadmap-2026-07-04.md
@@ -67,7 +67,7 @@ Automatic provider startup in print/JSON/RPC does not prompt and fails closed wh
 | Per-switch interactive fresh/bootstrap chooser | **Intentionally deferred/rejected** | Fresh is the safe default; explicit CLI/environment/user consent already covers higher-trust bootstrap without another prompt. |
 | Session-scoped cloud choices beyond runtime and acknowledgement | **Intentionally deferred/rejected** | Current session state persists only runtime and acknowledgement. CLI, environment, and user config already cover explicit repo/ref/context/direct-push/local-state/environment choices. Revisit only if a temporary session-only UX is approved. |
 | Explicit HTTPS repo/ref/direct-push mapping | **Implemented** | `src/cursor-cloud-options.ts`; `test/cursor-cloud-options.test.ts`. |
-| Dirty/unpushed local-state validation against the explicit cloud repo/ref target | **Still open** | Current code checks the working tree and current branch upstream only. P0.1 defines target-aware acceptance. |
+| Dirty/unpushed local-state validation against the explicit cloud repo/ref target | **Implemented** | `src/cursor-cloud-local-state.ts` matches conservative HTTPS plus GitHub SSH/scp repository identities, normalizes branch targets shared with SDK options, compares `HEAD` with a locally observable non-symbolic target tracking ref uniquely covered by the selected remote fetch refspec, isolates Git from ambient repository/index/config environment redirection while allowing ordinary user/system URL and refspec config only to veto target authorization, detects hidden-index/untracked/submodule state, rejects replacement/graft ancestry, and reports reasoned fail-closed outcomes for mismatch, ambiguity, missing refs, or Git errors; `src/cursor-provider-turn-prepare.ts` supplies the resolved target. Coverage: `test/cursor-cloud-local-state.test.ts`, `test/cursor-cloud-options.test.ts`, `test/cursor-provider-cloud-env-validation.test.ts`. |
 | Fingerprinted interactive warn-once/status behavior for unchanged dirty state | **Intentionally deferred/rejected** | Current runs fail every time unless explicitly allowed; no repeated-click UX is needed until product feedback justifies it. |
 | Pi env forwarding and `.env` reading | **Intentionally deferred/rejected** | `src/cursor-cloud-options.ts` rejects configured forwarding and directs users to Cursor-native environments; covered by `test/cursor-provider-cloud-env-validation.test.ts`. |
 | Explicit Cursor-managed cloud/pool/machine environment selection | **Implemented** | `src/cursor-cloud-options.ts`; `test/cursor-provider-stream-config.test.ts`. |
@@ -101,22 +101,17 @@ Automatic provider startup in print/JSON/RPC does not prompt and fails closed wh
 
 ## Prioritized remaining work
 
-These are separate implementation flights. This roadmap records them only.
+These are separate implementation flights. Completed flights remain recorded with their landed evidence.
 
 ### P0.1 — Target-aware repo/ref local-state validation
 
-**Status: Still open.**
+**Status: Implemented.**
 
-Current limitation: `src/cursor-cloud-options.ts` checks the working tree and current branch upstream, but does not compare explicit `cloud.repo` / `cloud.branch` with a matching local remote/tracking ref.
+`inspectCursorCloudLocalState()` now matches local HTTPS remotes against the same explicit HTTPS identity and, for GitHub, accepts equivalent `ssh://user@github.com/path` and scp-style `user@github.com:path` remotes while preserving transport-specific identity for other hosts plus conservative GitHub case/lowercase-`.git` rules. It requires exactly one remote whose Git-resolved fetch and push URLs identify that target; isolates Git from ambient repository/index/config environment redirection case-insensitively while allowing ordinary user/system URL and refspec config only to veto target authorization; uses bounded Git subprocesses with a 64 MiB output buffer; detects hidden-index, ordinary untracked, submodule, POSIX file-mode, and fsmonitor-safe state; rejects replacement/graft ancestry; and compares `HEAD` with a locally observable non-symbolic remote-tracking ref uniquely covered by that remote's fetch refspec. `refs/heads/<branch>` is normalized once for inspection and SDK options, while invalid Git branch names and other `refs/*` forms are rejected. Inside a Git worktree, an explicit repo without a starting ref and a full commit SHA are unverified because server defaults and remote commit containment cannot be proven from the available tracking evidence; `allowLocalState` is the explicit override and skips local Git probes while static repo/ref validation remains active. No-explicit-repo inspection retains current-upstream comparison. Sparse checkouts intentionally fail closed because skip-worktree entries require `allowLocalState`. This is local tracking evidence, not a fetch; users must fetch when remote state may have changed. Stashes are intentionally excluded because they are not active worktree, index, or `HEAD` state. Repo mismatch, ambiguous or mixed/rewritten remote URLs, local-only or unproven refs/upstreams, hidden index state, replacement/graft ancestry, bare repositories, absent `HEAD`, ambient Git redirection, and Git failures remain reasoned fail-closed local-only state.
 
-Acceptance criteria:
+Source anchors: `src/cursor-cloud-options.ts` (cloud option mapping and preflight), `src/cursor-cloud-local-state.ts` (target normalization, Git environment/runner, remote identity/refspec validation, and local-state inspection), and the cloud-only call in `src/cursor-provider-turn-prepare.ts`.
 
-- Normalize observable local remote URLs and match the explicit cloud repo without accepting ambiguous matches.
-- Detect unpushed commits relative to the matching explicit target ref.
-- Fail closed for unknown or ambiguous state unless `allowLocalState` is explicitly active.
-- Cover URL normalization, remote mismatch, missing tracking ref, ahead/behind, dirty state, and Git failure.
-
-Likely anchors: `src/cursor-cloud-options.ts`, `test/cursor-cloud-options.test.ts`.
+Test anchors: `test/cursor-cloud-local-state.test.ts` covers starting-ref normalization, repository discovery, environment isolation, large Git output, HTTPS and GitHub SSH/scp identity matching, target-probe provenance, wildcard/refspec ownership, ahead/behind commits, hidden index and dirty state, ambient Git redirection, replacement/graft ancestry, bare repositories, unborn `HEAD`, and Git failures; `test/cursor-cloud-options.test.ts` covers preflight messages and SDK option mapping; `test/cursor-provider-cloud-env-validation.test.ts` proves target mismatch blocks cloud agent creation.
 
 ### P0.2 — Non-interactive project-trust proof
 
@@ -222,7 +217,8 @@ Retained local evidence remains current only for its named local contracts, incl
 
 - `src/cursor-config.ts` — effective config, precedence, safety caps, project trust, fast-default migration.
 - `src/cursor-runtime-state.ts` — runtime selection, acknowledgement, status, commands.
-- `src/cursor-cloud-options.ts` — cloud preflight, repo/ref/direct-push/local-state validation, Cursor-managed environment mapping.
+- `src/cursor-cloud-options.ts` — cloud preflight, repository/direct-push options, and Cursor-managed environment mapping.
+- `src/cursor-cloud-local-state.ts` — starting-ref validation, hermetic Git probes, remote/refspec verification, and local-state inspection.
 - `src/cursor-provider-turn-prepare.ts` — cloud agent creation, context handoff, bridge/replay exclusion, naming.
 - `src/cursor-provider-turn-send.ts` — send options, run-ID persistence, abort cancellation.
 - `src/cursor-provider-turn-finalize.ts` — successful cloud reporting and outcome finalization.
@@ -239,6 +235,7 @@ Primary focused coverage:
 - `test/cursor-config.test.ts`
 - `test/cursor-runtime-state.test.ts`
 - `test/cursor-cloud-options.test.ts`
+- `test/cursor-cloud-local-state.test.ts`
 - `test/cursor-provider-stream-config.test.ts`
 - `test/cursor-provider-cloud-env-validation.test.ts`
 - `test/cursor-provider-cloud-reporting.test.ts`

--- a/src/cursor-cloud-local-state.ts
+++ b/src/cursor-cloud-local-state.ts
@@ -1,0 +1,536 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { devNull } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+export type CursorCloudLocalStateUnknownReason =
+	| { code: "bare_repo" }
+	| { code: "repository_detection_failed" }
+	| { code: "status_failed" }
+	| { code: "index_failed" }
+	| { code: "hidden_index_state" }
+	| { code: "history_probe_failed" }
+	| { code: "history_overrides" }
+	| { code: "head_unavailable" }
+	| { code: "unverified_target" }
+	| { code: "target_probe_failed" }
+	| { code: "comparison_failed" };
+
+export type CursorCloudLocalStateUnknownReasons = [
+	CursorCloudLocalStateUnknownReason,
+	...CursorCloudLocalStateUnknownReason[],
+];
+
+export type CursorCloudLocalState =
+	| { insideGitRepo: false }
+	| { insideGitRepo: true; dirty: boolean; comparison: "contains_head" | "unpushed" }
+	| {
+			insideGitRepo: true | "unknown";
+			dirty: boolean | "unknown";
+			comparison: "unknown";
+			reasons: CursorCloudLocalStateUnknownReasons;
+	  };
+
+export type CursorCloudStartingRef =
+	| { kind: "absent" }
+	| { kind: "branch" | "commit"; value: string }
+	| { kind: "unsupported" };
+
+export type CursorCloudGitRunner = (cwd: string, args: string[]) => string | undefined;
+
+type ComparisonRefResult =
+	| { kind: "found"; ref: string }
+	| { kind: "unverified" }
+	| { kind: "failed" };
+
+type RemoteResult =
+	| { kind: "found"; remote: string }
+	| { kind: "unverified" }
+	| { kind: "failed" };
+
+function isValidCursorCloudBranchName(branch: string): boolean {
+	if (!branch || branch === "HEAD") return false;
+	if (branch.startsWith("-") || branch.endsWith(".") || branch.endsWith("/") || branch.includes("..") || branch.includes("@{")) return false;
+	if (/[\x00-\x20\x7f~^:?*\[\\]/.test(branch)) return false;
+	const components = branch.split("/");
+	return components.every((component) => component.length > 0 && !component.startsWith(".") && !component.endsWith(".lock"));
+}
+
+export function normalizeCursorCloudStartingRef(value: string | undefined): CursorCloudStartingRef {
+	const ref = value?.trim();
+	if (!ref) return { kind: "absent" };
+	if (ref.startsWith("refs/heads/")) {
+		const branch = ref.slice("refs/heads/".length);
+		return isValidCursorCloudBranchName(branch) ? { kind: "branch", value: branch } : { kind: "unsupported" };
+	}
+	if (ref.startsWith("refs/")) return { kind: "unsupported" };
+	if (/^[0-9a-fA-F]{40}$/.test(ref)) return { kind: "commit", value: ref };
+	return isValidCursorCloudBranchName(ref) ? { kind: "branch", value: ref } : { kind: "unsupported" };
+}
+
+function buildCursorCloudGitEnvironment(source: NodeJS.ProcessEnv, isolateConfig: boolean): NodeJS.ProcessEnv {
+	const env: NodeJS.ProcessEnv = {};
+	for (const [name, value] of Object.entries(source)) {
+		if (name.toUpperCase().startsWith("GIT_")) continue;
+		env[name] = value;
+	}
+	if (isolateConfig) {
+		const configNullDevice = process.platform === "win32" ? "NUL" : devNull;
+		env.GIT_CONFIG_GLOBAL = configNullDevice;
+		env.GIT_CONFIG_SYSTEM = configNullDevice;
+		env.GIT_CONFIG_NOSYSTEM = "1";
+	}
+	env.GIT_NO_REPLACE_OBJECTS = "1";
+	return env;
+}
+
+export function sanitizeCursorCloudGitEnvironment(source: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+	return buildCursorCloudGitEnvironment(source, true);
+}
+
+function runGitWithEnvironment(cwd: string, args: string[], env: NodeJS.ProcessEnv): string | undefined {
+	try {
+		const output = execFileSync("git", args, {
+			cwd,
+			env,
+			encoding: "utf8",
+			stdio: ["ignore", "pipe", "ignore"],
+			timeout: 30_000,
+			maxBuffer: 64 * 1024 * 1024,
+		});
+		return output.endsWith("\n") ? output.slice(0, -1) : output;
+	} catch {
+		return undefined;
+	}
+}
+
+export function runCursorCloudGit(cwd: string, args: string[]): string | undefined {
+	return runGitWithEnvironment(cwd, args, sanitizeCursorCloudGitEnvironment());
+}
+
+function runCursorCloudGitWithUserConfig(cwd: string, args: string[]): string | undefined {
+	return runGitWithEnvironment(cwd, args, buildCursorCloudGitEnvironment(process.env, false));
+}
+
+function hasPlausibleGitMetadata(cwd: string): boolean {
+	let current = cwd;
+	while (true) {
+		if (existsSync(join(current, ".git"))) return true;
+		if (["HEAD", "config", "objects", "refs"].every((name) => existsSync(join(current, name)))) return true;
+		const parent = dirname(current);
+		if (parent === current) return false;
+		current = parent;
+	}
+}
+
+const HTTPS_REPOSITORY_PROTOCOLS = new Set(["https:"]);
+const LOCAL_REPOSITORY_PROTOCOLS = new Set(["https:", "ssh:"]);
+
+function parseRepositoryTransportUrl(value: string, protocols: ReadonlySet<string>): URL | undefined {
+	if (value !== value.trim() || /[\s\\\x00-\x1f\x7f]/.test(value)) return undefined;
+	const scheme = /^([a-z][a-z0-9+.-]*):\/\//i.exec(value);
+	if (!scheme?.[1]) return undefined;
+	const protocol = `${scheme[1].toLowerCase()}:`;
+	if (!protocols.has(protocol)) return undefined;
+	const authorityAndPath = value.slice(scheme[0].length);
+	const pathSeparator = authorityAndPath.indexOf("/");
+	if (pathSeparator <= 0) return undefined;
+	const authority = authorityAndPath.slice(0, pathSeparator);
+	const rawPath = authorityAndPath.slice(pathSeparator);
+	if (protocol === "https:" && authority.includes("@")) return undefined;
+	if (protocol === "ssh:" && authority.includes("@")) {
+		const userinfo = authority.slice(0, authority.lastIndexOf("@"));
+		if (!userinfo || userinfo.includes(":")) return undefined;
+	}
+	if (!rawPath.replace(/\/+$/, "")) return undefined;
+	for (const part of rawPath.split("/")) {
+		let decoded: string;
+		try {
+			decoded = decodeURIComponent(part);
+		} catch {
+			return undefined;
+		}
+		if (decoded === "." || decoded === ".." || /[\/\\\s\x00-\x1f\x7f]/.test(decoded)) return undefined;
+	}
+	try {
+		const url = new URL(value);
+		return url.search || url.hash || url.password || !url.hostname || url.pathname === "/" ? undefined : url;
+	} catch {
+		return undefined;
+	}
+}
+
+export function parseCursorCloudRepositoryUrl(value: string | undefined): string | undefined {
+	if (!value || value !== value.trim()) return undefined;
+	const url = parseRepositoryTransportUrl(value, HTTPS_REPOSITORY_PROTOCOLS);
+	return url && !url.username ? value : undefined;
+}
+
+function normalizeRepositoryIdentity(value: string): string | undefined {
+	if (value !== value.trim() || /[\s\\\x00-\x1f\x7f]/.test(value)) return undefined;
+	const url = parseRepositoryTransportUrl(value, LOCAL_REPOSITORY_PROTOCOLS);
+	let transport: string;
+	let host: string;
+	let pathname: string;
+	if (url) {
+		transport = url.protocol;
+		host = url.host.toLowerCase();
+		pathname = url.pathname;
+	} else {
+		if (value.includes("://") || /^[A-Za-z]:/.test(value)) return undefined;
+		const match = /^(?:[^@/:]+@)?([^@/:]+):([^?#]+)$/.exec(value);
+		if (!match?.[1] || !match[2]) return undefined;
+		transport = "scp:";
+		host = match[1].toLowerCase();
+		pathname = `/${match[2]}`;
+	}
+	pathname = pathname.replace(/\/+$/, "");
+	return host === "github.com"
+		? `${host}${pathname.replace(/\.git$/, "").toLowerCase()}`
+		: `${transport}//${host}${pathname}`;
+}
+
+function verifiedGitOutput(
+	cwd: string,
+	args: string[],
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): string | undefined {
+	const output = runGit(cwd, args);
+	if (output === undefined || verifyGit === runGit) return output;
+	return verifyGit(cwd, args) === output ? output : undefined;
+}
+
+interface GitConfigRecord {
+	key: string;
+	value: string;
+	raw: string;
+}
+
+function parseNullGitConfigRecords(output: string): GitConfigRecord[] | undefined {
+	const records = output.split("\0");
+	if (records.pop() !== "" || records.some((record) => !record)) return undefined;
+	const parsed: GitConfigRecord[] = [];
+	for (const raw of records) {
+		const separator = raw.indexOf("\n");
+		if (separator <= 0) return undefined;
+		parsed.push({ key: raw.slice(0, separator), value: raw.slice(separator + 1), raw });
+	}
+	return parsed;
+}
+
+interface ConfiguredRemoteUrls {
+	fetch: string[];
+	push: string[];
+}
+
+function readConfiguredRemoteUrls(
+	cwd: string,
+	remote: string,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): ConfiguredRemoteUrls | null | undefined {
+	const escapedRemote = remote.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+	const output = verifiedGitOutput(
+		cwd,
+		["config", "--null", "--get-regexp", `^remote\\.${escapedRemote}\\.(url|pushurl)$`],
+		runGit,
+		verifyGit,
+	);
+	if (output === undefined) return undefined;
+	const records = parseNullGitConfigRecords(output);
+	if (!records?.length) return undefined;
+	const fetch = records.filter(({ key }) => key.toLowerCase().endsWith(".url")).map(({ value }) => value);
+	const push = records.filter(({ key }) => key.toLowerCase().endsWith(".pushurl")).map(({ value }) => value);
+	return fetch.length > 0 && [...fetch, ...push].every((url) => normalizeRepositoryIdentity(url))
+		? { fetch, push }
+		: null;
+}
+
+interface UrlRewriteRule {
+	kind: "fetch" | "push";
+	prefix: string;
+	raw: string;
+}
+
+function readUrlRewriteRules(cwd: string, runGit: CursorCloudGitRunner): UrlRewriteRule[] | undefined {
+	const output = runGit(cwd, ["config", "--null", "--list"]);
+	if (output === undefined) return undefined;
+	const records = parseNullGitConfigRecords(output);
+	if (!records) return undefined;
+	const rules: UrlRewriteRule[] = [];
+	for (const { key, value, raw } of records) {
+		const normalizedKey = key.toLowerCase();
+		if (!normalizedKey.startsWith("url.")) continue;
+		if (normalizedKey.endsWith(".insteadof")) rules.push({ kind: "fetch", prefix: value, raw });
+		else if (normalizedKey.endsWith(".pushinsteadof")) rules.push({ kind: "push", prefix: value, raw });
+	}
+	return rules;
+}
+
+function selectedUrlRewriteRules(rules: UrlRewriteRule[], kind: UrlRewriteRule["kind"], url: string): string[] {
+	const matches = rules.filter((rule) => rule.kind === kind && url.startsWith(rule.prefix));
+	const longest = matches.reduce((length, rule) => Math.max(length, rule.prefix.length), 0);
+	return matches.filter((rule) => rule.prefix.length === longest).map(({ raw }) => raw).sort();
+}
+
+function urlRewriteSignature(rules: UrlRewriteRule[], urls: ConfiguredRemoteUrls): string {
+	const selected: string[] = [];
+	for (const url of urls.fetch) selected.push("fetch", ...selectedUrlRewriteRules(rules, "fetch", url));
+	if (urls.push.length > 0) {
+		for (const url of urls.push) selected.push("push", ...selectedUrlRewriteRules(rules, "fetch", url));
+	} else {
+		for (const url of urls.fetch) {
+			const pushRules = selectedUrlRewriteRules(rules, "push", url);
+			selected.push("push", ...(pushRules.length > 0 ? pushRules : selectedUrlRewriteRules(rules, "fetch", url)));
+		}
+	}
+	return selected.join("\0");
+}
+
+function urlRewriteConfigAgrees(
+	cwd: string,
+	urls: ConfiguredRemoteUrls,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): boolean {
+	if (verifyGit === runGit) return true;
+	const primary = readUrlRewriteRules(cwd, runGit);
+	const ordinary = readUrlRewriteRules(cwd, verifyGit);
+	return primary !== undefined && ordinary !== undefined
+		&& urlRewriteSignature(primary, urls) === urlRewriteSignature(ordinary, urls);
+}
+
+function listRemotes(cwd: string, runGit: CursorCloudGitRunner, verifyGit: CursorCloudGitRunner): string[] | undefined {
+	const output = verifiedGitOutput(cwd, ["remote"], runGit, verifyGit);
+	return output === undefined ? undefined : output.split("\n").filter(Boolean);
+}
+
+function resolveRemoteRepository(
+	cwd: string,
+	remote: string,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): string | null | undefined {
+	const configuredUrls = readConfiguredRemoteUrls(cwd, remote, runGit, verifyGit);
+	if (configuredUrls === undefined) return undefined;
+	if (configuredUrls === null) return null;
+	if (!urlRewriteConfigAgrees(cwd, configuredUrls, runGit, verifyGit)) return undefined;
+	const fetchUrls = verifiedGitOutput(cwd, ["remote", "get-url", "--all", remote], runGit, verifyGit);
+	const pushUrls = verifiedGitOutput(cwd, ["remote", "get-url", "--push", "--all", remote], runGit, verifyGit);
+	if (fetchUrls === undefined || pushUrls === undefined) return undefined;
+	const records = `${fetchUrls}\n${pushUrls}`.split("\n");
+	if (records.some((record) => !record)) return null;
+	const urls = records.map(normalizeRepositoryIdentity);
+	const repository = urls[0];
+	return repository && urls.every((url) => url === repository) ? repository : null;
+}
+
+function findMatchingRemote(
+	cwd: string,
+	repo: string,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): RemoteResult {
+	const target = normalizeRepositoryIdentity(repo);
+	if (!target) return { kind: "unverified" };
+	const remotes = listRemotes(cwd, runGit, verifyGit);
+	if (!remotes) return { kind: "failed" };
+	const matches: string[] = [];
+	for (const remote of remotes) {
+		const repository = resolveRemoteRepository(cwd, remote, runGit, verifyGit);
+		if (repository === undefined) return { kind: "failed" };
+		if (repository === target) matches.push(remote);
+	}
+	return matches.length === 1 ? { kind: "found", remote: matches[0]! } : { kind: "unverified" };
+}
+
+function matchRefPattern(pattern: string, ref: string): string | undefined {
+	const wildcard = pattern.indexOf("*");
+	if (wildcard === -1) return pattern === ref ? "" : undefined;
+	if (pattern.indexOf("*", wildcard + 1) !== -1) return undefined;
+	const prefix = pattern.slice(0, wildcard);
+	const suffix = pattern.slice(wildcard + 1);
+	if (ref.length < prefix.length + suffix.length || !ref.startsWith(prefix) || !ref.endsWith(suffix)) return undefined;
+	return ref.slice(prefix.length, ref.length - suffix.length);
+}
+
+function isValidFetchRefspecShape(refspec: string): boolean {
+	if (refspec.startsWith("^")) {
+		const source = refspec.slice(1);
+		return source.startsWith("refs/") && !source.includes(":") && (source.match(/\*/g)?.length ?? 0) <= 1;
+	}
+	const positive = refspec.startsWith("+") ? refspec.slice(1) : refspec;
+	if (positive.startsWith("^")) return false;
+	const separator = positive.indexOf(":");
+	const source = separator === -1 ? positive : positive.slice(0, separator);
+	const destination = separator === -1 ? undefined : positive.slice(separator + 1);
+	if (
+		!source ||
+		(separator !== -1 && positive.indexOf(":", separator + 1) !== -1) ||
+		(!source.startsWith("refs/") && !/^[0-9a-fA-F]{40}$/.test(source)) ||
+		(destination !== undefined && destination !== "" && !destination.startsWith("refs/"))
+	) return false;
+	const sourceWildcards = source.match(/\*/g)?.length ?? 0;
+	const destinationWildcards = destination?.match(/\*/g)?.length ?? 0;
+	return sourceWildcards <= 1 && sourceWildcards === destinationWildcards;
+}
+
+function parseFetchRefspecs(
+	cwd: string,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): Map<string, string[]> | undefined {
+	const output = verifiedGitOutput(cwd, ["config", "--get-regexp", "^remote\\..*\\.fetch$"], runGit, verifyGit);
+	if (output === undefined) return undefined;
+	const remotes = new Map<string, string[]>();
+	for (const line of output.split("\n")) {
+		const match = /^remote\.(.+)\.fetch\s+(.+)$/.exec(line);
+		if (!match?.[1] || !match[2] || !isValidFetchRefspecShape(match[2])) return undefined;
+		remotes.set(match[1], [...(remotes.get(match[1]) ?? []), match[2]]);
+	}
+	return remotes;
+}
+
+function sourceForDestination(refspec: string, destination: string): string | undefined {
+	const positive = refspec.startsWith("+") ? refspec.slice(1) : refspec;
+	if (positive.startsWith("^")) return undefined;
+	const separator = positive.indexOf(":");
+	if (separator === -1) return undefined;
+	const sourcePattern = positive.slice(0, separator);
+	const matched = matchRefPattern(positive.slice(separator + 1), destination);
+	if (matched === undefined) return undefined;
+	return sourcePattern.includes("*") ? sourcePattern.replace("*", matched) : matched === "" ? sourcePattern : undefined;
+}
+
+function remoteTracksBranch(
+	cwd: string,
+	remote: string,
+	branch: string,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): boolean {
+	const allRefspecs = parseFetchRefspecs(cwd, runGit, verifyGit);
+	if (!allRefspecs) return false;
+	const source = `refs/heads/${branch}`;
+	const destination = `refs/remotes/${remote}/${branch}`;
+	const selectedRefspecs = allRefspecs.get(remote) ?? [];
+	if (selectedRefspecs.some((refspec) => refspec.startsWith("^") && matchRefPattern(refspec.slice(1), source) !== undefined)) return false;
+	const writers = new Set<string>();
+	for (const [writerRemote, refspecs] of allRefspecs) {
+		for (const refspec of refspecs) {
+			const writerSource = sourceForDestination(refspec, destination);
+			if (writerSource) writers.add(`${writerRemote}\0${writerSource}`);
+		}
+	}
+	return writers.size === 1 && writers.has(`${remote}\0${source}`);
+}
+
+function resolveRemoteTrackingRef(
+	cwd: string,
+	remote: string,
+	branch: string,
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): ComparisonRefResult {
+	if (!remoteTracksBranch(cwd, remote, branch, runGit, verifyGit)) return { kind: "unverified" };
+	const ref = `refs/remotes/${remote}/${branch}`;
+	return runGit(cwd, ["for-each-ref", "--format=%(objecttype)%09%(symref)", ref]) === "commit\t"
+		? { kind: "found", ref }
+		: { kind: "unverified" };
+}
+
+function hasHistoryOverrides(cwd: string, runGit: CursorCloudGitRunner): boolean | undefined {
+	const replacements = runGit(cwd, ["for-each-ref", "--format=%(refname)", "refs/replace"]);
+	const graftsPath = runGit(cwd, ["rev-parse", "--git-path", "info/grafts"]);
+	if (replacements === undefined || graftsPath === undefined) return undefined;
+	return replacements.length > 0 || existsSync(resolve(cwd, graftsPath));
+}
+
+function resolveComparisonRef(
+	cwd: string,
+	target: { repo?: string; branch?: string },
+	runGit: CursorCloudGitRunner,
+	verifyGit: CursorCloudGitRunner,
+): ComparisonRefResult {
+	if (!target.repo) {
+		const upstream = verifiedGitOutput(
+			cwd,
+			["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"],
+			runGit,
+			verifyGit,
+		);
+		if (!upstream) return { kind: "unverified" };
+		const remotes = listRemotes(cwd, runGit, verifyGit);
+		if (!remotes) return { kind: "failed" };
+		const matches = remotes.filter((remote) => upstream.startsWith(`${remote}/`));
+		if (matches.length !== 1) return { kind: "unverified" };
+		const remote = matches[0]!;
+		const repository = resolveRemoteRepository(cwd, remote, runGit, verifyGit);
+		if (repository === undefined) return { kind: "failed" };
+		if (!repository) return { kind: "unverified" };
+		return resolveRemoteTrackingRef(cwd, remote, upstream.slice(remote.length + 1), runGit, verifyGit);
+	}
+	const ref = normalizeCursorCloudStartingRef(target.branch);
+	if (ref.kind !== "branch") return { kind: "unverified" };
+	const remote = findMatchingRemote(cwd, target.repo, runGit, verifyGit);
+	return remote.kind === "found"
+		? resolveRemoteTrackingRef(cwd, remote.remote, ref.value, runGit, verifyGit)
+		: remote;
+}
+
+export function inspectCursorCloudLocalState(
+	cwd: string,
+	target: { repo?: string; branch?: string } = {},
+	runGit: CursorCloudGitRunner = runCursorCloudGit,
+): CursorCloudLocalState {
+	const verifyGit = runGit === runCursorCloudGit ? runCursorCloudGitWithUserConfig : runGit;
+	const insideWorkTree = runGit(cwd, ["rev-parse", "--is-inside-work-tree"]);
+	if (insideWorkTree !== "true") {
+		const bareRepository = runGit(cwd, ["rev-parse", "--is-bare-repository"]);
+		if (bareRepository === "true") {
+			return { insideGitRepo: true, dirty: "unknown", comparison: "unknown", reasons: [{ code: "bare_repo" }] };
+		}
+		const gitAlive = runGit(cwd, ["--version"]) !== undefined;
+		if (gitAlive && !hasPlausibleGitMetadata(cwd)) return { insideGitRepo: false };
+		return {
+			insideGitRepo: "unknown",
+			dirty: "unknown",
+			comparison: "unknown",
+			reasons: [{ code: "repository_detection_failed" }],
+		};
+	}
+	const status = runGit(cwd, [
+		...(process.platform === "win32" ? [] : ["-c", "core.fileMode=true"]),
+		"-c", "core.fsmonitor=false", "--no-optional-locks", "status", "--porcelain=v1", "--untracked-files=normal", "--ignore-submodules=none",
+	]);
+	const indexFlags = runGit(cwd, ["ls-files", "-v", "--", ":/"]);
+	const dirty = status === undefined ? "unknown" : status.length > 0;
+	const reasons: CursorCloudLocalStateUnknownReason[] = [];
+	if (status === undefined) reasons.push({ code: "status_failed" });
+	if (indexFlags === undefined) reasons.push({ code: "index_failed" });
+	else if (indexFlags.split("\n").some((line) => /^[a-zS] /.test(line))) reasons.push({ code: "hidden_index_state" });
+	const historyOverrides = hasHistoryOverrides(cwd, runGit);
+	if (historyOverrides === undefined) reasons.push({ code: "history_probe_failed" });
+	else if (historyOverrides) reasons.push({ code: "history_overrides" });
+	const hasHead = runGit(cwd, ["rev-parse", "--verify", "HEAD"]) !== undefined;
+	if (!hasHead) reasons.push({ code: "head_unavailable" });
+	const comparisonRef = resolveComparisonRef(cwd, target, runGit, verifyGit);
+	if (comparisonRef.kind === "failed") reasons.push({ code: "target_probe_failed" });
+	else if (comparisonRef.kind === "unverified") reasons.push({ code: "unverified_target" });
+	const ahead = hasHead && comparisonRef.kind === "found" ? runGit(cwd, ["rev-list", "--count", `${comparisonRef.ref}..HEAD`]) : undefined;
+	const aheadCount = ahead !== undefined && /^\d+$/.test(ahead) ? Number(ahead) : Number.NaN;
+	if (hasHead && comparisonRef.kind === "found" && !Number.isFinite(aheadCount)) reasons.push({ code: "comparison_failed" });
+	const [firstReason, ...remainingReasons] = reasons;
+	if (firstReason) {
+		return {
+			insideGitRepo: true,
+			dirty,
+			comparison: "unknown",
+			reasons: [firstReason, ...remainingReasons],
+		};
+	}
+	return { insideGitRepo: true, dirty: dirty as boolean, comparison: aheadCount > 0 ? "unpushed" : "contains_head" };
+}
+
+export const __testUtils = { sourceForDestination };

--- a/src/cursor-cloud-options.ts
+++ b/src/cursor-cloud-options.ts
@@ -1,14 +1,11 @@
-import { execFileSync } from "node:child_process";
-import { existsSync } from "node:fs";
-import { dirname, join } from "node:path";
 import type { AgentModeOption, AgentOptions, ModelSelection } from "@cursor/sdk";
 import { isCursorCloudEnvironmentType, type CursorResolvedSdkConfig } from "./cursor-config.js";
-
-export interface CursorCloudLocalState {
-	insideGitRepo: boolean;
-	dirty: boolean;
-	unpushed: boolean;
-}
+import {
+	normalizeCursorCloudStartingRef,
+	parseCursorCloudRepositoryUrl,
+	type CursorCloudLocalState,
+	type CursorCloudLocalStateUnknownReason,
+} from "./cursor-cloud-local-state.js";
 
 export interface CursorCloudPreflightIssue {
 	code:
@@ -20,6 +17,7 @@ export interface CursorCloudPreflightIssue {
 		| "cloud_environment_type_required"
 		| "cloud_environment_repo_conflict"
 		| "cloud_branch_repo_required"
+		| "cloud_branch_invalid"
 		| "cloud_repo_invalid";
 	message: string;
 }
@@ -29,63 +27,21 @@ export interface CursorCloudPreflightResult {
 	issues: CursorCloudPreflightIssue[];
 }
 
-type GitRunner = (cwd: string, args: string[]) => string | undefined;
-
 const CLOUD_REPO_URL_MESSAGE = "Cursor cloud repository must be an HTTPS repository URL without embedded credentials, query parameters, or fragments.";
-
-export function parseCursorCloudRepositoryUrl(value: string | undefined): string | undefined {
-	const trimmed = value?.trim();
-	if (!trimmed) return undefined;
-	try {
-		const url = new URL(trimmed);
-		if (
-			url.protocol !== "https:" ||
-			url.username !== "" ||
-			url.password !== "" ||
-			url.search !== "" ||
-			url.hash !== "" ||
-			url.pathname === "/"
-		) return undefined;
-		return trimmed;
-	} catch {
-		return undefined;
-	}
-}
-
-function git(cwd: string, args: string[]): string | undefined {
-	try {
-		return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
-	} catch {
-		return undefined;
-	}
-}
-
-function hasGitMetadata(cwd: string): boolean {
-	let current = cwd;
-	while (true) {
-		if (existsSync(join(current, ".git"))) return true;
-		const parent = dirname(current);
-		if (parent === current) return false;
-		current = parent;
-	}
-}
-
-export function inspectCursorCloudLocalState(cwd: string, runGit: GitRunner = git): CursorCloudLocalState {
-	const insideGitRepo = runGit(cwd, ["rev-parse", "--is-inside-work-tree"]);
-	if (insideGitRepo !== "true") {
-		return hasGitMetadata(cwd)
-			? { insideGitRepo: true, dirty: true, unpushed: true }
-			: { insideGitRepo: false, dirty: false, unpushed: false };
-	}
-	const status = runGit(cwd, ["status", "--porcelain=v1"]);
-	const dirty = status === undefined || status.length > 0;
-	const hasHead = runGit(cwd, ["rev-parse", "--verify", "HEAD"]) !== undefined;
-	const upstream = runGit(cwd, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]);
-	const ahead = upstream ? runGit(cwd, ["rev-list", "--count", "@{upstream}..HEAD"]) : undefined;
-	const aheadCount = ahead === undefined ? Number.NaN : Number(ahead);
-	const unpushed = hasHead && (!upstream || !Number.isFinite(aheadCount) || aheadCount > 0);
-	return { insideGitRepo: true, dirty, unpushed };
-}
+const CLOUD_STARTING_REF_MESSAGE = "Cursor cloud branch/ref must be a valid Git branch name, refs/heads/<branch>, or full commit SHA; invalid branch names and other refs/* are unsupported.";
+const CLOUD_LOCAL_STATE_REASON_LABELS: Record<CursorCloudLocalStateUnknownReason["code"], string> = {
+	bare_repo: "the repository is bare",
+	repository_detection_failed: "Git could not determine whether the working directory is a repository",
+	status_failed: "Git could not determine whether the worktree or index is clean",
+	index_failed: "Git index inspection failed",
+	hidden_index_state: "the index hides worktree changes",
+	history_probe_failed: "Git could not inspect replacement or graft history overrides",
+	history_overrides: "replacement refs or graft metadata are present",
+	head_unavailable: "local HEAD is unavailable",
+	unverified_target: "the cloud target has no locally verified tracking ref",
+	target_probe_failed: "Git failed while resolving the cloud target",
+	comparison_failed: "the local HEAD comparison failed",
+};
 
 export function buildCursorCloudAgentOptions(options: {
 	apiKey: string;
@@ -101,6 +57,8 @@ export function buildCursorCloudAgentOptions(options: {
 	const configuredRepo = resolvedConfig.cloud.repo.value;
 	const repo = parseCursorCloudRepositoryUrl(configuredRepo);
 	if (configuredRepo && !repo) throw new Error(CLOUD_REPO_URL_MESSAGE);
+	const startingRef = normalizeCursorCloudStartingRef(resolvedConfig.cloud.branch.value);
+	if (startingRef.kind === "unsupported") throw new Error(CLOUD_STARTING_REF_MESSAGE);
 	const cloud = {
 		...(isCursorCloudEnvironmentType(environmentType)
 			? {
@@ -115,7 +73,7 @@ export function buildCursorCloudAgentOptions(options: {
 					repos: [
 						{
 							url: repo,
-							...(resolvedConfig.cloud.branch.value ? { startingRef: resolvedConfig.cloud.branch.value } : {}),
+							...(startingRef.kind === "branch" || startingRef.kind === "commit" ? { startingRef: startingRef.value } : {}),
 						},
 					],
 				}
@@ -133,7 +91,7 @@ export function buildCursorCloudAgentOptions(options: {
 
 export function preflightCursorCloudRuntime(options: {
 	resolvedConfig: CursorResolvedSdkConfig;
-	localState?: CursorCloudLocalState;
+	localState: CursorCloudLocalState;
 	hasPriorContext?: boolean;
 }): CursorCloudPreflightResult {
 	const { resolvedConfig } = options;
@@ -151,13 +109,22 @@ export function preflightCursorCloudRuntime(options: {
 		});
 	}
 	if (
-		options.localState?.insideGitRepo &&
-		(options.localState.dirty || options.localState.unpushed) &&
+		options.localState.insideGitRepo !== false &&
+		(options.localState.dirty !== false || options.localState.comparison !== "contains_head") &&
 		!resolvedConfig.cloud.allowLocalState.value
 	) {
+		const causes: string[] = [];
+		if (options.localState.dirty === true) causes.push("the worktree or index is dirty");
+		if (options.localState.dirty === "unknown") causes.push("Git could not determine whether the worktree or index is clean");
+		if (options.localState.comparison === "unpushed") causes.push("local HEAD contains unpushed commits");
+		if (options.localState.comparison === "unknown") {
+			causes.push(...options.localState.reasons
+				.filter((reason) => reason.code !== "status_failed")
+				.map((reason) => CLOUD_LOCAL_STATE_REASON_LABELS[reason.code]));
+		}
 		issues.push({
 			code: "local_state_not_allowed",
-			message: "Cursor cloud runtime cannot see dirty or unpushed local state; pass --cursor-cloud-allow-local-state only after accepting that risk.",
+			message: `Cursor cloud runtime cannot safely omit local state because ${causes.join("; ")}. Configure an explicit repository branch/ref with current local tracking evidence, or pass --cursor-cloud-allow-local-state only after accepting that risk.`,
 		});
 	}
 	if (resolvedConfig.cloud.envNames.value.length > 0 || resolvedConfig.cloud.envFromFiles.value) {
@@ -177,6 +144,9 @@ export function preflightCursorCloudRuntime(options: {
 			code: "cloud_branch_repo_required",
 			message: "Cursor cloud branch/ref requires --cursor-cloud-repo because the installed Cursor SDK supports startingRef only on cloud.repos entries.",
 		});
+	}
+	if (normalizeCursorCloudStartingRef(resolvedConfig.cloud.branch.value).kind === "unsupported") {
+		issues.push({ code: "cloud_branch_invalid", message: CLOUD_STARTING_REF_MESSAGE });
 	}
 	const environment = resolvedConfig.cloud.environment.value;
 	if (environment?.type && !isCursorCloudEnvironmentType(environment.type)) {

--- a/src/cursor-provider-turn-prepare.ts
+++ b/src/cursor-provider-turn-prepare.ts
@@ -32,9 +32,9 @@ import { getEffectiveCursorSettingSources } from "./cursor-setting-sources.js";
 import {
 	formatCursorCloudPreflightError,
 	buildCursorCloudAgentOptions,
-	inspectCursorCloudLocalState,
 	preflightCursorCloudRuntime,
 } from "./cursor-cloud-options.js";
+import { inspectCursorCloudLocalState } from "./cursor-cloud-local-state.js";
 import { getCursorSessionName, getCursorSessionProjectTrusted } from "./cursor-session-scope.js";
 import { resolveCursorPiToolBridgeEnabled } from "./cursor-pi-tool-bridge-env.js";
 import {
@@ -127,7 +127,12 @@ async function prepareCursorCloudProviderTurn(
 	try {
 		const preflight = preflightCursorCloudRuntime({
 			resolvedConfig,
-			localState: inspectCursorCloudLocalState(cwd),
+			localState: resolvedConfig.cloud.allowLocalState.value
+				? { insideGitRepo: false }
+				: inspectCursorCloudLocalState(cwd, {
+					repo: resolvedConfig.cloud.repo.value,
+					branch: resolvedConfig.cloud.branch.value,
+				}),
 			hasPriorContext: context.messages.length > 1,
 		});
 		if (!preflight.ok) throw new Error(formatCursorCloudPreflightError(preflight));

--- a/test/cursor-cloud-local-state.test.ts
+++ b/test/cursor-cloud-local-state.test.ts
@@ -1,0 +1,893 @@
+import { appendFileSync, chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { devNull, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	__testUtils,
+	inspectCursorCloudLocalState,
+	normalizeCursorCloudStartingRef,
+	runCursorCloudGit,
+	sanitizeCursorCloudGitEnvironment,
+	type CursorCloudGitRunner,
+} from "../src/cursor-cloud-local-state.js";
+import { preflightCursorCloudRuntime } from "../src/cursor-cloud-options.js";
+import { resolveCursorSdkConfig } from "../src/cursor-config.js";
+import { initTrackedGitRepo as initTrackedRepo, runGit as git } from "./helpers/git-repo.js";
+
+describe("Cursor cloud local state", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "pi-cursor-cloud-local-state-"));
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("scrubs Git child environment names case-insensitively and installs canonical null config", () => {
+		const env = sanitizeCursorCloudGitEnvironment({
+			PATH: "/bin",
+			git_dir: "/tmp/wrong",
+			GiT_InDeX_FiLe: "/tmp/index",
+			git_config_key_0: "url.test.insteadOf",
+			GIT_CONFIG_VALUE_0: "secret",
+			gIt_CeIlInG_DiReCtOrIeS: "/tmp",
+		});
+
+		expect(env).toEqual({
+			PATH: "/bin",
+			GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : devNull,
+			GIT_CONFIG_SYSTEM: process.platform === "win32" ? "NUL" : devNull,
+			GIT_CONFIG_NOSYSTEM: "1",
+			GIT_NO_REPLACE_OBJECTS: "1",
+		});
+	});
+
+	it("returns Git output larger than Node's default 1 MiB buffer", () => {
+		git(root, ["init"]);
+		const blobPath = join(root, "two-megabyte-blob");
+		writeFileSync(blobPath, "x".repeat(2 * 1024 * 1024));
+		const oid = git(root, ["hash-object", "-w", blobPath]);
+
+		expect(runCursorCloudGit(root, ["cat-file", "blob", oid])?.length).toBe(2 * 1024 * 1024);
+	});
+
+	it("rejects crafted refspecs whose wildcard prefix and suffix overlap", () => {
+		expect(__testUtils.sourceForDestination("+refs/heads/*:ab*bc", "abc")).toBeUndefined();
+		expect(__testUtils.sourceForDestination("+refs/heads/*:ab*bc", "abXbc")).toBe("refs/heads/X");
+	});
+
+	it("reports unborn HEAD and dirty state together in one preflight message", () => {
+		git(root, ["init"]);
+		writeFileSync(join(root, "untracked.txt"), "local");
+		const localState = inspectCursorCloudLocalState(root);
+		const result = preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({
+				cli: { runtime: "cloud", cloud: { acknowledged: true } },
+			}),
+			localState,
+		});
+
+		expect(localState).toMatchObject({
+			insideGitRepo: true,
+			dirty: true,
+			comparison: "unknown",
+			reasons: expect.arrayContaining([{ code: "head_unavailable" }, { code: "unverified_target" }]),
+		});
+		expect(result.issues[0]?.message).toContain("worktree or index is dirty");
+		expect(result.issues[0]?.message).toContain("local HEAD is unavailable");
+	});
+
+	it.each([
+		["status failure", "status_failed", (args: string[]) => args.includes("status")],
+		["index failure", "index_failed", (args: string[]) => args[0] === "ls-files"],
+		["history failure", "history_probe_failed", (args: string[]) => args.includes("refs/replace")],
+		["comparison failure", "comparison_failed", (args: string[]) => args[0] === "rev-list"],
+	] as const)("preserves %s provenance", (_label, code, shouldFail) => {
+		const runner: CursorCloudGitRunner = (_cwd, args) => {
+			if (shouldFail(args)) return undefined;
+			const command = args.join(" ");
+			if (command === "rev-parse --is-inside-work-tree") return "true";
+			if (args.includes("status")) return "";
+			if (args[0] === "ls-files") return "H file.txt";
+			if (command === "for-each-ref --format=%(refname) refs/replace") return "";
+			if (command === "rev-parse --git-path info/grafts") return ".git/info/grafts";
+			if (command === "rev-parse --verify HEAD") return "a".repeat(40);
+			if (command === "rev-parse --abbrev-ref --symbolic-full-name @{upstream}") return "origin/main";
+			if (command === "remote") return "origin";
+			if (args[0] === "config" && args.includes("--null")) {
+				return "remote.origin.url\nhttps://github.com/example/repo.git\0";
+			}
+			if (args[0] === "remote" && args.includes("get-url")) return "https://github.com/example/repo.git";
+			if (command === "config --get-regexp ^remote\\..*\\.fetch$") return "remote.origin.fetch +refs/heads/*:refs/remotes/origin/*";
+			if (args[0] === "for-each-ref" && args.at(-1) === "refs/remotes/origin/main") return "commit\t";
+			if (args[0] === "rev-list") return "0";
+			return undefined;
+		};
+
+		const state = inspectCursorCloudLocalState(root, {}, runner);
+		expect(state).toMatchObject({
+			comparison: "unknown",
+			reasons: expect.arrayContaining([{ code }]),
+		});
+	});
+
+	it.each([
+		["empty", ""],
+		["whitespace", " "],
+		["trailing whitespace", "0 "],
+		["hexadecimal", "0x0"],
+		["negative", "-1"],
+	])("rejects %s ahead-count output", (_label, ahead) => {
+		const runner: CursorCloudGitRunner = (_cwd, args) => {
+			const command = args.join(" ");
+			if (command === "rev-parse --is-inside-work-tree") return "true";
+			if (args.includes("status")) return "";
+			if (args[0] === "ls-files") return "H file.txt";
+			if (command === "for-each-ref --format=%(refname) refs/replace") return "";
+			if (command === "rev-parse --git-path info/grafts") return ".git/info/grafts";
+			if (command === "rev-parse --verify HEAD") return "a".repeat(40);
+			if (command === "rev-parse --abbrev-ref --symbolic-full-name @{upstream}") return "origin/main";
+			if (command === "remote") return "origin";
+			if (args[0] === "config" && args.includes("--null")) {
+				return "remote.origin.url\nhttps://github.com/example/repo.git\0";
+			}
+			if (args[0] === "remote" && args.includes("get-url")) return "https://github.com/example/repo.git";
+			if (command === "config --get-regexp ^remote\\..*\\.fetch$") return "remote.origin.fetch +refs/heads/*:refs/remotes/origin/*";
+			if (args[0] === "for-each-ref" && args.at(-1) === "refs/remotes/origin/main") return "commit\t";
+			if (args[0] === "rev-list") return ahead;
+			return undefined;
+		};
+
+		expect(inspectCursorCloudLocalState(root, {}, runner)).toMatchObject({
+			comparison: "unknown",
+			reasons: [{ code: "comparison_failed" }],
+		});
+	});
+
+	it.each([
+		["HEAD", "unsupported"],
+		["-bad", "unsupported"],
+		["foo..bar", "unsupported"],
+		["foo.lock", "unsupported"],
+		["bad branch", "unsupported"],
+		["bad\\branch", "unsupported"],
+		["bad~branch", "unsupported"],
+		["bad^branch", "unsupported"],
+		["bad:branch", "unsupported"],
+		["bad?branch", "unsupported"],
+		["bad*branch", "unsupported"],
+		["bad[branch", "unsupported"],
+		["foo//bar", "unsupported"],
+		["foo/@{bar", "unsupported"],
+		[".hidden", "unsupported"],
+		["foo/.hidden", "unsupported"],
+		["foo/bar.lock", "unsupported"],
+		["foo.", "unsupported"],
+		["foo/", "unsupported"],
+		["main", "branch"],
+		["feature/demo", "branch"],
+		["foo]bar", "branch"],
+		["@", "branch"],
+	] as const)("normalizes Git starting ref %s as %s", (ref, kind) => {
+		expect(normalizeCursorCloudStartingRef(ref).kind).toBe(kind);
+	});
+
+	it("normalizes refs/heads branches and preserves full commit SHAs", () => {
+		expect(normalizeCursorCloudStartingRef("refs/heads/feature/demo")).toEqual({ kind: "branch", value: "feature/demo" });
+		const sha = "a".repeat(40);
+		expect(normalizeCursorCloudStartingRef(sha)).toEqual({ kind: "commit", value: sha });
+	});
+
+	it("matches explicit HTTPS remotes without case, trailing-slash, or .git differences", () => {
+		initTrackedRepo(root, "https://GitHub.com/Example/Repo.git/");
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo",
+			branch: "refs/heads/main",
+		})).toEqual({ insideGitRepo: true, dirty: false, comparison: "contains_head" });
+	});
+
+	it.each([
+		["backslash URL", "https:\\github.com\\example\\repo.git"],
+		["leading space", " https://github.com/example/repo.git"],
+		["trailing space", "https://github.com/example/repo.git "],
+		["trailing tab", "https://github.com/example/repo.git\t"],
+		["trailing carriage return", "https://github.com/example/repo.git\r"],
+		["trailing newline", "https://github.com/example/repo.git\n"],
+		["encoded parent segment", "https://github.com/a/%2e%2e/example/repo.git"],
+		["empty userinfo", "https://@github.com/example/repo.git"],
+		["empty userinfo with delimiter", "https://:@github.com/example/repo.git"],
+	])("rejects malformed local remote identity with %s", (_label, remoteUrl) => {
+		initTrackedRepo(root, remoteUrl);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ comparison: "unknown", reasons: [{ code: "unverified_target" }] });
+	});
+
+	it.each([
+		["SSH URL", "ssh://git@github.com/Example/Repo.git"],
+		["scp URL", "git@github.com:Example/Repo.git"],
+	])("matches an explicit HTTPS repository to a %s local remote", (_label, remoteUrl) => {
+		initTrackedRepo(root, remoteUrl);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: false, comparison: "contains_head" });
+	});
+
+	it("matches mixed SSH fetch and scp push identities for the same repository", () => {
+		initTrackedRepo(root, "ssh://git@github.com/Example/Repo.git");
+		git(root, ["remote", "set-url", "--push", "origin", "git@github.com:example/repo.git"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: false, comparison: "contains_head" });
+	});
+
+	it.each([
+		["generic SSH URL", "ssh://git@git.example/repo.git", "https://git.example/repo.git"],
+		["generic scp URL", "git@git.example:repo.git", "https://git.example/repo.git"],
+		["DOS drive path", "C:repo.git", "https://c/repo.git"],
+	])("does not equate a %s with HTTPS", (_label, remoteUrl, repo) => {
+		initTrackedRepo(root, remoteUrl);
+
+		expect(inspectCursorCloudLocalState(root, { repo, branch: "main" })).toMatchObject({
+			comparison: "unknown",
+			reasons: [{ code: "unverified_target" }],
+		});
+	});
+
+	it("fails closed when SSH fetch and push identities differ", () => {
+		initTrackedRepo(root, "ssh://git@github.com/example/repo.git");
+		git(root, ["remote", "set-url", "--push", "origin", "git@github.com:example/other.git"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("does not fold path case for unknown HTTPS Git hosts", () => {
+		initTrackedRepo(root, "https://git.example/Org/Repo.git");
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://git.example/org/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it.each([
+		["mixed-case GitHub suffix", "https://github.com/example/repo.GIT", "https://github.com/example/repo"],
+		["generic-host suffix", "https://git.example/Org/Repo.git", "https://git.example/Org/Repo"],
+	])("does not normalize an unverified %s", (_label, remoteUrl, repo) => {
+		initTrackedRepo(root, remoteUrl);
+
+		expect(inspectCursorCloudLocalState(root, { repo, branch: "main" })).toMatchObject({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+		});
+	});
+
+	it("fails closed when the explicit repo does not match a local remote unless local state is allowed", () => {
+		initTrackedRepo(root);
+		const localState = inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/other/repo.git",
+			branch: "main",
+		});
+
+		expect(localState).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+		expect(preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({
+				cli: {
+					runtime: "cloud",
+					cloud: { acknowledged: true, repo: "https://github.com/other/repo.git", branch: "main" },
+				},
+			}),
+			localState,
+		}).issues.map((issue) => issue.code)).toEqual(["local_state_not_allowed"]);
+		expect(preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({
+				cli: {
+					runtime: "cloud",
+					cloud: {
+						acknowledged: true,
+						allowLocalState: true,
+						repo: "https://github.com/other/repo.git",
+						branch: "main",
+					},
+				},
+			}),
+			localState,
+		})).toEqual({ ok: true, issues: [] });
+	});
+
+	it("fails closed when more than one local remote matches the explicit repo", () => {
+		initTrackedRepo(root);
+		git(root, ["remote", "add", "mirror", "https://github.com/EXAMPLE/repo"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed when one remote has mixed repository URLs", () => {
+		initTrackedRepo(root);
+		git(root, ["config", "--add", "remote.origin.url", "https://github.com/other/repo.git"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it.each([
+		["insteadOf", ["config", "url.https://github.com/other/.insteadOf", "https://github.com/example/"]],
+		["pushInsteadOf", ["config", "url.https://github.com/other/.pushInsteadOf", "https://github.com/example/"]],
+		["pushurl", ["remote", "set-url", "--push", "origin", "https://github.com/other/repo.git"]],
+	])("fails closed when Git rewrites the effective %s destination", (_label, command) => {
+		initTrackedRepo(root);
+		git(root, command);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed when a local rewrite destination has a trailing carriage return", () => {
+		initTrackedRepo(root, "https://source.example/repo.git");
+		git(root, [
+			"config",
+			"url.https://github.com/example/repo.git\r.insteadOf",
+			"https://source.example/repo.git",
+		]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ comparison: "unknown", reasons: [{ code: "unverified_target" }] });
+	});
+
+	it("ignores global pushInsteadOf when an explicit pushurl is configured", () => {
+		initTrackedRepo(root);
+		git(root, ["remote", "set-url", "--push", "origin", "https://github.com/example/repo.git"]);
+		const home = join(root, ".git", "inactive-push-rewrite-home");
+		mkdirSync(home);
+		writeFileSync(
+			join(home, ".gitconfig"),
+			'[url "https://github.com/other/"]\n\tpushInsteadOf = https://github.com/example/\n',
+		);
+		const previousHome = process.env.HOME;
+		process.env.HOME = home;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://github.com/example/repo.git",
+				branch: "main",
+			})).toEqual({ insideGitRepo: true, dirty: false, comparison: "contains_head" });
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+		}
+	});
+
+	it("ignores a shorter global rewrite shadowed by a local longest-prefix match", () => {
+		initTrackedRepo(root, "https://source.example/org/repo.git");
+		git(root, [
+			"config",
+			"url.https://github.com/example/repo.git.insteadOf",
+			"https://source.example/org/repo.git",
+		]);
+		const home = join(root, ".git", "shadowed-rewrite-home");
+		mkdirSync(home);
+		writeFileSync(
+			join(home, ".gitconfig"),
+			'[url "https://github.com/other/"]\n\tinsteadOf = https://source.example/\n',
+		);
+		const previousHome = process.env.HOME;
+		process.env.HOME = home;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://github.com/example/repo.git",
+				branch: "main",
+			})).toEqual({ insideGitRepo: true, dirty: false, comparison: "contains_head" });
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+		}
+	});
+
+	it("fails closed for an explicit repo without a starting ref because the server default is not locally provable", () => {
+		initTrackedRepo(root);
+		const localState = inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+		});
+
+		expect(localState).toEqual({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+			reasons: [{ code: "unverified_target" }],
+		});
+		expect(preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({
+				cli: { runtime: "cloud", cloud: { acknowledged: true, repo: "https://github.com/example/repo.git" } },
+			}),
+			localState,
+		}).issues.map((issue) => issue.code)).toEqual(["local_state_not_allowed"]);
+		expect(preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({
+				cli: { runtime: "cloud", cloud: { acknowledged: true, allowLocalState: true, repo: "https://github.com/example/repo.git" } },
+			}),
+			localState,
+		})).toEqual({ ok: true, issues: [] });
+	});
+
+	it("preserves current-upstream validation when no explicit target is configured", () => {
+		initTrackedRepo(root);
+
+		expect(inspectCursorCloudLocalState(root)).toEqual({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "contains_head",
+		});
+		git(root, ["branch", "--unset-upstream"]);
+		expect(inspectCursorCloudLocalState(root)).toMatchObject({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+		});
+	});
+
+	it("fails closed without an explicit target when upstream fetch/push identity is ambiguous", () => {
+		initTrackedRepo(root);
+		git(root, ["remote", "set-url", "--push", "origin", "https://github.com/other/repo.git"]);
+
+		expect(inspectCursorCloudLocalState(root)).toMatchObject({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+		});
+	});
+
+	it("fails closed for a local-only upstream", () => {
+		initTrackedRepo(root);
+		git(root, ["config", "branch.main.remote", "."]);
+		git(root, ["config", "branch.main.merge", "refs/heads/main"]);
+
+		expect(inspectCursorCloudLocalState(root)).toMatchObject({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+		});
+	});
+
+	it("fails closed when the requested remote-tracking ref is missing", () => {
+		initTrackedRepo(root);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "missing",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it.each([
+		["missing", ["config", "--unset-all", "remote.origin.fetch"]],
+		["retargeted", ["config", "--replace-all", "remote.origin.fetch", "+refs/heads/*:refs/other/*"]],
+		["excluded", ["config", "--add", "remote.origin.fetch", "^refs/heads/main"]],
+	])("fails closed when the requested branch has a %s fetch refspec", (_label, command) => {
+		initTrackedRepo(root);
+		git(root, command);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it.each([
+		["forced negative", "+^refs/heads/main"],
+		["mismatched wildcard", "+refs/heads/main:refs/remotes/origin/*"],
+		["multiple wildcards", "+refs/heads/**:refs/remotes/origin/**"],
+	])("fails closed when a %s fetch refspec is configured", (_label, refspec) => {
+		initTrackedRepo(root);
+		git(root, ["config", "--add", "remote.origin.fetch", refspec]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed when another remote can write the target tracking ref", () => {
+		initTrackedRepo(root);
+		git(root, ["remote", "add", "other", "https://github.com/other/repo.git"]);
+		git(root, ["config", "remote.other.fetch", "+refs/heads/*:refs/remotes/origin/*"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed when another source can write the target tracking ref", () => {
+		initTrackedRepo(root);
+		git(root, ["config", "--add", "remote.origin.fetch", "+refs/other/*:refs/remotes/origin/*"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed for symbolic remote-tracking refs", () => {
+		initTrackedRepo(root);
+		git(root, ["symbolic-ref", "refs/remotes/origin/main", "refs/heads/main"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed for local refs that do not prove remote observability", () => {
+		initTrackedRepo(root);
+		git(root, ["tag", "local-only"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "refs/tags/local-only",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("detects commits ahead of the requested remote-tracking ref", () => {
+		initTrackedRepo(root);
+		appendFileSync(join(root, "src", "file.txt"), "ahead");
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "ahead"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: false, comparison: "unpushed" });
+	});
+
+	it("accepts a clean HEAD behind the requested remote-tracking ref", () => {
+		initTrackedRepo(root);
+		appendFileSync(join(root, "src", "file.txt"), "remote");
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "remote"]);
+		git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+		git(root, ["reset", "--hard", "HEAD^"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: false, comparison: "contains_head" });
+	});
+
+	it.each([
+		["assume-unchanged", ["update-index", "--assume-unchanged", "src/file.txt"]],
+		["skip-worktree", ["update-index", "--skip-worktree", "src/file.txt"]],
+	])("fails closed for tracked changes hidden by %s", (_label, command) => {
+		initTrackedRepo(root);
+		git(root, command);
+		appendFileSync(join(root, "src", "file.txt"), "hidden local change");
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("finds hidden root-level index state when inspection starts in a subdirectory", () => {
+		initTrackedRepo(root);
+		writeFileSync(join(root, "top.txt"), "base");
+		git(root, ["add", "top.txt"]);
+		git(root, ["commit", "-m", "add top-level file"]);
+		git(root, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+		git(root, ["update-index", "--skip-worktree", "top.txt"]);
+		writeFileSync(join(root, "top.txt"), "hidden local change");
+
+		expect(inspectCursorCloudLocalState(join(root, "src"), {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+			reasons: [{ code: "hidden_index_state" }],
+		});
+	});
+
+	it.skipIf(process.platform === "win32")("detects mode-only changes even when core.fileMode is disabled", () => {
+		initTrackedRepo(root);
+		git(root, ["config", "core.fileMode", "false"]);
+		chmodSync(join(root, "src", "file.txt"), 0o755);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: true, comparison: "contains_head" });
+	});
+
+	it("ignores an ambient alternate Git index", () => {
+		initTrackedRepo(root);
+		const alternateIndex = join(root, ".git", "alternate-index");
+		copyFileSync(join(root, ".git", "index"), alternateIndex);
+		git(root, ["rm", "--cached", "src/file.txt"]);
+		const previousIndex = process.env.GIT_INDEX_FILE;
+		process.env.GIT_INDEX_FILE = alternateIndex;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://github.com/example/repo.git",
+				branch: "main",
+			})).toEqual({ insideGitRepo: true, dirty: true, comparison: "contains_head" });
+		} finally {
+			if (previousIndex === undefined) delete process.env.GIT_INDEX_FILE;
+			else process.env.GIT_INDEX_FILE = previousIndex;
+		}
+	});
+
+	it("ignores ambient Git global-config redirection", () => {
+		initTrackedRepo(root, "https://github.com/other/repo.git");
+		const alternateConfig = join(root, ".git", "alternate-global-config");
+		writeFileSync(alternateConfig, '[url "https://github.com/example/"]\n\tinsteadOf = https://github.com/other/\n');
+		const previousGlobalConfig = process.env.GIT_CONFIG_GLOBAL;
+		process.env.GIT_CONFIG_GLOBAL = alternateConfig;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://github.com/example/repo.git",
+				branch: "main",
+			})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+		} finally {
+			if (previousGlobalConfig === undefined) delete process.env.GIT_CONFIG_GLOBAL;
+			else process.env.GIT_CONFIG_GLOBAL = previousGlobalConfig;
+		}
+	});
+
+	it("ignores ambient default global Git config", () => {
+		initTrackedRepo(root, "https://github.com/other/repo.git");
+		const home = join(root, ".git", "fake-home");
+		mkdirSync(home);
+		writeFileSync(join(home, ".gitconfig"), '[url "https://github.com/example/"]\n\tinsteadOf = https://github.com/other/\n');
+		const previousHome = process.env.HOME;
+		process.env.HOME = home;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://github.com/example/repo.git",
+				branch: "main",
+			})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+		}
+	});
+
+	it.each([
+		["space", " "],
+		["carriage return", "\r"],
+	])("preserves a trailing %s so ordinary URL rewrites can veto authorization", (_label, suffix) => {
+		initTrackedRepo(root);
+		const home = join(root, ".git", "whitespace-rewrite-home");
+		mkdirSync(home);
+		writeFileSync(
+			join(home, ".gitconfig"),
+			`[url "https://github.com/example/repo.git${suffix}"]\n\tinsteadOf = https://github.com/example/repo.git\n`,
+		);
+		const previousHome = process.env.HOME;
+		process.env.HOME = home;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://github.com/example/repo.git",
+				branch: "main",
+			})).toMatchObject({
+				comparison: "unknown",
+				reasons: [{ code: "target_probe_failed" }],
+			});
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+		}
+	});
+
+	it("lets ordinary global URL rewrites veto hermetic target authorization", () => {
+		initTrackedRepo(root, "https://git.example/repo.git");
+		const home = join(root, ".git", "rewrite-home");
+		mkdirSync(home);
+		writeFileSync(
+			join(home, ".gitconfig"),
+			'[url "ssh://git@git.example/other/"]\n\tinsteadOf = https://git.example/\n',
+		);
+		const previousHome = process.env.HOME;
+		process.env.HOME = home;
+
+		try {
+			expect(inspectCursorCloudLocalState(root, {
+				repo: "https://git.example/repo.git",
+				branch: "main",
+			})).toMatchObject({
+				insideGitRepo: true,
+				dirty: false,
+				comparison: "unknown",
+				reasons: [{ code: "target_probe_failed" }],
+			});
+		} finally {
+			if (previousHome === undefined) delete process.env.HOME;
+			else process.env.HOME = previousHome;
+		}
+	});
+
+	it("fails closed when replacement refs can alter ancestry", () => {
+		initTrackedRepo(root);
+		appendFileSync(join(root, "src", "file.txt"), "ahead");
+		git(root, ["add", "."]);
+		git(root, ["commit", "-m", "ahead"]);
+		git(root, ["replace", "HEAD", "refs/remotes/origin/main"]);
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("fails closed when graft metadata can alter ancestry", () => {
+		initTrackedRepo(root);
+		mkdirSync(join(root, ".git", "info"), { recursive: true });
+		writeFileSync(join(root, ".git", "info", "grafts"), "");
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toMatchObject({ insideGitRepo: true, dirty: false, comparison: "unknown" });
+	});
+
+	it("detects a dirty tree against an otherwise contained explicit target", () => {
+		initTrackedRepo(root);
+		appendFileSync(join(root, "src", "file.txt"), "dirty");
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: true, comparison: "contains_head" });
+	});
+
+	it("detects untracked files even when Git config hides them by default", () => {
+		initTrackedRepo(root);
+		git(root, ["config", "status.showUntrackedFiles", "no"]);
+		writeFileSync(join(root, "untracked.txt"), "local only");
+
+		expect(inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: true, comparison: "contains_head" });
+	});
+
+	it("detects modified submodules even when Git config hides them by default", () => {
+		const main = join(root, "main");
+		const dependency = join(root, "dependency");
+		mkdirSync(main);
+		mkdirSync(dependency);
+		initTrackedRepo(main);
+		initTrackedRepo(dependency, "https://github.com/example/dependency.git");
+		git(main, ["-c", "protocol.file.allow=always", "submodule", "add", dependency, "dependency"]);
+		git(main, ["commit", "-am", "add dependency"]);
+		git(main, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+		git(main, ["config", "submodule.dependency.ignore", "all"]);
+		appendFileSync(join(main, "dependency", "src", "file.txt"), "local only");
+
+		expect(inspectCursorCloudLocalState(main, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		})).toEqual({ insideGitRepo: true, dirty: true, comparison: "contains_head" });
+	});
+
+	it.each([
+		["remote listing", (args: string[]) => args.length === 1 && args[0] === "remote"],
+		["remote URL", (args: string[]) => args[0] === "remote" && args[1] === "get-url"],
+	] as const)("reports target_probe_failed when %s fails", (_label, shouldFail) => {
+		initTrackedRepo(root);
+		const state = inspectCursorCloudLocalState(root, {
+			repo: "https://github.com/example/repo.git",
+			branch: "main",
+		}, (cwd, args) => shouldFail(args) ? undefined : runCursorCloudGit(cwd, args));
+
+		expect(state).toMatchObject({
+			insideGitRepo: true,
+			dirty: false,
+			comparison: "unknown",
+			reasons: [{ code: "target_probe_failed" }],
+		});
+	});
+
+	it("uses --no-optional-locks for status inspection", () => {
+		initTrackedRepo(root);
+		let statusArgs: string[] | undefined;
+		inspectCursorCloudLocalState(root, {}, (cwd, args) => {
+			if (args.includes("status")) statusArgs = args;
+			return runCursorCloudGit(cwd, args);
+		});
+		expect(statusArgs).toContain("--no-optional-locks");
+	});
+
+	it("reports unknown cleanliness without claiming the worktree is dirty", () => {
+		initTrackedRepo(root);
+		const localState = inspectCursorCloudLocalState(root, {}, (cwd, args) =>
+			args.includes("status") ? undefined : runCursorCloudGit(cwd, args));
+		const result = preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({ cli: { runtime: "cloud", cloud: { acknowledged: true } } }),
+			localState,
+		});
+
+		expect(localState).toMatchObject({ dirty: "unknown", reasons: [{ code: "status_failed" }] });
+		expect(result.issues[0]?.message).toBe(
+			"Cursor cloud runtime cannot safely omit local state because Git could not determine whether the worktree or index is clean. Configure an explicit repository branch/ref with current local tracking evidence, or pass --cursor-cloud-allow-local-state only after accepting that risk.",
+		);
+		expect(result.issues[0]?.message).not.toContain("is dirty");
+	});
+
+	it("fails closed inside a bare repository", () => {
+		git(root, ["init", "--bare"]);
+
+		expect(inspectCursorCloudLocalState(root)).toEqual({
+			insideGitRepo: true,
+			dirty: "unknown",
+			comparison: "unknown",
+			reasons: [{ code: "bare_repo" }],
+		});
+	});
+
+	it("recognizes an ordinary directory when Git is available", () => {
+		expect(inspectCursorCloudLocalState(root)).toEqual({ insideGitRepo: false });
+	});
+
+	it("fails closed when repository discovery fails in an empty directory", () => {
+		const localState = inspectCursorCloudLocalState(root, {}, () => undefined);
+		const result = preflightCursorCloudRuntime({
+			resolvedConfig: resolveCursorSdkConfig({ cli: { runtime: "cloud", cloud: { acknowledged: true } } }),
+			localState,
+		});
+
+		expect(localState).toEqual({
+			insideGitRepo: "unknown",
+			dirty: "unknown",
+			comparison: "unknown",
+			reasons: [{ code: "repository_detection_failed" }],
+		});
+		expect(result.issues[0]?.message).toBe(
+			"Cursor cloud runtime cannot safely omit local state because Git could not determine whether the worktree or index is clean; Git could not determine whether the working directory is a repository. Configure an explicit repository branch/ref with current local tracking evidence, or pass --cursor-cloud-allow-local-state only after accepting that risk.",
+		);
+	});
+
+	it("fails closed when repository discovery fails in a bare repository", () => {
+		git(root, ["init", "--bare"]);
+		expect(inspectCursorCloudLocalState(root, {}, () => undefined)).toEqual({
+			insideGitRepo: "unknown",
+			dirty: "unknown",
+			comparison: "unknown",
+			reasons: [{ code: "repository_detection_failed" }],
+		});
+	});
+
+	it("fails closed when .git metadata exists but repository discovery fails", () => {
+		mkdirSync(join(root, ".git"));
+		expect(inspectCursorCloudLocalState(root, {}, () => undefined)).toMatchObject({
+			insideGitRepo: "unknown",
+			dirty: "unknown",
+			comparison: "unknown",
+		});
+	});
+});

--- a/test/cursor-cloud-options.test.ts
+++ b/test/cursor-cloud-options.test.ts
@@ -1,31 +1,14 @@
-import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { execFileSync } from "node:child_process";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
 import { resolveCursorSdkConfig } from "../src/cursor-config.js";
 import {
 	buildCursorCloudAgentOptions,
 	formatCursorCloudPreflightError,
-	inspectCursorCloudLocalState,
 	preflightCursorCloudRuntime,
 } from "../src/cursor-cloud-options.js";
 
-function git(cwd: string, args: string[]): void {
-	execFileSync("git", args, { cwd, stdio: "ignore" });
-}
+const OUTSIDE_GIT = { insideGitRepo: false } as const;
 
 describe("Cursor cloud options", () => {
-	let root: string;
-
-	beforeEach(() => {
-		root = mkdtempSync(join(tmpdir(), "pi-cursor-cloud-options-"));
-	});
-
-	afterEach(() => {
-		rmSync(root, { recursive: true, force: true });
-	});
-
 	it("builds cloud Agent options without local tools, MCP servers, or agent ids", () => {
 		const resolvedConfig = resolveCursorSdkConfig({
 			cli: {
@@ -63,11 +46,93 @@ describe("Cursor cloud options", () => {
 		expect(result).not.toHaveProperty("agentId");
 	});
 
+	it("normalizes refs/heads starting refs for SDK options", () => {
+		const resolvedConfig = resolveCursorSdkConfig({
+			cli: {
+				runtime: "cloud",
+				cloud: { acknowledged: true, repo: "https://github.com/example/repo.git", branch: "refs/heads/main" },
+			},
+		});
+
+		expect(buildCursorCloudAgentOptions({
+			apiKey: "test-key",
+			modelSelection: { id: "composer-2.5" },
+			agentMode: "agent",
+			resolvedConfig,
+		}).cloud?.repos).toEqual([{ url: "https://github.com/example/repo.git", startingRef: "main" }]);
+	});
+
+	it("rejects unsupported refs in preflight and SDK options", () => {
+		const resolvedConfig = resolveCursorSdkConfig({
+			cli: {
+				runtime: "cloud",
+				cloud: { acknowledged: true, repo: "https://github.com/example/repo.git", branch: "refs/tags/release" },
+			},
+		});
+		expect(preflightCursorCloudRuntime({ resolvedConfig, localState: OUTSIDE_GIT }).issues.map((issue) => issue.code)).toEqual(["cloud_branch_invalid"]);
+		expect(() => buildCursorCloudAgentOptions({
+			apiKey: "test-key",
+			modelSelection: { id: "composer-2.5" },
+			agentMode: "agent",
+			resolvedConfig,
+		})).toThrow("other refs/* are unsupported");
+	});
+
+	it("rejects an invalid Git branch before SDK creation", () => {
+		const resolvedConfig = resolveCursorSdkConfig({
+			cli: {
+				runtime: "cloud",
+				cloud: { acknowledged: true, repo: "https://github.com/example/repo.git", branch: "HEAD" },
+			},
+		});
+		expect(preflightCursorCloudRuntime({ resolvedConfig, localState: OUTSIDE_GIT }).issues.map((issue) => issue.code)).toEqual(["cloud_branch_invalid"]);
+		expect(() => buildCursorCloudAgentOptions({
+			apiKey: "test-key",
+			modelSelection: { id: "composer-2.5" },
+			agentMode: "agent",
+			resolvedConfig,
+		})).toThrow("valid Git branch name");
+	});
+
+	it("passes a valid Git branch name to the SDK", () => {
+		const branch = "feature/demo";
+		const resolvedConfig = resolveCursorSdkConfig({
+			cli: {
+				runtime: "cloud",
+				cloud: { acknowledged: true, repo: "https://github.com/example/repo.git", branch },
+			},
+		});
+		expect(buildCursorCloudAgentOptions({
+			apiKey: "test-key",
+			modelSelection: { id: "composer-2.5" },
+			agentMode: "agent",
+			resolvedConfig,
+		}).cloud?.repos).toEqual([{ url: "https://github.com/example/repo.git", startingRef: branch }]);
+	});
+
+	it("passes a full commit SHA to the SDK", () => {
+		const sha = "a".repeat(40);
+		const resolvedConfig = resolveCursorSdkConfig({
+			cli: {
+				runtime: "cloud",
+				cloud: { acknowledged: true, repo: "https://github.com/example/repo.git", branch: sha },
+			},
+		});
+
+		expect(buildCursorCloudAgentOptions({
+			apiKey: "test-key",
+			modelSelection: { id: "composer-2.5" },
+			agentMode: "agent",
+			resolvedConfig,
+		}).cloud?.repos).toEqual([{ url: "https://github.com/example/repo.git", startingRef: sha }]);
+	});
+
 	it.each([
 		{ directPush: false, label: "branch-only" },
 		{ directPush: true, label: "branch plus direct push" },
 	])("fails closed for $label config without a repo", ({ directPush }) => {
 		const result = preflightCursorCloudRuntime({
+			localState: OUTSIDE_GIT,
 			resolvedConfig: resolveCursorSdkConfig({
 				cli: {
 					runtime: "cloud",
@@ -83,6 +148,7 @@ describe("Cursor cloud options", () => {
 
 	it("accepts a branch when its repo is configured", () => {
 		const result = preflightCursorCloudRuntime({
+			localState: OUTSIDE_GIT,
 			resolvedConfig: resolveCursorSdkConfig({
 				cli: {
 					runtime: "cloud",
@@ -99,15 +165,24 @@ describe("Cursor cloud options", () => {
 	});
 
 	it.each([
-		"https://user:secret@example.com/org/repo.git",
-		"http://example.com/org/repo.git",
-		"https://example.com/org/repo.git?token=secret",
-		"git@example.com:org/repo.git",
-	])("rejects unsafe cloud repository URL %s without echoing it", (repo) => {
+		["embedded credentials", "https://user:secret@example.com/org/repo.git"],
+		["insecure scheme", "http://example.com/org/repo.git"],
+		["query credentials", "https://example.com/org/repo.git?token=secret"],
+		["backslashes", "https:\\github.com\\example\\repo.git"],
+		["path whitespace", "https://example.com/org/repo git"],
+		["encoded parent segment", "https://github.com/a/%2e%2e/repo.git"],
+		["encoded parent and slash", "https://github.com/a/%2e%2e%2f/repo.git"],
+		["encoded backslash", "https://github.com/a/%5c/repo.git"],
+		["encoded space", "https://github.com/a/%20/repo.git"],
+		["encoded newline", "https://github.com/a/%0a/repo.git"],
+		["empty userinfo", "https://@github.com/repo.git"],
+		["empty userinfo delimiter", "https://:@github.com/repo.git"],
+		["scp transport", "git@example.com:org/repo.git"],
+	])("rejects unsafe cloud repository URL with %s without echoing it", (_label, repo) => {
 		const resolvedConfig = resolveCursorSdkConfig({
 			cli: { runtime: "cloud", cloud: { acknowledged: true, repo } },
 		});
-		const result = preflightCursorCloudRuntime({ resolvedConfig });
+		const result = preflightCursorCloudRuntime({ resolvedConfig, localState: OUTSIDE_GIT });
 		const message = formatCursorCloudPreflightError(result);
 
 		expect(result.issues.map((issue) => issue.code)).toEqual(["cloud_repo_invalid"]);
@@ -128,7 +203,7 @@ describe("Cursor cloud options", () => {
 				user: { cloud: { contextHandoff: "never" } },
 			}),
 			hasPriorContext: true,
-			localState: { insideGitRepo: true, dirty: true, unpushed: true },
+			localState: { insideGitRepo: true, dirty: true, comparison: "unpushed" },
 		});
 
 		expect(result.ok).toBe(false);
@@ -144,6 +219,7 @@ describe("Cursor cloud options", () => {
 
 	it("fails closed when a cloud environment name is supplied without a type", () => {
 		const result = preflightCursorCloudRuntime({
+			localState: OUTSIDE_GIT,
 			resolvedConfig: resolveCursorSdkConfig({
 				cli: { runtime: "cloud", cloud: { acknowledged: true, allowLocalState: true, environment: { name: "gpu-pool" } } },
 			}),
@@ -156,6 +232,7 @@ describe("Cursor cloud options", () => {
 
 	it("fails closed when a named Cursor cloud environment is combined with an explicit repo", () => {
 		const result = preflightCursorCloudRuntime({
+			localState: OUTSIDE_GIT,
 			resolvedConfig: resolveCursorSdkConfig({
 				cli: {
 					runtime: "cloud",
@@ -176,6 +253,7 @@ describe("Cursor cloud options", () => {
 
 	it("fails closed when a cloud environment type is invalid", () => {
 		const result = preflightCursorCloudRuntime({
+			localState: OUTSIDE_GIT,
 			resolvedConfig: resolveCursorSdkConfig({
 				env: { PI_CURSOR_CLOUD_ENV_TYPE: " poll " },
 				cli: { runtime: "cloud", cloud: { acknowledged: true, allowLocalState: true } },
@@ -187,41 +265,6 @@ describe("Cursor cloud options", () => {
 		expect(formatCursorCloudPreflightError(result)).toContain('Invalid Cursor cloud environment type "poll"');
 	});
 
-	it("treats no-upstream commits and dirty files as local-only cloud state", () => {
-		git(root, ["init"]);
-		git(root, ["config", "user.email", "test@example.com"]);
-		git(root, ["config", "user.name", "Test User"]);
-		mkdirSync(join(root, "src"));
-		writeFileSync(join(root, "src", "file.txt"), "base");
-		git(root, ["add", "."]);
-		git(root, ["commit", "-m", "base"]);
-		appendFileSync(join(root, "src", "file.txt"), "dirty");
-
-		expect(inspectCursorCloudLocalState(root)).toMatchObject({ insideGitRepo: true, dirty: true, unpushed: true });
-	});
-
-	it("fails closed when git state inside a repo is unknown", () => {
-		const result = inspectCursorCloudLocalState(root, (_cwd, args) => {
-			const key = args.join(" ");
-			if (key === "rev-parse --is-inside-work-tree") return "true";
-			if (key === "rev-parse --verify HEAD") return "abc123";
-			if (key === "rev-parse --abbrev-ref --symbolic-full-name @{upstream}") return "origin/main";
-			return undefined;
-		});
-
-		expect(result).toEqual({ insideGitRepo: true, dirty: true, unpushed: true });
-	});
-
-	it("fails closed when git metadata exists but the root git probe fails", () => {
-		mkdirSync(join(root, ".git"));
-
-		expect(inspectCursorCloudLocalState(root, () => undefined)).toEqual({
-			insideGitRepo: true,
-			dirty: true,
-			unpushed: true,
-		});
-	});
-
 	it("does not require context handoff for a first cloud user prompt", () => {
 		const result = preflightCursorCloudRuntime({
 			resolvedConfig: resolveCursorSdkConfig({
@@ -231,7 +274,7 @@ describe("Cursor cloud options", () => {
 				},
 			}),
 			hasPriorContext: false,
-			localState: { insideGitRepo: true, dirty: true, unpushed: true },
+			localState: { insideGitRepo: true, dirty: true, comparison: "unpushed" },
 		});
 
 		expect(result).toEqual({ ok: true, issues: [] });

--- a/test/cursor-provider-cloud-env-validation.test.ts
+++ b/test/cursor-provider-cloud-env-validation.test.ts
@@ -1,6 +1,11 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { inspectCursorCloudLocalState } from "../src/cursor-cloud-local-state.js";
 import { registerCursorRuntimeControls } from "../src/cursor-state.js";
 import { streamCursor } from "../src/cursor-provider.js";
+import { __testUtils as cursorSessionScopeTestUtils } from "../src/cursor-session-scope.js";
 import {
 	collectEvents,
 	createPiHarness,
@@ -12,9 +17,20 @@ import {
 	mockedResume,
 	resetCursorProviderTestState,
 } from "./helpers/cursor-provider-harness.js";
+import { initTrackedGitRepo } from "./helpers/git-repo.js";
 
-describe("streamCursor cloud env request validation", () => {
-	beforeEach(resetCursorProviderTestState);
+vi.mock("../src/cursor-cloud-local-state.js", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("../src/cursor-cloud-local-state.js")>();
+	return { ...actual, inspectCursorCloudLocalState: vi.fn(actual.inspectCursorCloudLocalState) };
+});
+
+const mockedInspectCursorCloudLocalState = vi.mocked(inspectCursorCloudLocalState);
+
+describe("streamCursor cloud request validation", () => {
+	beforeEach(async () => {
+		await resetCursorProviderTestState();
+		mockedInspectCursorCloudLocalState.mockClear();
+	});
 
 	it("rejects an all-invalid PI_CURSOR_CLOUD_ENV request before SDK calls", async () => {
 		process.env.PI_CURSOR_CLOUD_ENV = "bad-name,CURSOR_SECRET,9INVALID";
@@ -43,6 +59,63 @@ describe("streamCursor cloud env request validation", () => {
 		expect(message).toContain("HTTPS repository URL without embedded credentials");
 		expect(message).not.toContain("repo-user");
 		expect(message).not.toContain("repo-secret");
+		expect(mockedCreate).not.toHaveBeenCalled();
+	});
+
+	it("blocks cloud agent creation when the explicit repo does not match the local remote", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-cursor-cloud-target-"));
+		initTrackedGitRepo(root, "https://github.com/example/local.git");
+		cursorSessionScopeTestUtils.set(root, join(root, "session.jsonl"), "test-session", true);
+		process.env.PI_CURSOR_RUNTIME = "cloud";
+		process.env.PI_CURSOR_CLOUD_ACK = "1";
+		process.env.PI_CURSOR_CLOUD_REPO = "https://github.com/example/other.git";
+		process.env.PI_CURSOR_CLOUD_BRANCH = "main";
+
+		try {
+			const events = await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+
+			expect(mockedInspectCursorCloudLocalState).toHaveBeenCalledOnce();
+			expect(getErrorEvent(events).error.errorMessage).toContain("cloud target has no locally verified tracking ref");
+			expect(mockedCreate).not.toHaveBeenCalled();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("skips local Git inspection when the explicit local-state override is active", async () => {
+		const missingRoot = join(tmpdir(), `pi-cursor-cloud-missing-${Date.now()}`);
+		cursorSessionScopeTestUtils.set(missingRoot, join(missingRoot, "session.jsonl"), "test-session", true);
+		process.env.PI_CURSOR_RUNTIME = "cloud";
+		process.env.PI_CURSOR_CLOUD_ACK = "1";
+		process.env.PI_CURSOR_CLOUD_ALLOW_LOCAL_STATE = "1";
+		const send = vi.fn().mockResolvedValue({
+			id: "run-1",
+			agentId: "bc-00000000-0000-0000-0000-000000000001",
+			status: "finished",
+			wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished", result: "cloud done" }),
+			cancel: vi.fn(),
+			supports: () => true,
+			unsupportedReason: () => undefined,
+		});
+		mockCreatedAgent({ agentId: "bc-00000000-0000-0000-0000-000000000001", send });
+
+		await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+
+		expect(mockedInspectCursorCloudLocalState).not.toHaveBeenCalled();
+		expect(mockedCreate).toHaveBeenCalledOnce();
+		expect(send).toHaveBeenCalledOnce();
+	});
+
+	it("rejects an invalid cloud branch before Agent.create", async () => {
+		process.env.PI_CURSOR_RUNTIME = "cloud";
+		process.env.PI_CURSOR_CLOUD_ACK = "1";
+		process.env.PI_CURSOR_CLOUD_ALLOW_LOCAL_STATE = "1";
+		process.env.PI_CURSOR_CLOUD_REPO = "https://github.com/example/repo.git";
+		process.env.PI_CURSOR_CLOUD_BRANCH = "foo..bar";
+
+		const events = await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+
+		expect(getErrorEvent(events).error.errorMessage).toContain("valid Git branch name");
 		expect(mockedCreate).not.toHaveBeenCalled();
 	});
 

--- a/test/helpers/git-repo.ts
+++ b/test/helpers/git-repo.ts
@@ -1,0 +1,27 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { sanitizeCursorCloudGitEnvironment } from "../../src/cursor-cloud-local-state.js";
+
+export function runGit(cwd: string, args: string[]): string {
+	return execFileSync("git", args, {
+		cwd,
+		env: sanitizeCursorCloudGitEnvironment(),
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	}).trim();
+}
+
+export function initTrackedGitRepo(cwd: string, remoteUrl = "https://github.com/example/repo.git"): void {
+	runGit(cwd, ["init"]);
+	runGit(cwd, ["config", "user.email", "test@example.com"]);
+	runGit(cwd, ["config", "user.name", "Test User"]);
+	mkdirSync(join(cwd, "src"), { recursive: true });
+	writeFileSync(join(cwd, "src", "file.txt"), "base");
+	runGit(cwd, ["add", "."]);
+	runGit(cwd, ["commit", "-m", "base"]);
+	runGit(cwd, ["branch", "-M", "main"]);
+	runGit(cwd, ["remote", "add", "origin", remoteUrl]);
+	runGit(cwd, ["update-ref", "refs/remotes/origin/main", "HEAD"]);
+	runGit(cwd, ["branch", "--set-upstream-to=origin/main"]);
+}


### PR DESCRIPTION
## Summary
- validate Cursor Cloud local state against the configured repository and starting ref
- fail closed for dirty, unpushed, ambiguous, rewritten, or otherwise unverifiable Git evidence unless `allowLocalState` is explicitly enabled
- keep local inspection cloud-only and skip Git probes under the explicit override while retaining static repo/ref validation
- document the target-aware contract and add hermetic real-Git regression coverage

## Validation
- `npm test` — 1,247 passed, 1 skipped
- `npm run typecheck`
- `npm run typecheck:tests`
- `npm pack --dry-run`
- `npm run smoke:cloud` — passed; agent `bc-bff07ad1-2b94-43fe-8ce4-0e87a9606307` archived
- `npm run smoke:platform:all` — passed all suites
  - macOS: `run-1784440566938-k9gr71`
  - Ubuntu: `run-1784440566940-174afu`
  - Windows native: `run-1784440567152-qjp3eb`
- final thermo-nuclear review — no findings
