### PR TITLE
fix: initialize Cursor SDK bundled ripgrep path (#178)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-provider-lazy.ts` owns the lazy `streamSimple` wrapper that defers Cursor provider runtime imports until the provider is invoked.
 - `src/cursor-session-scope.ts` owns pi session cwd, session file/id/name/generation scope keys, and `session_start` / `session_info_changed` registration for session-agent pooling, cloud agent names, and debug grouping.
 - `src/cursor-http1.ts` owns branch-scoped local HTTP/1.1 session state, global-preference override tracking, and extension-owned SDK configuration/null reset.
+- `src/cursor-ripgrep-path.ts` owns bundled Cursor SDK platform ripgrep resolution and local-agent environment initialization.
 - `src/cursor-session-agent.ts` owns session-scoped SDK agent pooling, transport-aware pool identity, send-state commits, busy tracking for in-flight SDK `run.wait()` work, and scoped acquire/dispose state.
 - `src/cursor-session-agent-lifecycle.ts` owns lazy session-agent lifecycle invalidation on model select, compaction, tree navigation, shutdown, and scope changes, including shutdown-time HTTP transport reset before module reload.
 - `src/cursor-session-compaction-prep.ts` owns `prepareCursorSessionForCompaction()` (release scoped live runs, reset pooled agent) wired from `session_before_compact` in `src/index.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add strictly opt-in Cursor Cloud pull-request controls: `--cursor-cloud-auto-create-pr` / `PI_CURSOR_CLOUD_AUTO_CREATE_PR` / `cloud.autoCreatePR` and `--cursor-cloud-skip-reviewer-request` / `PI_CURSOR_CLOUD_SKIP_REVIEWER_REQUEST` / `cloud.skipReviewerRequest`. Unset controls remain omitted from SDK options, project config is excluded, and local runtime behavior is unchanged.
 - Add strictly opt-in local-agent HTTP/1.1/SSE compatibility through `PI_CURSOR_HTTP_1_1`, `/cursor-http [on|off|toggle]`, and user `cursor-sdk.json` `local.useHttp1ForAgent`, resolved as session > environment > user > unset. Explicit values configure the Cursor SDK before local agent creation, session shutdown clears extension-owned SDK transport state before module reload, transport choices split the pooled agent key, and enabled local status shows `http1`; cloud and unset/default behavior remain unchanged. The pool-key shape change makes pre-upgrade local resume handles rebootstrap once; superseded handles remain eligible for explicit `/cursor-local-resume-cleanup`.
 
+### Fixed
+
+- Initialize `CURSOR_RIPGREP_PATH` from the installed Cursor SDK platform package before local agent creation, including nested npm dependency layouts, so Cursor-native Grep/Glob can use the bundled executable.
+
 ### Changed
 
 - Expand the maintainer-only `npm run smoke:cloud` release gate to create, seed, and delete a private UUID-named GitHub repository while proving cancel, starting-ref branch, direct-push, missing-branch, lifecycle-delete, exact agent cleanup, and authenticated repository-deletion contracts. Add fail-closed `SIGINT`/`SIGTERM` handling, including a real event-loop checkpoint before the atomic evidence commit and handlers retained through process teardown, plus account-conditional artifact/raw-usage observations. The gate now requires `gh` authorization to create/push/delete private repositories; product runtime behavior and defaults are unchanged.

--- a/src/cursor-provider-turn-prepare.ts
+++ b/src/cursor-provider-turn-prepare.ts
@@ -2,6 +2,7 @@ import type { Context, SimpleStreamOptions } from "@earendil-works/pi-ai/compat"
 import type { AgentModeOption, ModelSelection, SDKAgent } from "@cursor/sdk";
 import { configureCursorSdkHttp1 } from "./cursor-http1.js";
 import { installCursorMcpToolTimeoutOverride } from "./cursor-mcp-timeout-override.js";
+import { ensureCursorRipgrepPath } from "./cursor-ripgrep-path.js";
 import { installCursorSdkOutputFilter, suppressCursorSdkOutput } from "./cursor-sdk-output-filter.js";
 import {
 	acquireSessionCursorAgent,
@@ -247,6 +248,7 @@ async function prepareCursorLocalProviderTurn(
 	let completed = false;
 
 	try {
+		ensureCursorRipgrepPath();
 		const localSafety = {
 			autoReview: resolvedConfig.local.autoReview.value,
 			sandboxEnabled: resolvedConfig.local.sandboxEnabled.value,

--- a/src/cursor-ripgrep-path.ts
+++ b/src/cursor-ripgrep-path.ts
@@ -1,14 +1,19 @@
 import { accessSync, constants } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 
-const require = createRequire(import.meta.url);
 const RIPGREP_ENV = "CURSOR_RIPGREP_PATH";
 
-export function resolveBundledCursorRipgrepPath(): string | undefined {
+export function resolveBundledCursorRipgrepPath(
+	fromModuleUrl: string | URL = import.meta.url,
+): string | undefined {
 	try {
+		const require = createRequire(fromModuleUrl);
 		const platformPackage = `@cursor/sdk-${process.platform}-${process.arch}`;
-		const packageDirectory = dirname(require.resolve(`${platformPackage}/package.json`));
+		const sdkEntry = require.resolve("@cursor/sdk");
+		const packageDirectory = dirname(
+			require.resolve(`${platformPackage}/package.json`, { paths: [dirname(sdkEntry)] }),
+		);
 		const ripgrepPath = join(packageDirectory, "bin", process.platform === "win32" ? "rg.exe" : "rg");
 		accessSync(ripgrepPath, constants.X_OK);
 		return ripgrepPath;
@@ -19,7 +24,7 @@ export function resolveBundledCursorRipgrepPath(): string | undefined {
 
 export function ensureCursorRipgrepPath(): string | undefined {
 	const configuredPath = process.env[RIPGREP_ENV];
-	if (configuredPath) return configuredPath;
+	if (configuredPath && isAbsolute(configuredPath)) return configuredPath;
 
 	const bundledPath = resolveBundledCursorRipgrepPath();
 	if (bundledPath) process.env[RIPGREP_ENV] = bundledPath;

--- a/src/cursor-ripgrep-path.ts
+++ b/src/cursor-ripgrep-path.ts
@@ -1,0 +1,27 @@
+import { accessSync, constants } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+
+const require = createRequire(import.meta.url);
+const RIPGREP_ENV = "CURSOR_RIPGREP_PATH";
+
+export function resolveBundledCursorRipgrepPath(): string | undefined {
+	try {
+		const platformPackage = `@cursor/sdk-${process.platform}-${process.arch}`;
+		const packageDirectory = dirname(require.resolve(`${platformPackage}/package.json`));
+		const ripgrepPath = join(packageDirectory, "bin", process.platform === "win32" ? "rg.exe" : "rg");
+		accessSync(ripgrepPath, constants.X_OK);
+		return ripgrepPath;
+	} catch {
+		return undefined;
+	}
+}
+
+export function ensureCursorRipgrepPath(): string | undefined {
+	const configuredPath = process.env[RIPGREP_ENV];
+	if (configuredPath) return configuredPath;
+
+	const bundledPath = resolveBundledCursorRipgrepPath();
+	if (bundledPath) process.env[RIPGREP_ENV] = bundledPath;
+	return bundledPath;
+}

--- a/test/cursor-provider-stream-config.test.ts
+++ b/test/cursor-provider-stream-config.test.ts
@@ -29,7 +29,7 @@ import { __testUtils as cursorSessionScopeTestUtils } from "../src/cursor-sessio
 import type { Context } from "@earendil-works/pi-ai/compat";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 async function setCursorModeForProviderTest(mode: "agent" | "plan"): Promise<void> {
 	const pi = createPiHarness({ flagValues: { "cursor-mode": mode } });
@@ -56,6 +56,32 @@ describe("streamCursor prompt and model config", () => {
 		await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
 
 		expect(mockedCreate.mock.calls[0][0].local).toEqual({ cwd: process.cwd(), settingSources: ["all"] });
+	});
+
+	it("sets absolute CURSOR_RIPGREP_PATH before local Agent.create", async () => {
+		delete process.env.CURSOR_RIPGREP_PATH;
+		let pathAtCreate: string | undefined;
+		mockedCreate.mockImplementation(async () => {
+			pathAtCreate = process.env.CURSOR_RIPGREP_PATH;
+			return asMockSdkAgent({
+				send: vi.fn().mockResolvedValue({
+					id: "run-1",
+					agentId: "agent-1",
+					status: "finished",
+					wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished" }),
+					cancel: vi.fn(),
+					supports: () => true,
+					unsupportedReason: () => undefined,
+				}),
+			});
+		});
+
+		await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+
+		expect(mockedCreate).toHaveBeenCalledTimes(1);
+		expect(pathAtCreate).toBeTruthy();
+		expect(isAbsolute(pathAtCreate!)).toBe(true);
+		expect(pathAtCreate!.replaceAll("\\", "/")).toContain(`@cursor/sdk-${process.platform}-${process.arch}`);
 	});
 
 	it("passes enabled local safety controls from env into Agent.create", async () => {

--- a/test/cursor-ripgrep-path.test.ts
+++ b/test/cursor-ripgrep-path.test.ts
@@ -1,4 +1,18 @@
-import { accessSync, constants } from "node:fs";
+import {
+	accessSync,
+	chmodSync,
+	constants,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	realpathSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import {
 	ensureCursorRipgrepPath,
@@ -6,6 +20,8 @@ import {
 } from "../src/cursor-ripgrep-path.js";
 
 const originalRipgrepPath = process.env.CURSOR_RIPGREP_PATH;
+const platformPackage = `@cursor/sdk-${process.platform}-${process.arch}`;
+const rgBinaryName = process.platform === "win32" ? "rg.exe" : "rg";
 
 afterEach(() => {
 	if (originalRipgrepPath === undefined) delete process.env.CURSOR_RIPGREP_PATH;
@@ -17,11 +33,65 @@ describe("Cursor ripgrep path", () => {
 		const ripgrepPath = resolveBundledCursorRipgrepPath();
 
 		if (!ripgrepPath) throw new Error("Expected the installed Cursor SDK platform package to include ripgrep");
-		expect(ripgrepPath.replaceAll("\\", "/")).toContain(`@cursor/sdk-${process.platform}-${process.arch}`);
+		expect(ripgrepPath.replaceAll("\\", "/")).toContain(platformPackage);
 		expect(() => accessSync(ripgrepPath, constants.X_OK)).not.toThrow();
 	});
 
-	it("configures an empty path without overriding an existing value", () => {
+	it("resolves a platform package nested under @cursor/sdk/node_modules", () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-cursor-ripgrep-nested-"));
+		try {
+			const consumerDir = join(root, "consumer");
+			const consumerModule = join(consumerDir, "index.js");
+			const sdkDir = join(consumerDir, "node_modules", "@cursor", "sdk");
+			const nestedPlatformDir = join(sdkDir, "node_modules", "@cursor", `sdk-${process.platform}-${process.arch}`);
+			const nestedBinDir = join(nestedPlatformDir, "bin");
+			const nestedRg = join(nestedBinDir, rgBinaryName);
+
+			mkdirSync(nestedBinDir, { recursive: true });
+			writeFileSync(join(sdkDir, "package.json"), JSON.stringify({ name: "@cursor/sdk", version: "1.0.23", main: "index.js" }));
+			writeFileSync(join(sdkDir, "index.js"), "module.exports = {};\n");
+			writeFileSync(
+				join(nestedPlatformDir, "package.json"),
+				JSON.stringify({ name: platformPackage, version: "1.0.23", bin: { rg: `bin/${rgBinaryName}` } }),
+			);
+			writeFileSync(nestedRg, "#!/bin/sh\nexit 0\n");
+			chmodSync(nestedRg, 0o755);
+			writeFileSync(consumerModule, "export {};\n");
+
+			// Nested only — no hoisted platform package beside @cursor/sdk.
+			const consumerRequire = createRequire(consumerModule);
+			expect(() => consumerRequire.resolve(`${platformPackage}/package.json`)).toThrow();
+			expect(consumerRequire.resolve("@cursor/sdk")).toBe(realpathSync(join(sdkDir, "index.js")));
+
+			const resolved = resolveBundledCursorRipgrepPath(pathToFileURL(consumerModule));
+			expect(resolved).toBe(realpathSync(nestedRg));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("locks installed @cursor/sdk 1.0.23 Agent.create ripgrep contract", () => {
+		const require = createRequire(import.meta.url);
+		const sdkEntry = require.resolve("@cursor/sdk");
+		const sdkRoot = join(dirname(sdkEntry), "..", "..");
+		const sdkPackage = JSON.parse(readFileSync(join(sdkRoot, "package.json"), "utf8")) as { version: string };
+		expect(sdkPackage.version).toBe("1.0.23");
+
+		// Agent.create lives in the local-runtime chunk (esm/357.js beside cjs entry's sibling esm).
+		const bundle = readFileSync(join(sdkRoot, "dist", "esm", "357.js"), "utf8");
+
+		// Absolute CURSOR_RIPGREP_PATH wins; otherwise search from process.argv[1]; then configure.
+		expect(bundle).toMatch(
+			/process\.env\.CURSOR_RIPGREP_PATH;w=\w+&&\(0,\w+\.isAbsolute\)\(\w+\)\?\w+:W\(\w+\),\w+\|\|\(\w+=\(0,\w+\.Qd\)\(\)\),\w+&&\(0,\w+\.J\)\(\w+\)/,
+		);
+		expect(bundle).toContain("if(!process.argv[1])return;");
+		expect(bundle).toContain("node_modules");
+		expect(bundle).toContain("`@cursor/sdk-${t}`");
+		expect(bundle).toContain('throw new Error("configureRipgrepPath: path must not be empty")');
+		expect(bundle).toContain("Ripgrep path not configured. Call configureRipgrepPath() at startup.");
+	});
+
+	it("configures an empty path without overriding an existing absolute value", () => {
 		process.env.CURSOR_RIPGREP_PATH = "";
 		const bundledPath = ensureCursorRipgrepPath();
 		expect(process.env.CURSOR_RIPGREP_PATH).toBe(bundledPath);

--- a/test/cursor-ripgrep-path.test.ts
+++ b/test/cursor-ripgrep-path.test.ts
@@ -1,0 +1,33 @@
+import { accessSync, constants } from "node:fs";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	ensureCursorRipgrepPath,
+	resolveBundledCursorRipgrepPath,
+} from "../src/cursor-ripgrep-path.js";
+
+const originalRipgrepPath = process.env.CURSOR_RIPGREP_PATH;
+
+afterEach(() => {
+	if (originalRipgrepPath === undefined) delete process.env.CURSOR_RIPGREP_PATH;
+	else process.env.CURSOR_RIPGREP_PATH = originalRipgrepPath;
+});
+
+describe("Cursor ripgrep path", () => {
+	it("resolves the executable from the installed Cursor SDK platform package", () => {
+		const ripgrepPath = resolveBundledCursorRipgrepPath();
+
+		if (!ripgrepPath) throw new Error("Expected the installed Cursor SDK platform package to include ripgrep");
+		expect(ripgrepPath.replaceAll("\\", "/")).toContain(`@cursor/sdk-${process.platform}-${process.arch}`);
+		expect(() => accessSync(ripgrepPath, constants.X_OK)).not.toThrow();
+	});
+
+	it("configures an empty path without overriding an existing value", () => {
+		process.env.CURSOR_RIPGREP_PATH = "";
+		const bundledPath = ensureCursorRipgrepPath();
+		expect(process.env.CURSOR_RIPGREP_PATH).toBe(bundledPath);
+
+		process.env.CURSOR_RIPGREP_PATH = "/custom/rg";
+		expect(ensureCursorRipgrepPath()).toBe("/custom/rg");
+		expect(process.env.CURSOR_RIPGREP_PATH).toBe("/custom/rg");
+	});
+});


### PR DESCRIPTION
## Summary
- Resolve bundled `@cursor/sdk-<platform>-<arch>/bin/rg` relative to the installed `@cursor/sdk`, including nested npm dependency layouts, and set `CURSOR_RIPGREP_PATH` before local `Agent.create`.
- Preserve an explicit absolute `CURSOR_RIPGREP_PATH`; replace empty or relative values with the bundled absolute path expected by Cursor SDK 1.0.23.
- Lock the installed SDK contract, nested dependency topology, and provider ordering with focused tests; document the module in `AGENTS.md` and the fix in `CHANGELOG.md`.

Closes #178

## Validation
- `npm test` — 1,347 passed, 2 skipped on the remediated PR head
- `npm run typecheck` — passed
- `npm run typecheck:tests` — passed
- Fresh thermo/deep maintainability review — no code, test, documentation, or structural findings after remediation
- Combined integration stack (#189, #187, #188): `npm test` — 1,356 passed, 2 skipped; `npm run typecheck` and `npm run typecheck:tests` — passed
- Combined integration stack: `npm run smoke:platform:all` — passed on macOS, Ubuntu, and native Windows; artifact index `.artifacts/platform-smoke/latest.json`, run IDs `run-1784743168208-aasxxm`, `run-1784743168210-cdhz9x`, `run-1784743168656-mlib9z`

## Notes
No npm publish, tag, release, or version bump.