### PR TITLE
fix: suppress DOMException [AbortError] during active sessions + classify 'Connection stalled repeatedly' ConnectError as network error

### DIFF
--- a/src/cursor-provider-errors.ts
+++ b/src/cursor-provider-errors.ts
@@ -165,6 +165,22 @@ function isCursorSdkStallAbortNetworkError(code: unknown, evidence: string, stac
 	);
 }
 
+/**
+ * Check if a ConnectError from @cursor/sdk's ConnectRPC retry logic indicates a stream
+ * that stalled repeatedly. Unlike isCursorSdkStallAbortNetworkError, this matches the
+ * "Connection stalled repeatedly" error message directly (not an AbortError wrapper).
+ * The SDK throws this when the retry count exceeds the limit in its fetchWithRetry
+ * wrapper (357.js function `fe`), typically after the stall detector failed to recover.
+ */
+function isCursorSdkStalledRepeatedlyNetworkError(code: unknown, evidence: string, stackEvidence: string): boolean {
+	return (
+		(code === 2 || (typeof code === "string" && /^(?:2|unknown)$/i.test(code))) &&
+		/\bstalled\b/i.test(evidence) &&
+		stackEvidence.includes("@cursor/sdk") &&
+		stackEvidence.includes("@connectrpc/connect-node")
+	);
+}
+
 function isCursorExtensionConnectStack(stack: string): boolean {
 	// pi runs Cursor SDK in Node, where the SDK dynamically imports connect-node.
 	// connect-web is the SDK's Bun/Deno path and is intentionally not classified for supported pi runs.
@@ -220,6 +236,10 @@ export function classifyCursorConnectError(error: unknown): CursorConnectErrorCl
 	}
 
 	if (isCursorSdkStallAbortNetworkError(code, evidence, stackEvidence)) {
+		return { kind: "network", source: getCursorConnectSource(error, record) };
+	}
+
+	if (isCursorSdkStalledRepeatedlyNetworkError(code, evidence, stackEvidence)) {
 		return { kind: "network", source: getCursorConnectSource(error, record) };
 	}
 

--- a/src/cursor-sdk-process-error-guard.ts
+++ b/src/cursor-sdk-process-error-guard.ts
@@ -113,7 +113,9 @@ function shouldSuppressProcessError(event: string | symbol, args: readonly unkno
 		return containLocalTransportClosedPipeError();
 	}
 	if (isCursorSdkWriteIterableClosedError(error)) return activeSessions.size > 0;
-	if (isCursorSdkAbortError(error)) return hasActiveAbortSuppression();
+	if (isCursorSdkAbortError(error)) {
+		return activeProviderTurns.size > 0 || activeSessions.size > 0;
+	}
 	const classification = classifyCursorConnectError(error);
 	if (!classification) return false;
 	if (classification.kind === "abort") return hasActiveAbortSuppression();


### PR DESCRIPTION
## Summary

Fixes two related crash paths in the process error guard that both terminate pi with an uncaught exception during Cursor SDK runs.

### Fix 1: `isCursorSdkAbortError` guard condition too narrow

The guard only suppressed `DOMException [AbortError]` when `hasActiveAbortSuppression()` was true — i.e., only when the user signal's `abortListener` explicitly called `sdkProcessErrorGuard.suppressAbortErrors()`. Two crash paths were missed:

1. **Stall detector timer** (`onStall` → `AbortController.abort()`) calls abort **directly**, bypassing the user-signal `abortListener`. `hasActiveAbortSuppression()` is never set.

2. **Stale timers** from a completed SDK run can fire **between provider turns** (`activeProviderTurns.size === 0` but session guard still alive). The session scope was never checked.

**Fix:** `shouldSuppressProcessError` now checks:
- `activeProviderTurns.size > 0` — catches stall-detector aborts during active runs
- `activeSessions.size > 0` — catches stale-timer aborts between turns within a session

```diff
- if (isCursorSdkAbortError(error)) return hasActiveAbortSuppression();
+ if (isCursorSdkAbortError(error)) {
+     return activeProviderTurns.size > 0 || activeSessions.size > 0;
+ }
```

### Fix 2: `classifyCursorConnectError` doesn't recognize "Connection stalled repeatedly"

The `@cursor/sdk` ConnectRPC retry wrapper (357.js function `fe`) throws a `ConnectError` with message `"Connection stalled repeatedly"` when the retry count exceeds the limit after repeated stalls. This message does **not** contain `"operation was aborted"` or `"canceled"`, so none of the existing patterns in `classifyCursorConnectError` match it, it returns `undefined`, and the crash proceeds.

**Fix:** Added `isCursorSdkStalledRepeatedlyNetworkError` that matches by:
- code 2 (`Code.Unknown` / `Code.Canceled`)
- evidence containing `"stalled"`
- stack containing `@cursor/sdk` and `@connectrpc/connect-node`

This is classified as `{ kind: "network" }`, which the error guard suppresses when an active provider turn or session is alive.

## Files changed

- `src/cursor-sdk-process-error-guard.ts` — fix 1: broaden AbortError suppression condition
- `src/cursor-provider-errors.ts` — fix 2: add `isCursorSdkStalledRepeatedlyNetworkError` classification

## Related

- Closes #194