### PR TITLE
fix: omit Pi system instructions from incremental prompts

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -375,7 +375,7 @@ export function shouldBootstrapCursorSend(
 }
 
 export function buildCursorIncrementalPrompt(context: Context, options: CursorPromptOptions = {}): CursorPrompt {
-	// Incremental sends omit the full Cursor SDK tool boundary block; the session agent retains prior bootstrap context.
+	// Incremental sends omit Pi system instructions and the full tool boundary; the session agent retains both from bootstrap.
 	const messages = normalizePiContextMessages(context.messages);
 	const latestUserMessageIndex = getLatestUserMessageIndex(messages);
 	const latestUserMessage = latestUserMessageIndex >= 0 ? messages[latestUserMessageIndex] : undefined;
@@ -383,9 +383,6 @@ export function buildCursorIncrementalPrompt(context: Context, options: CursorPr
 	const sectionsBeforeMessages = [
 		"Continue the conversation using Cursor SDK capabilities only. Do not list, promise, or call pi-only tools from earlier context as if they were available.",
 	];
-	if (context.systemPrompt) {
-		sectionsBeforeMessages.push(`System instructions from pi:\n${sanitizeSystemPromptForCursor(context.systemPrompt)}`);
-	}
 	const latestUserMessageSections =
 		latestUserText && latestUserMessageIndex >= 0 ? [{ index: latestUserMessageIndex, text: latestUserText }] : [];
 	const images = extractLatestImages(messages);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -655,6 +655,8 @@ describe("cursor session prompt assembly", () => {
 		expect(prompt.text).toContain("Continue the conversation using Cursor SDK capabilities only");
 		expect(prompt.text).toContain("User: Follow up");
 		expect(prompt.text).not.toContain("Cursor SDK tool boundary:");
+		expect(prompt.text).not.toContain("System instructions from pi:");
+		expect(prompt.text).not.toContain("Be helpful.");
 		expect(prompt.text).not.toContain("User: Hello");
 	});
 
@@ -694,12 +696,36 @@ describe("cursor session prompt assembly", () => {
 		expect(planCursorSessionSend(sendState, editedContext).mode).toBe("bootstrap");
 	});
 
-	it("omits the full tool boundary block from incremental prompts", () => {
+	it("rebootstraps with current system instructions when the system context diverges", () => {
+		const priorContext: Context = {
+			systemPrompt: "Previous invariant instruction.",
+			messages: [{ role: "user", content: "Hello", timestamp: 1 }],
+		};
+		const context: Context = {
+			systemPrompt: "Current invariant instruction.",
+			messages: priorContext.messages,
+		};
+		const sendState = {
+			bootstrapped: true,
+			contextFingerprint: computeCursorContextFingerprint(priorContext),
+			incrementalSendCount: 0,
+		};
+		const plan = planCursorSessionSend(sendState, context);
+		const prompt = buildCursorSessionSendPrompt(context, {}, plan);
+
+		expect(plan).toMatchObject({ mode: "bootstrap", reason: "context_divergence" });
+		expect(prompt.text).toContain("System instructions from pi:\nCurrent invariant instruction.");
+		expect(prompt.text).not.toContain("Previous invariant instruction.");
+	});
+
+	it("omits invariant bootstrap instructions from incremental prompts", () => {
 		const incremental = buildCursorIncrementalPrompt({
 			systemPrompt: "Be helpful.",
 			messages: [{ role: "user", content: "Follow up", timestamp: 3 }],
 		});
 		expect(incremental.text).not.toContain("Cursor SDK tool boundary:");
+		expect(incremental.text).not.toContain("System instructions from pi:");
+		expect(incremental.text).not.toContain("Be helpful.");
 		expect(incremental.text).toContain("Continue the conversation using Cursor SDK capabilities only");
 		expect(incremental.text).toContain(getCursorToolTailGuardText());
 	});
@@ -726,6 +752,7 @@ describe("cursor session prompt assembly", () => {
 			{ maxInputTokens: 80, charsPerToken: 1 },
 		);
 
+		expect(incremental.text).not.toContain("Long pi system prompt.");
 		expect(incremental.text).toContain("User: Keep this exact follow-up request");
 		expect(incremental.text).toContain(getCursorToolTailGuardText());
 	});


### PR DESCRIPTION
## Summary

Stop resending invariant Pi system instructions on true incremental sends to an already-bootstrapped local Cursor session agent.

Bootstrap and rebootstrap prompts still include the current Pi system instructions. System-prompt changes remain part of the context fingerprint and therefore continue to trigger a full context-divergence bootstrap.

## Why

The session agent already retains its bootstrap context. Repeating the full Pi system prompt on each incremental turn accumulates duplicate AGENTS/skills/policy text in native Cursor history and consumes context without changing the intended instructions.

## Tests

- Incremental prompt omits the Pi system section and its text.
- Bootstrap prompt retains it.
- A changed system prompt still selects context-divergence bootstrap with the updated instructions.
- Full typecheck and test suite pass in the fork integration branch.