### PR TITLE
fix: ask less via cursor_ask_question

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -65,7 +65,9 @@ function getCursorToolBoundaryText(
 			? "For exposed pi bridge tools, call pi__* MCP names, not pi card/history names."
 			: undefined,
 		"Do not claim pi-side or WebSearch/WebFetch tools unless Cursor ran an equivalent tool.",
-		includePiAskQuestionGuidance ? "Use pi__cursor_ask_question for material choices if exposed." : undefined,
+		includePiAskQuestionGuidance
+			? "Rarely use pi__cursor_ask_question. Prefer a reasonable default and state it; ask only when the wrong choice is costly or hard to undo."
+			: undefined,
 		getCursorPlanModeToolGuidanceText(options.agentMode, { includePiBridgeGuidance }),
 		"Images: only latest user images are sent; ask to reattach prior images.",
 	].filter((line): line is string => line !== undefined);

--- a/src/cursor-question-tool.ts
+++ b/src/cursor-question-tool.ts
@@ -216,13 +216,13 @@ export function registerCursorQuestionTool(pi: CursorQuestionToolExtensionApi): 
 		name: CURSOR_ASK_QUESTION_TOOL_NAME,
 		label: "Cursor question",
 		description:
-			"Ask the user a clarifying question from Cursor. Use when user preferences materially affect the next step; provide options when possible.",
-		promptSnippet: "Ask the user a clarifying question through pi UI when material choices affect Cursor's next step",
+			"Ask the user a clarifying question from Cursor. Use rarely — only when the wrong choice is costly or hard to undo; provide options when possible.",
+		promptSnippet: "Rarely ask through pi UI; prefer a stated default unless the wrong choice is costly",
 		executionMode: "sequential",
 		parameters: CursorAskQuestionParamsSchema,
 		promptGuidelines: [
-			"Use cursor_ask_question only when running a Cursor model and user input would materially change the plan, scope, platform, or implementation path.",
-			"Prefer cursor_ask_question with 2-4 concrete options instead of guessing when Cursor plan mode needs user choices.",
+			"Default to proceeding with a stated assumption. Use cursor_ask_question only when the wrong choice would waste significant work or be hard to undo (scope, platform, destructive).",
+			"Do not ask for routine next-step confirmation or among several reasonable implementation details. When you must ask, use 2-4 concrete options.",
 		],
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			const questions = normalizeQuestions(params as CursorAskQuestionParams);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -551,9 +551,9 @@ describe("buildCursorPrompt", () => {
 		const unknownTools = buildCursorPrompt({ messages: [{ role: "user", content: "test", timestamp: 1 }] });
 
 		expect(withTools.text).toContain("For exposed pi bridge tools");
-		expect(withTools.text).toContain("Use pi__cursor_ask_question");
+		expect(withTools.text).toContain("Rarely use pi__cursor_ask_question");
 		expect(unknownTools.text).toContain("For exposed pi bridge tools");
-		expect(unknownTools.text).toContain("Use pi__cursor_ask_question");
+		expect(unknownTools.text).toContain("Rarely use pi__cursor_ask_question");
 
 		const unknownToolsPlan = buildCursorPrompt({ messages: [{ role: "user", content: "test", timestamp: 1 }] }, { agentMode: "plan" });
 		expect(unknownToolsPlan.text).toContain("Exposed pi__* bridge tools");
@@ -570,7 +570,7 @@ describe("buildCursorPrompt", () => {
 		expect(result.text).toContain("call pi__* MCP names");
 		expect(result.text).toContain("not pi card/history names");
 		expect(result.text).toContain("Do not claim pi-side or WebSearch/WebFetch tools");
-		expect(result.text).toContain("Use pi__cursor_ask_question for material choices if exposed");
+		expect(result.text).toContain("Rarely use pi__cursor_ask_question");
 		expect(result.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
 		expect(result.text).not.toContain("Pi bridge contract:");
 		expect(result.text).not.toContain("do not use SwitchMode");


### PR DESCRIPTION
## Summary
- Tighten bootstrap + tool guidance so Cursor models (especially Grok) default to a stated assumption instead of frequent `pi__cursor_ask_question` questionnaires.
- Ask only when the wrong choice is costly or hard to undo (scope/platform/destructive), not for routine next steps.

## Test plan
- [x] `npx vitest run test/context.test.ts test/cursor-bridge-contract.test.ts`
- [ ] Dogfood a long Cursor/Grok session and confirm fewer ask-question cards


Made with [Cursor](https://cursor.com)