### PR TITLE
chore: suppress non-fatal '[shell-exec] Close event did not fire' console.warn from @cursor/sdk

### DIFF
--- a/shared/cursor-sdk-output-filter.mjs
+++ b/shared/cursor-sdk-output-filter.mjs
@@ -10,6 +10,7 @@ export const CURSOR_SDK_STARTUP_NOISE_PATTERNS = [
 	"AgentSkillsCursorRulesService load completed",
 	"Error initializing ignore mapping for",
 	"Ripgrep path not configured. Call configureRipgrepPath() at startup.",
+	"[shell-exec]",
 ];
 
 export function isCursorSdkOutputSuppressed() {

--- a/shared/cursor-sdk-output-filter.mjs
+++ b/shared/cursor-sdk-output-filter.mjs
@@ -85,3 +85,13 @@ export function installCursorSdkOutputFilter() {
 		outputFilterOriginals = undefined;
 	};
 }
+
+// Permanent [shell-exec] suppression: the SDK timer fires 5000ms after the
+// child exits, by which the per-turn output filter may have been restored.
+// This wrapper stays in place for the lifetime of the process.
+const __origConsoleWarn = console.warn;
+console.warn = (...args) => {
+	const text = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
+	if (text.includes("[shell-exec]")) return;
+	return __origConsoleWarn.apply(console, args);
+};


### PR DESCRIPTION
## Summary

Suppresses a non-fatal `console.warn` from the `@cursor/sdk` local shell executor that leaks into user-visible stderr.

## Background

The `@cursor/sdk` shell executor spawns a child process for each shell command. After the child's `'exit'` event fires, a 5-second timeout starts. If `'close'` does not fire within that window — because a background subprocess inherited the pipe file descriptors — the SDK logs:

> `[shell-exec] Close event did not fire within 5000ms after exit. This may indicate a background process is holding file descriptors open. Proceeding anyway to prevent hang.`

This is **not an error** — shell output is already captured and the exit code is known. The message says `Proceeding anyway`. However, it leaks to stderr and reaches user-visible output.

## The problem: per-turn filter vs async timer

`pi-cursor-sdk` already has `installCursorSdkOutputFilter()` which patches `console.warn` and `process.stderr.write` to suppress SDK noise. However, this filter is **per-turn**: it is installed when a provider turn starts and restored when it ends.

The `[shell-exec]` warning fires **5000ms after the child exits**. By that time, the provider turn has long ended and the output filter has been restored. Adding `"[shell-exec]"` to `CURSOR_SDK_STARTUP_NOISE_PATTERNS` alone does not help because the patched `console.warn` is no longer active.

## Fix: permanent module-level wrapper + noise pattern

Two changes in `shared/cursor-sdk-output-filter.mjs`:

### 1. Permanent `console.warn` wrapper (module load time)

```js
const __origConsoleWarn = console.warn;
console.warn = (...args) => {
    const text = args.map((a) => (typeof a === "string" ? a : String(a))).join(" ");
    if (text.includes("[shell-exec]")) return;
    return __origConsoleWarn.apply(console, args);
};
```

This wrapper is installed once at module load and never removed. When the per-turn filter is active, it wraps this wrapper (via `createFilteredConsoleMethod`). When the filter is restored, `console.warn` falls back to this wrapper, which still catches `[shell-exec]`.

### 2. `"[shell-exec]"` added to `CURSOR_SDK_STARTUP_NOISE_PATTERNS`

This ensures the warning is also suppressed when the per-turn filter is active (redundant with the permanent wrapper, but consistent).

## Testing

```bash
# Before: warning leaks after 5s even with active filter
# After: warning is permanently suppressed regardless of filter state
```

## Related

- Previous PR #195 (closed) contained abort-guard fixes that have since been released in upstream commits. This PR isolates the one remaining upstream change.