### PR TITLE
fix: suppress raw Cursor SDK AbortError in process error guard

### DIFF
--- a/src/cursor-sdk-process-error-guard.ts
+++ b/src/cursor-sdk-process-error-guard.ts
@@ -54,6 +54,24 @@ function isCursorSdkWriteIterableClosedError(error: unknown): boolean {
 	);
 }
 
+// The Cursor SDK aborts an in-flight controlled-exec turn via its internal
+// `AbortController.abort()` (user interrupt or stall-detector cancellation),
+// which surfaces as a raw `DOMException [AbortError]` rather than a
+// `ConnectError`. `classifyCursorConnectError` returns undefined for it, so it
+// otherwise falls through the emit patch and terminates the process. A
+// DOMException is not `instanceof Error`, so match structurally on the
+// `AbortError` name plus the same `@cursor/sdk/dist` stack provenance the
+// WriteIterableClosedError recognizer uses, keeping unrelated AbortErrors fatal.
+function isCursorSdkAbortError(error: unknown): boolean {
+	if (typeof error !== "object" || error === null) return false;
+	const { name, stack } = error as { name?: unknown; stack?: unknown };
+	return (
+		name === "AbortError" &&
+		typeof stack === "string" &&
+		/(?:^|[\\/])node_modules[\\/]@cursor[\\/]sdk[\\/]dist[\\/]/.test(stack)
+	);
+}
+
 // The exact observed incident: the Cursor SDK 1.0.23 local shell executor writes a
 // spawned child's stdin without a stream 'error' listener, so a child exiting while
 // a write is in flight surfaces a raw `write EPIPE` uncaught exception whose stack
@@ -95,6 +113,7 @@ function shouldSuppressProcessError(event: string | symbol, args: readonly unkno
 		return containLocalTransportClosedPipeError();
 	}
 	if (isCursorSdkWriteIterableClosedError(error)) return activeSessions.size > 0;
+	if (isCursorSdkAbortError(error)) return hasActiveAbortSuppression();
 	const classification = classifyCursorConnectError(error);
 	if (!classification) return false;
 	if (classification.kind === "abort") return hasActiveAbortSuppression();

--- a/test/cursor-sdk-process-error-guard.test.ts
+++ b/test/cursor-sdk-process-error-guard.test.ts
@@ -94,6 +94,24 @@ function makeCursorSdkWriteIterableClosedError(): Error {
 	return error;
 }
 
+function makeCursorSdkRawAbortDomException(): DOMException {
+	const error = new DOMException("This operation was aborted", "AbortError");
+	error.stack =
+		"AbortError: This operation was aborted\n" +
+		"    at AbortSignal.abort (/repo/node_modules/@cursor/sdk/dist/esm/996.js:1:5705)\n" +
+		"    at Y.onStall (/repo/node_modules/@cursor/sdk/dist/esm/357.js:1:75246)";
+	return error;
+}
+
+function makeCursorSdkRawAbortError(): Error {
+	const error = new Error("This operation was aborted");
+	error.name = "AbortError";
+	error.stack =
+		"AbortError: This operation was aborted\n" +
+		"    at abort (/repo/node_modules/@cursor/sdk/dist/esm/index.js:1:1125976)";
+	return error;
+}
+
 function makeCursorSdkUnauthenticatedConnectError(): Error & { rawMessage: string; code: number } {
 	const error = new Error("[unauthenticated] Error") as Error & { rawMessage: string; code: number };
 	error.name = "ConnectError";
@@ -494,6 +512,114 @@ setTimeout(() => console.log("survived"), 20);
 		} finally {
 			process.removeListener("uncaughtException", listener);
 			suppression.dispose();
+		}
+	});
+
+	it("suppresses a raw Cursor SDK DOMException AbortError while a suppressing provider turn is active", () => {
+		const turnGuard = installCursorSdkProcessErrorGuard();
+		turnGuard.suppressAbortErrors();
+		let listenerCalled = false;
+		const listener = () => {
+			listenerCalled = true;
+		};
+		process.once("uncaughtException", listener);
+		try {
+			const emitted = process.emit("uncaughtException", makeCursorSdkRawAbortDomException(), "uncaughtException");
+			expect(emitted).toBe(true);
+			expect(listenerCalled).toBe(false);
+		} finally {
+			process.removeListener("uncaughtException", listener);
+			turnGuard.dispose();
+		}
+	});
+
+	it("suppresses a raw Cursor SDK DOMException AbortError via the unhandledRejection path when suppression is active", () => {
+		const turnGuard = installCursorSdkProcessErrorGuard();
+		turnGuard.suppressAbortErrors();
+		let listenerCalled = false;
+		const listener = () => {
+			listenerCalled = true;
+		};
+		process.once("unhandledRejection", listener);
+		try {
+			const emitted = process.emit("unhandledRejection", makeCursorSdkRawAbortDomException(), Promise.resolve());
+			expect(emitted).toBe(true);
+			expect(listenerCalled).toBe(false);
+		} finally {
+			process.removeListener("unhandledRejection", listener);
+			turnGuard.dispose();
+		}
+	});
+
+	it("does not suppress a Cursor SDK AbortError for a provider turn that has not declared abort suppression", () => {
+		const turnGuard = installCursorSdkProcessErrorGuard();
+		let listenerCalled = false;
+		const listener = () => {
+			listenerCalled = true;
+		};
+		process.once("uncaughtException", listener);
+		try {
+			const emitted = process.emit("uncaughtException", makeCursorSdkRawAbortDomException(), "uncaughtException");
+			expect(emitted).toBe(true);
+			expect(listenerCalled).toBe(true);
+		} finally {
+			process.removeListener("uncaughtException", listener);
+			turnGuard.dispose();
+		}
+	});
+
+	it("suppresses a plain Error AbortError variant with Cursor SDK provenance when suppression is active", () => {
+		const turnGuard = installCursorSdkProcessErrorGuard();
+		turnGuard.suppressAbortErrors();
+		let listenerCalled = false;
+		const listener = () => {
+			listenerCalled = true;
+		};
+		process.once("uncaughtException", listener);
+		try {
+			const emitted = process.emit("uncaughtException", makeCursorSdkRawAbortError(), "uncaughtException");
+			expect(emitted).toBe(true);
+			expect(listenerCalled).toBe(false);
+		} finally {
+			process.removeListener("uncaughtException", listener);
+			turnGuard.dispose();
+		}
+	});
+
+	it("does not suppress an AbortError without Cursor SDK stack provenance", () => {
+		const turnGuard = installCursorSdkProcessErrorGuard();
+		turnGuard.suppressAbortErrors();
+		const error = makeCursorSdkRawAbortDomException();
+		error.stack = "AbortError: This operation was aborted\n    at abort (/repo/src/app.ts:1:1)";
+		let listenerCalled = false;
+		const listener = () => {
+			listenerCalled = true;
+		};
+		process.once("uncaughtException", listener);
+		try {
+			const emitted = process.emit("uncaughtException", error, "uncaughtException");
+			expect(emitted).toBe(true);
+			expect(listenerCalled).toBe(true);
+		} finally {
+			process.removeListener("uncaughtException", listener);
+			turnGuard.dispose();
+		}
+	});
+
+	it("does not suppress a Cursor SDK AbortError when no provider turn is active", () => {
+		const sessionGuard = installCursorSdkSessionProcessErrorGuard();
+		let listenerCalled = false;
+		const listener = () => {
+			listenerCalled = true;
+		};
+		process.once("uncaughtException", listener);
+		try {
+			const emitted = process.emit("uncaughtException", makeCursorSdkRawAbortDomException(), "uncaughtException");
+			expect(emitted).toBe(true);
+			expect(listenerCalled).toBe(true);
+		} finally {
+			process.removeListener("uncaughtException", listener);
+			sessionGuard.dispose();
 		}
 	});
 


### PR DESCRIPTION
## Summary

Fixes an intermittent process crash when `pi-cursor-sdk` is the active provider: a raw `DOMException [AbortError]` raised by `@cursor/sdk`'s internal `AbortController.abort()` was terminating the pi process instead of being suppressed like the other Cursor SDK abort surfaces.

## Background

When a user interrupts a turn (Ctrl+C) or the SDK's stall detector cancels a run, `@cursor/sdk` aborts the in-flight controlled-exec turn. Most of the time that abort surfaces as a `ConnectError` whose `kind` classifies as `abort`, which the process-error guard already suppresses while abort suppression is active. But the SDK also surfaces the same cancellation as a **raw** `DOMException [AbortError]` (not wrapped in a `ConnectError`). `classifyCursorConnectError` returns `undefined` for a raw `DOMException`, so `shouldSuppressProcessError` fell through and the error propagated out of the `process.emit` patch. Since pi installs no `uncaughtException` handler by design, the process terminated. This happens most often on slow models / high thinking levels where cancellations are more likely.

## Fix

Add a targeted `isCursorSdkAbortError` recognizer that fires inside `shouldSuppressProcessError` before the `classifyCursorConnectError` gate, mirroring the existing `isCursorSdkWriteIterableClosedError` precedent:

- Matches structurally on `name === "AbortError"` plus an `@cursor/sdk/dist` `node_modules` stack frame (the same provenance regex the WriteIterableClosed recognizer uses). It does **not** rely on `instanceof Error`, because a `DOMException` is not always an `Error` across Node versions.
- Gates suppression on `hasActiveAbortSuppression()` — the **same** condition the wrapped `ConnectError` abort case uses on the next line — so the raw and wrapped forms of the same abort are handled identically. `suppressAbortErrors()` is set synchronously by the abort listener the moment the interrupt/stall-cancellation fires, before the DOMException surfaces, so this covers the real crash path.

Anything else stays fatal: an `AbortError` without `@cursor/sdk` provenance, and an `AbortError` during a provider turn that never declared abort suppression (or with no active turn at all), all continue to propagate normally.

## Testing

Added six focused cases to `test/cursor-sdk-process-error-guard.test.ts` covering: suppression of a raw `DOMException` `AbortError` via both the `uncaughtException` and `unhandledRejection` paths; the non-`DOMException` plain-`Error` variant; and three negatives — an active turn that did not declare suppression, foreign (non-`@cursor/sdk`) stack provenance, and a session guard with no active provider turn. The full guard suite passes (52 tests) and `npm run typecheck` is clean.

Closes #174

AI was used for assistance.
