### PR TITLE
Let config declare Cursor custom subagents with per-subagent models

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-tool-result-display-readers.ts` owns canonical result readers shared by transcript/replay paths, including MCP-like content display normalization.
 - `src/cursor-tool-transcript.ts` owns the raw `unknown toolCall -> transcript/display` façade; `src/cursor-transcript-tool-specs.ts`, `src/cursor-transcript-utils.ts`, and `src/cursor-transcript-tool-formatters.ts` implement spec dispatch and formatting.
 - `src/cursor-mcp-timeout-override.ts` owns Cursor SDK MCP timeout overrides: 3600s default for `callTool`, 10s default for verified initialize/listTools paths on first send, and SDK-default behavior for unknown MCP protocol stacks.
+- `src/cursor-custom-subagents.ts` owns the configured custom subagent shape and its parsing/validation; it imports nothing but config helpers.
+- `src/cursor-custom-subagent-definitions.ts` maps parsed subagents onto Cursor SDK `AgentOptions.agents`, resolving each per-subagent model through `buildCursorModelSelection`.
 - `src/cursor-config.ts` owns Cursor SDK config loading, parsing, source precedence, safety-cap resolution, cloud environment selection, and legacy fast-default config persistence.
 - `src/cursor-cloud-options.ts` owns cloud SDK option mapping and fail-closed preflight.
 - `src/cursor-cloud-local-state.ts` owns canonical cloud starting-ref normalization, hermetic Git probes, remote identity/refspec validation, and reasoned local-state inspection.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Support configured Cursor custom subagents through `subagents` in the Cursor SDK config file, mapping each named entry onto SDK `AgentOptions.agents` with its own pi Cursor model id, thinking level, and fast variant, so delegated tasks can run on a model other than the ones Cursor's built-in `task` subagent types allow. Definitions participate in the local session-agent pool key and are passed to both local and cloud runtimes. The installed SDK narrows local runs to `RuntimeCustomSubagentDefinition` and keeps only `model.id`, so thinking/fast/context params apply on cloud runtime and are dropped by the SDK on local runtime.
 - Add a dated, hash-verified evidence bundle for Cursor's persisted system messages and reconstructed tool guidance for Grok 4.5, Claude Opus/Fable 5, and GPT-5.6 Sol/Terra/Luna.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -515,6 +515,40 @@ Use `npm run debug:provider-events` to capture the same `onDelta`/`onStep` paylo
 
 See [Cursor testing lessons](docs/cursor-testing-lessons.md#cursor-sdk-event-capture-probe) for usage, artifact layout, and safety notes.
 
+## Custom subagents
+
+Cursor's built-in `task` subagent types accept only the models Cursor's own registry allows, so a delegated task cannot be pointed at an arbitrary Cursor model through that tool. The installed Cursor SDK exposes `AgentOptions.agents`, where each named custom subagent carries its own `model`. Declare those subagents under `subagents` in `~/.pi/agent/cursor-sdk.json` (user) or `.pi/cursor-sdk.json` in a trusted project, and Cursor gains one named subagent type per entry, each pinned to the model you chose:
+
+```json
+{
+  "subagents": {
+    "explore": {
+      "description": "Low-complexity exploration and code search.",
+      "prompt": "You explore the repository and report findings concisely.",
+      "model": "composer-2-5"
+    },
+    "implement": {
+      "description": "Medium-complexity implementation work.",
+      "prompt": "You implement scoped changes and report what you changed.",
+      "model": "grok-4.5",
+      "thinking": "high"
+    },
+    "architect": {
+      "description": "High-complexity design and multi-file reasoning.",
+      "prompt": "You design and justify multi-file changes.",
+      "model": "claude-opus-5@300k",
+      "thinking": "high"
+    }
+  }
+}
+```
+
+`model` takes a pi Cursor model id exactly as `pi --list-models cursor` prints it, including `-`/`.` aliases such as `composer-2-5` and context variants such as `claude-opus-5@300k`. `thinking` accepts pi thinking levels (`off`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) and maps to the model's Cursor reasoning/effort/thinking parameter the same way session thinking does; it defaults to `off`. Optional `fast` selects the Cursor fast/slow variant for models that support it; subagents read it only from this config, so `/cursor-fast` and `fastDefaults` stay scoped to the session model and never leak into a subagent. Set `"model": "inherit"` to run a subagent on the parent session's model, and omit `model` to leave the choice to the Cursor SDK default. An id with no registered Cursor metadata is passed through unchanged, so a typo surfaces as a Cursor delegation error rather than being silently rewritten.
+
+**Model parameters apply on cloud runtime only.** The installed Cursor SDK narrows custom subagents to `RuntimeCustomSubagentDefinition` for local runs, whose `model` is a plain string, and its local converter keeps only `model.id`. So on the default local runtime a subagent runs on the model you named, but `thinking`, `fast`, and the context part of a variant such as `@300k` are dropped by the SDK and the model's own defaults apply. Cloud runs pass the full selection. This is an SDK-side limitation, not a pi override; `test/cursor-custom-subagents.test.ts` pins both SDK shapes so the behavior change is caught if a future SDK preserves local params.
+
+Delegation happens by subagent name rather than by model argument, so instructions in `AGENTS.md` should reference the names you declared (for example "use `implement` for medium-complexity subtasks"). Entries whose name is unusable or whose `description`/`prompt` is missing are skipped so one bad entry cannot discard the rest of the config; an unrecognized `thinking` value is dropped and the subagent still runs. A block with no usable entry at all is treated as absent rather than as an empty set, so it cannot shadow a lower-precedence layer. Precedence is trusted project config, then user config, with the winning layer replacing the whole set rather than merging per name; there is no CLI flag or environment variable for subagent definitions. Changing a definition splits the local agent pool so the next turn creates a Cursor agent with the new subagents instead of reusing the old one. Per-subagent `mcpServers` is not exposed by this config shape; SDK custom subagents inherit the parent agent's MCP configuration.
+
 ## Fallback models
 
 If startup has no stored `/login` key or `CURSOR_API_KEY`, model discovery fails, or discovery returns no models, the extension registers a bundled fallback snapshot of the latest reviewed Cursor SDK model catalog and notifies interactive users when possible. Pi CLI `--api-key` remains available to provider turns but is not parsed independently during startup discovery.

--- a/docs/cursor-model-ux-spec.md
+++ b/docs/cursor-model-ux-spec.md
@@ -400,6 +400,24 @@ cursor:local · fast:on
 cursor:local · fast:on · http1
 ```
 
+## Custom Subagent Model Behavior
+
+Cursor's built-in `task` subagent types resolve models through Cursor's own registry, so a delegated task cannot select an arbitrary Cursor model there. The installed SDK's `AgentOptions.agents` accepts named definitions whose `model` is `ModelSelection | "inherit"`, which is the seam pi uses for per-subagent model choice.
+
+Rules:
+
+- Users declare subagents under `subagents` in the Cursor SDK config file (user or trusted project), keyed by a Cursor-addressable name.
+- A subagent's `model` is a pi Cursor model id, so aliases and context variants such as `@300k` resolve through the same metadata as session model selection; `inherit` passes through verbatim and an omitted `model` leaves the SDK default. An unregistered id is passed through unchanged so Cursor reports it instead of pi rewriting it.
+- `thinking` reuses pi thinking levels and the model's `thinkingLevelMap`, defaulting to `off`; optional `fast` reuses fast-capability metadata. Neither invents model-specific parameter names.
+- `fast` comes only from a subagent's own config. Session fast state (`/cursor-fast`, `fastDefaults`) is user state for the selected session model, and the cloud parent path omits `fast` entirely, so inheriting it would make a subagent's model depend on unrelated session toggles.
+- Built selections are complete, but the installed SDK narrows local runs to `RuntimeCustomSubagentDefinition` (`model: string`) and keeps only `model.id`, so on local runtime the model id applies and thinking/fast/context params are dropped by the SDK. Cloud runs receive the full `ModelSelection`. Contract tests pin both SDK shapes rather than asserting pi-side intent alone.
+- Definitions participate in the local session-agent pool key so a changed definition creates a new Cursor agent instead of reusing one built with stale subagents.
+- Local and cloud runtimes pass the same definitions; nothing is duplicated into the prompt.
+
+Reason:
+
+- Per-subagent models belong to Cursor's agent loop, so pi supplies definitions rather than reimplementing delegation, and keeps model ids/params sourced from Cursor SDK metadata.
+
 ## Cursor SDK Mode Behavior
 
 Current Cursor SDK exposes SDK-native conversation mode:

--- a/src/cursor-cloud-options.ts
+++ b/src/cursor-cloud-options.ts
@@ -1,4 +1,5 @@
 import type { AgentModeOption, AgentOptions, ModelSelection } from "@cursor/sdk";
+import type { CursorCustomSubagentDefinitions } from "./cursor-custom-subagent-definitions.js";
 import { isCursorCloudEnvironmentType, type CursorResolvedSdkConfig } from "./cursor-config.js";
 import {
 	normalizeCursorCloudStartingRef,
@@ -49,6 +50,7 @@ export function buildCursorCloudAgentOptions(options: {
 	agentMode: AgentModeOption;
 	resolvedConfig: CursorResolvedSdkConfig;
 	name?: string;
+	customSubagents?: CursorCustomSubagentDefinitions;
 }): AgentOptions {
 	const { resolvedConfig } = options;
 	const environment = resolvedConfig.cloud.environment.value;
@@ -91,6 +93,7 @@ export function buildCursorCloudAgentOptions(options: {
 		model: options.modelSelection,
 		mode: options.agentMode,
 		...(options.name ? { name: options.name } : {}),
+		...(options.customSubagents ? { agents: options.customSubagents } : {}),
 		cloud,
 	};
 }

--- a/src/cursor-config.ts
+++ b/src/cursor-config.ts
@@ -13,6 +13,7 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "@earendil-works/pi-coding-agent";
+import { parseCursorCustomSubagents, type CursorCustomSubagents } from "./cursor-custom-subagents.js";
 import { parseOptionalEnvBoolean } from "./cursor-env-boolean.js";
 import { asRecord } from "./cursor-record-utils.js";
 
@@ -51,6 +52,7 @@ export interface CursorCloudEnvironmentConfig {
 export interface CursorSdkConfig {
 	fastDefaults?: Record<string, boolean>;
 	runtime?: CursorRuntime;
+	subagents?: CursorCustomSubagents;
 	cloud?: {
 		repo?: string;
 		branch?: string;
@@ -94,6 +96,7 @@ export interface CursorResolvedSetting<T> {
 
 export interface CursorResolvedSdkConfig {
 	runtime: CursorResolvedSetting<CursorRuntime>;
+	subagents: CursorResolvedSetting<CursorCustomSubagents>;
 	cloud: {
 		repo: CursorResolvedSetting<string | undefined>;
 		branch: CursorResolvedSetting<string | undefined>;
@@ -243,6 +246,9 @@ export function parseCursorSdkConfig(value: unknown): CursorSdkConfig | undefine
 	const config: CursorSdkConfig = {};
 
 	if (isCursorRuntime(record.runtime)) config.runtime = record.runtime;
+
+	const subagents = parseCursorCustomSubagents(record.subagents);
+	if (subagents) config.subagents = subagents;
 
 	const fastDefaults = asRecord(record.fastDefaults);
 	if (fastDefaults) {
@@ -531,6 +537,9 @@ type CursorFieldValues<T> = Partial<Record<CursorFieldSource, T>>;
 const RUNTIME_ORDER: CursorFieldSource[] = ["cli", "environment", "session", "project", "user", "builtin"];
 const CLOUD_ORDER: CursorFieldSource[] = ["cli", "environment", "session", "user", "builtin"];
 const LOCAL_ORDER: CursorFieldSource[] = ["cli", "environment", "project", "user", "builtin"];
+// Subagent definitions are prompt/model records, so they come from config files rather than CLI flags
+// or environment strings, and a trusted project layer replaces the user layer whole.
+const SUBAGENTS_ORDER: CursorFieldSource[] = ["project", "user", "builtin"];
 const LOCAL_FORCE_ORDER: CursorFieldSource[] = ["cli", "environment", "builtin"];
 const HTTP1_ORDER: CursorFieldSource[] = ["session", "environment", "user", "builtin"];
 
@@ -648,6 +657,11 @@ export function resolveCursorSdkConfig(options: ResolveCursorSdkConfigOptions = 
 			},
 			(value) => (value === "cloud" ? 1 : 0),
 		),
+		subagents: resolveOrdinaryField(SUBAGENTS_ORDER, {
+			project: project?.subagents,
+			user: user?.subagents,
+			builtin: builtIn.subagents ?? {},
+		}),
 		cloud: {
 			repo: resolveOrdinaryField(CLOUD_ORDER, {
 				cli: cli?.cloud?.repo,

--- a/src/cursor-custom-subagent-definitions.ts
+++ b/src/cursor-custom-subagent-definitions.ts
@@ -1,0 +1,40 @@
+import type { AgentDefinition, ModelSelection } from "@cursor/sdk";
+import type { CursorCustomSubagentConfig, CursorCustomSubagents } from "./cursor-custom-subagents.js";
+import { buildCursorModelSelection } from "./model-discovery.js";
+
+/** `AgentDefinition.model` sentinel accepted by the installed Cursor SDK for parent-model inheritance. */
+const INHERIT_MODEL = "inherit";
+
+export type CursorCustomSubagentDefinitions = Record<string, AgentDefinition>;
+
+/**
+ * Resolves one subagent's SDK model field. An omitted config `model` keeps the SDK default, `inherit`
+ * passes through verbatim, and any other value resolves through Cursor model metadata. An id with no
+ * registered metadata is passed through unchanged so Cursor reports it at delegation time instead of
+ * pi silently rewriting it.
+ *
+ * `fast` is applied only when config states it: session fast state (`/cursor-fast`, `fastDefaults`) is
+ * session-scoped user state for the selected model, and the cloud parent path omits `fast` entirely.
+ */
+function resolveSubagentModel(subagent: CursorCustomSubagentConfig): ModelSelection | typeof INHERIT_MODEL | undefined {
+	if (subagent.model === undefined) return undefined;
+	if (subagent.model === INHERIT_MODEL) return INHERIT_MODEL;
+	return buildCursorModelSelection(subagent.model, subagent.thinking ?? "off", subagent.fast);
+}
+
+/** Maps configured subagents onto Cursor SDK `AgentOptions.agents`. */
+export function buildCursorCustomSubagentDefinitions(
+	subagents: CursorCustomSubagents | undefined,
+): CursorCustomSubagentDefinitions | undefined {
+	if (!subagents || Object.keys(subagents).length === 0) return undefined;
+	const definitions: CursorCustomSubagentDefinitions = {};
+	for (const [name, subagent] of Object.entries(subagents)) {
+		const model = resolveSubagentModel(subagent);
+		definitions[name] = {
+			description: subagent.description,
+			prompt: subagent.prompt,
+			...(model === undefined ? {} : { model }),
+		};
+	}
+	return definitions;
+}

--- a/src/cursor-custom-subagents.ts
+++ b/src/cursor-custom-subagents.ts
@@ -1,0 +1,74 @@
+import type { ModelThinkingLevel } from "@earendil-works/pi-ai/compat";
+import { asRecord } from "./cursor-record-utils.js";
+
+export interface CursorCustomSubagentConfig {
+	description: string;
+	prompt: string;
+	/** pi Cursor model id such as `grok-4.5` or `claude-opus-5@300k`, or `inherit` for the parent model. */
+	model?: string;
+	thinking?: ModelThinkingLevel;
+	fast?: boolean;
+}
+
+export type CursorCustomSubagents = Record<string, CursorCustomSubagentConfig>;
+
+// Config keys become Cursor subagent type names, so they stay word-safe and bounded instead of
+// accepting arbitrary keys. README documents this rule because unusable names are skipped silently.
+const SUBAGENT_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9._-]{0,63}$/;
+// Exhaustive by construction so a new pi thinking level fails the build instead of being rejected at runtime.
+const THINKING_LEVELS: Record<ModelThinkingLevel, true> = {
+	off: true,
+	minimal: true,
+	low: true,
+	medium: true,
+	high: true,
+	xhigh: true,
+	max: true,
+};
+
+function isCursorSubagentName(value: string): boolean {
+	return SUBAGENT_NAME_PATTERN.test(value);
+}
+
+function isCursorSubagentThinkingLevel(value: unknown): value is ModelThinkingLevel {
+	return typeof value === "string" && Object.hasOwn(THINKING_LEVELS, value);
+}
+
+function parseRequiredText(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const trimmed = value.trim();
+	return trimmed ? trimmed : undefined;
+}
+
+function parseSubagentEntry(value: unknown): CursorCustomSubagentConfig | undefined {
+	const record = asRecord(value);
+	if (!record) return undefined;
+	const description = parseRequiredText(record.description);
+	const prompt = parseRequiredText(record.prompt);
+	if (!description || !prompt) return undefined;
+	const model = parseRequiredText(record.model);
+	return {
+		description,
+		prompt,
+		...(model ? { model } : {}),
+		...(isCursorSubagentThinkingLevel(record.thinking) ? { thinking: record.thinking } : {}),
+		...(typeof record.fast === "boolean" ? { fast: record.fast } : {}),
+	};
+}
+
+/**
+ * Parses configured custom subagents, dropping entries that Cursor could not address (unusable name,
+ * missing description/prompt) instead of rejecting the whole config file. Returns undefined when no
+ * usable entry remains so an empty or fully invalid block does not shadow a lower-precedence layer.
+ */
+export function parseCursorCustomSubagents(value: unknown): CursorCustomSubagents | undefined {
+	const record = asRecord(value);
+	if (!record) return undefined;
+	const parsed: CursorCustomSubagents = {};
+	for (const [name, entry] of Object.entries(record)) {
+		if (!isCursorSubagentName(name)) continue;
+		const subagent = parseSubagentEntry(entry);
+		if (subagent) parsed[name] = subagent;
+	}
+	return Object.keys(parsed).length > 0 ? parsed : undefined;
+}

--- a/src/cursor-provider-turn-prepare.ts
+++ b/src/cursor-provider-turn-prepare.ts
@@ -29,6 +29,10 @@ import {
 } from "./cursor-state.js";
 import { resolveEffectiveCursorConfig } from "./cursor-runtime-state.js";
 import type { CursorResolvedSdkConfig } from "./cursor-config.js";
+import {
+	buildCursorCustomSubagentDefinitions,
+	type CursorCustomSubagentDefinitions,
+} from "./cursor-custom-subagent-definitions.js";
 import { buildCursorModelSelection } from "./model-discovery.js";
 import { getEffectiveCursorSettingSources } from "./cursor-setting-sources.js";
 import {
@@ -76,6 +80,7 @@ interface PrepareCursorProviderTurnContext extends PrepareCursorProviderTurnPara
 	agentMode: AgentModeOption;
 	selection: ModelSelection;
 	fastEnabled: boolean | undefined;
+	customSubagents: CursorCustomSubagentDefinitions | undefined;
 }
 
 function buildCursorCloudPromptContext(context: Context, handoff: "fresh" | "bootstrap" | "never"): Context {
@@ -119,7 +124,7 @@ function buildLocalCursorProviderTurnLifecycle(
 async function prepareCursorCloudProviderTurn(
 	prepareParams: PrepareCursorProviderTurnContext,
 ): Promise<CloudCursorProviderTurnPrepareResult> {
-	const { params, cwd, resolvedApiKey, sdkEventDebug, throwIfAborted, resolvedConfig, agentMode, selection, fastEnabled } = prepareParams;
+	const { params, cwd, resolvedApiKey, sdkEventDebug, throwIfAborted, resolvedConfig, agentMode, selection, fastEnabled, customSubagents } = prepareParams;
 	const { model, context, options } = params;
 
 	let restoreCursorSdkOutputFilter: (() => void) | undefined;
@@ -162,6 +167,7 @@ async function prepareCursorCloudProviderTurn(
 				agentMode,
 				resolvedConfig,
 				name: getCursorSessionName(),
+				...(customSubagents ? { customSubagents } : {}),
 			})),
 		);
 		cloudAgentForCleanup = agent;
@@ -199,6 +205,7 @@ async function prepareCursorCloudProviderTurn(
 			promptOptions,
 			agentMode,
 			localForce: false,
+			...(customSubagents ? { customSubagentNames: Object.keys(customSubagents) } : {}),
 		});
 
 		completed = true;
@@ -239,7 +246,7 @@ async function prepareCursorCloudProviderTurn(
 async function prepareCursorLocalProviderTurn(
 	prepareParams: PrepareCursorProviderTurnContext,
 ): Promise<LocalCursorProviderTurnPrepareResult> {
-	const { params, cwd, resolvedApiKey, sdkEventDebug, throwIfAborted, resolvedConfig, agentMode, selection, fastEnabled } = prepareParams;
+	const { params, cwd, resolvedApiKey, sdkEventDebug, throwIfAborted, resolvedConfig, agentMode, selection, fastEnabled, customSubagents } = prepareParams;
 	const { model, context, options } = params;
 
 	let restoreCursorSdkOutputFilter: (() => void) | undefined;
@@ -273,6 +280,7 @@ async function prepareCursorLocalProviderTurn(
 			modelSelection: selection,
 			settingSources,
 			localSafety,
+			...(customSubagents ? { customSubagents } : {}),
 			localResume: resolvedConfig.local.resume.value,
 			useHttp1ForAgent,
 			debugRecorder: sdkEventDebug,
@@ -359,6 +367,7 @@ async function prepareCursorLocalProviderTurn(
 			activeToolNames: activeToolNames ? [...activeToolNames] : [],
 			sessionAgentScopeKey,
 			bridgeRunId: bridgeRun?.id,
+			...(customSubagents ? { customSubagentNames: Object.keys(customSubagents) } : {}),
 		});
 		const nativeReplayId = createCursorNativeReplayId();
 		const textDeltas: string[] = [];
@@ -447,7 +456,14 @@ export async function prepareCursorProviderTurn(
 	const agentMode = getCursorProviderAgentModeOrThrow();
 	const fastEnabled = resolvedConfig.runtime.value === "cloud" ? undefined : getEffectiveFastForModelId(model.id);
 	const selection = buildCursorModelSelection(model.id, options?.reasoning ?? "off", fastEnabled);
-	const context: PrepareCursorProviderTurnContext = { ...prepareParams, agentMode, selection, fastEnabled };
+	const customSubagents = buildCursorCustomSubagentDefinitions(resolvedConfig.subagents.value);
+	const context: PrepareCursorProviderTurnContext = {
+		...prepareParams,
+		agentMode,
+		selection,
+		fastEnabled,
+		customSubagents,
+	};
 
 	return resolvedConfig.runtime.value === "cloud"
 		? prepareCursorCloudProviderTurn(context)

--- a/src/cursor-session-agent.ts
+++ b/src/cursor-session-agent.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type { AgentModeOption, LocalAgentOptions, LocalAgentStore, ModelSelection, SDKAgent, SettingSource } from "@cursor/sdk";
 import type { Context } from "@earendil-works/pi-ai/compat";
+import type { CursorCustomSubagentDefinitions } from "./cursor-custom-subagent-definitions.js";
 import {
 	getRegisteredCursorPiToolBridge,
 	type CursorPiBridgeToolRequest,
@@ -127,6 +128,7 @@ interface SessionCursorAgentCreateParams {
 	modelSelection: ModelSelection;
 	settingSources?: SettingSource[];
 	localSafety?: CursorLocalSafetyOptions;
+	customSubagents?: CursorCustomSubagentDefinitions;
 	useHttp1ForAgent?: boolean;
 	onBridgeToolRequest?: (request: CursorPiBridgeToolRequest) => void;
 	debugRecorder?: CursorSdkEventDebugRecorder;
@@ -201,8 +203,17 @@ function buildLocalSafetyPoolKey(localSafety?: CursorLocalSafetyOptions): string
 	});
 }
 
-function buildApiKeyPoolKeyFingerprint(apiKey: string): string {
-	return createHash("sha256").update(apiKey).digest("hex").slice(0, 16);
+function buildPoolKeyFingerprint(value: string): string {
+	return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+// Keeps whole subagent prompts out of the pool key while still repooling when a definition changes.
+function buildCustomSubagentsPoolKey(customSubagents?: CursorCustomSubagentDefinitions): string {
+	if (!customSubagents) return "subagents:none";
+	const entries = Object.keys(customSubagents)
+		.sort()
+		.map((name) => [name, customSubagents[name]] as const);
+	return `subagents:${buildPoolKeyFingerprint(JSON.stringify(entries))}`;
 }
 
 function buildBridgePoolKeySuffix(): string {
@@ -218,12 +229,13 @@ function buildSessionAgentPoolKey(scopeKey: string, params: SessionCursorAgentCr
 		buildModelPoolKey(params.modelSelection),
 		buildSettingSourcesPoolKey(params.settingSources),
 		buildLocalSafetyPoolKey(params.localSafety),
+		buildCustomSubagentsPoolKey(params.customSubagents),
 		params.useHttp1ForAgent === undefined
 			? "http1:default"
 			: params.useHttp1ForAgent
 				? "http1:on"
 				: "http1:off",
-		buildApiKeyPoolKeyFingerprint(params.apiKey),
+		buildPoolKeyFingerprint(params.apiKey),
 		buildBridgePoolKeySuffix(),
 	].join("\0");
 }
@@ -489,6 +501,7 @@ async function createSessionAgentEntry(
 				store: sessionStore!.store,
 			}),
 			...(bridgeRun?.mcpServers ? { mcpServers: bridgeRun.mcpServers } : {}),
+			...(params.customSubagents ? { agents: params.customSubagents } : {}),
 		});
 		let agent: SDKAgent | undefined;
 		let effectiveSendState = sendState;
@@ -677,7 +690,8 @@ export const __testUtils = {
 	resetSessionCursorAgent,
 	refreshSessionCursorAgentConfig,
 	disposeAllSessionCursorAgents,
-	buildApiKeyPoolKeyFingerprint,
+	buildPoolKeyFingerprint,
+	buildCustomSubagentsPoolKey,
 	buildSessionAgentPoolKey,
 	setDeadTransportAgentDisposeTimeoutMs(ms: number): number {
 		const previous = deadTransportAgentDisposeTimeoutMs;

--- a/test/cursor-config.test.ts
+++ b/test/cursor-config.test.ts
@@ -571,6 +571,17 @@ describe("Cursor SDK config resolver", () => {
 		expect(cloud.repo).toMatchObject({ value: "session-repo", source: "session" });
 	});
 
+	it("ignores cli, environment, and session for subagents (per-field source order)", () => {
+		const subagents = { reviewer: { description: "Session.", prompt: "Session." } };
+
+		expect(resolveCursorSdkConfig({ env: {}, session: { subagents } }).subagents).toMatchObject({ value: {}, source: "builtin" });
+		expect(resolveCursorSdkConfig({ env: { PI_CURSOR_SUBAGENTS: JSON.stringify(subagents) } }).subagents).toMatchObject({
+			value: {},
+			source: "builtin",
+		});
+		expect(resolveCursorSdkConfig({ env: {}, cli: { subagents } }).subagents).toMatchObject({ value: {}, source: "builtin" });
+	});
+
 	it("resolves local safety controls by CLI, env, project, user, built-in order", () => {
 		const user = { local: { autoReview: true, sandboxOptions: { enabled: true }, force: true, resume: true } };
 		const project = { local: { autoReview: false, sandbox: false, force: true, resume: false } };

--- a/test/cursor-custom-subagents.test.ts
+++ b/test/cursor-custom-subagents.test.ts
@@ -1,0 +1,243 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { buildCursorCloudAgentOptions } from "../src/cursor-cloud-options.js";
+import { parseCursorSdkConfig, resolveCursorSdkConfig } from "../src/cursor-config.js";
+import { parseCursorCustomSubagents } from "../src/cursor-custom-subagents.js";
+import { buildCursorCustomSubagentDefinitions } from "../src/cursor-custom-subagent-definitions.js";
+import { buildCursorModelSelection, __testUtils as modelDiscoveryTestUtils } from "../src/model-discovery.js";
+import {
+	acquireSessionCursorAgent,
+	__testUtils as sessionAgentTestUtils,
+} from "../src/cursor-session-agent.js";
+import { __testUtils as cursorSessionScopeTestUtils } from "../src/cursor-session-scope.js";
+import { installCursorSessionStoreMock } from "./helpers/cursor-session-store.js";
+import { cursorModelItems } from "./helpers/cursor-provider-harness.js";
+
+const REVIEWER = {
+	description: "Reviews diffs.",
+	prompt: "You review diffs.",
+	model: "gpt-5.5@272k",
+	thinking: "high",
+} as const;
+
+const SDK_DIST = new URL("../node_modules/@cursor/sdk/dist/esm/", import.meta.url);
+
+describe("Cursor custom subagents", () => {
+	beforeEach(() => {
+		modelDiscoveryTestUtils.registerModelItems(cursorModelItems);
+	});
+
+	it("tracks the installed SDK custom subagent option contract", () => {
+		const options = readFileSync(new URL("options.d.ts", SDK_DIST), "utf8");
+
+		expect(options).toMatch(/export interface AgentDefinition \{/);
+		expect(options).toMatch(/model\?: ModelSelection \| "inherit";/);
+		expect(options).toMatch(/agents\?: Record<string, AgentDefinition>;/);
+	});
+
+	it("tracks the installed SDK local-runtime subagent model downgrade", () => {
+		// Local runs narrow subagents to RuntimeCustomSubagentDefinition, whose model is a plain id, so pi
+		// documents thinking/fast/context as cloud-only. This fails if a future SDK keeps local params.
+		const runtimeTypes = readFileSync(new URL("run-store-public-types.d.ts", SDK_DIST), "utf8");
+		const conversion = readFileSync(new URL("subagent-conversion.d.ts", SDK_DIST), "utf8");
+
+		expect(runtimeTypes, "installed SDK local subagent model is no longer a plain id").toMatch(
+			/export interface RuntimeCustomSubagentDefinition \{[\s\S]*?readonly model: string;/,
+		);
+		expect(conversion, "installed SDK local converter no longer narrows to RuntimeCustomSubagentDefinition").toMatch(
+			/convertAgentDefinitionsToRuntimeCustomSubagents\(agents: Record<string, AgentDefinition> \| undefined\): RuntimeCustomSubagentDefinition\[\]/,
+		);
+		expect(conversion, "installed SDK cloud/local subagent model shapes converged").toMatch(
+			/interface SDKCustomSubagentDefinition \{[\s\S]*?model: ModelSelection \| "inherit";/,
+		);
+	});
+
+	it("parses usable subagent entries and drops unusable ones", () => {
+		expect(
+			parseCursorCustomSubagents({
+				reviewer: REVIEWER,
+				"bad name": REVIEWER,
+				"1leading-digit": REVIEWER,
+				missingPrompt: { description: "No prompt." },
+				missingDescription: { prompt: "No description." },
+				blank: { description: "   ", prompt: "   " },
+				notAnObject: "reviewer",
+			}),
+		).toEqual({ reviewer: { description: "Reviews diffs.", prompt: "You review diffs.", model: "gpt-5.5@272k", thinking: "high" } });
+	});
+
+	it("treats an empty or fully invalid block as absent so it cannot shadow a lower layer", () => {
+		expect(parseCursorCustomSubagents({})).toBeUndefined();
+		expect(parseCursorCustomSubagents({ "bad name": REVIEWER })).toBeUndefined();
+		expect(
+			resolveCursorSdkConfig({
+				env: {},
+				user: { subagents: { reviewer: { description: "User.", prompt: "User." } } },
+				project: parseCursorSdkConfig({ subagents: {} }),
+			}).subagents,
+		).toMatchObject({ source: "user" });
+	});
+
+	it("keeps fast and ignores an unsupported thinking level", () => {
+		expect(
+			parseCursorCustomSubagents({
+				explorer: { description: "Explores.", prompt: "You explore.", model: "gpt-5.5@1m", thinking: "turbo", fast: true },
+			}),
+		).toEqual({ explorer: { description: "Explores.", prompt: "You explore.", model: "gpt-5.5@1m", fast: true } });
+	});
+
+	it("builds SDK agent definitions from real Cursor model metadata", () => {
+		const definitions = buildCursorCustomSubagentDefinitions({
+			reviewer: REVIEWER,
+			inheriting: { description: "Inherits.", prompt: "You inherit.", model: "inherit" },
+			defaulted: { description: "Defaults.", prompt: "You default." },
+			slowed: { description: "Slow.", prompt: "You are slow.", model: "gpt-5.5@1m", fast: false },
+		});
+
+		expect(definitions).toEqual({
+			reviewer: {
+				description: "Reviews diffs.",
+				prompt: "You review diffs.",
+				model: buildCursorModelSelection("gpt-5.5@272k", "high"),
+			},
+			inheriting: { description: "Inherits.", prompt: "You inherit.", model: "inherit" },
+			defaulted: { description: "Defaults.", prompt: "You default." },
+			slowed: {
+				description: "Slow.",
+				prompt: "You are slow.",
+				model: buildCursorModelSelection("gpt-5.5@1m", "off", false),
+			},
+		});
+		// The reviewer selection must carry the requested context variant and thinking parameter.
+		expect(definitions?.reviewer?.model).toMatchObject({
+			id: "gpt-5.5",
+			params: expect.arrayContaining([
+				{ id: "context", value: "272k" },
+				{ id: "reasoning", value: "high" },
+			]),
+		});
+		expect(definitions?.slowed?.model).toMatchObject({ params: expect.arrayContaining([{ id: "fast", value: "false" }]) });
+	});
+
+	it("resolves pi model id aliases and passes unknown ids through unchanged", () => {
+		modelDiscoveryTestUtils.registerModelItems([
+			{
+				id: "composer-2.5",
+				displayName: "Composer 2.5",
+				aliases: ["composer-2-5"],
+				parameters: [{ id: "fast", displayName: "Fast", values: [{ value: "false" }, { value: "true" }] }],
+				variants: [{ params: [{ id: "fast", value: "true" }], displayName: "Composer 2.5", isDefault: true }],
+			},
+		]);
+		const definitions = buildCursorCustomSubagentDefinitions({
+			aliased: { description: "Aliased.", prompt: "Aliased.", model: "composer-2-5" },
+			typo: { description: "Typo.", prompt: "Typo.", model: "composer-2-5-typo" },
+		});
+
+		expect(definitions?.aliased?.model).toMatchObject({ id: "composer-2-5" });
+		expect(definitions?.typo?.model).toEqual({ id: "composer-2-5-typo" });
+	});
+
+	it("returns no definitions when nothing is configured", () => {
+		expect(buildCursorCustomSubagentDefinitions(undefined)).toBeUndefined();
+		expect(buildCursorCustomSubagentDefinitions({})).toBeUndefined();
+	});
+
+	it("keys the agent pool on bounded definition content, not declaration order", () => {
+		const poolKey = sessionAgentTestUtils.buildCustomSubagentsPoolKey;
+		const first = buildCursorCustomSubagentDefinitions({ a: REVIEWER, b: { description: "B.", prompt: "B." } });
+		const reordered = buildCursorCustomSubagentDefinitions({ b: { description: "B.", prompt: "B." }, a: REVIEWER });
+		const changed = buildCursorCustomSubagentDefinitions({ a: { ...REVIEWER, prompt: "You review carefully." }, b: { description: "B.", prompt: "B." } });
+
+		expect(poolKey(first)).toBe(poolKey(reordered));
+		expect(poolKey(changed)).not.toBe(poolKey(first));
+		expect(poolKey(first)).toMatch(/^subagents:[0-9a-f]{16}$/);
+		expect(poolKey(undefined)).toBe("subagents:none");
+	});
+
+	it("parses subagents from Cursor SDK config files", () => {
+		expect(parseCursorSdkConfig({ subagents: { reviewer: REVIEWER, "bad name": REVIEWER } })).toEqual({
+			subagents: { reviewer: { description: "Reviews diffs.", prompt: "You review diffs.", model: "gpt-5.5@272k", thinking: "high" } },
+		});
+	});
+
+	it("resolves subagents from trusted project, then user, then builtin", () => {
+		const user = { subagents: { reviewer: { description: "User.", prompt: "User." } } };
+		const project = { subagents: { reviewer: { description: "Project.", prompt: "Project." } } };
+
+		expect(resolveCursorSdkConfig({ env: {} }).subagents).toMatchObject({ value: {}, source: "builtin" });
+		expect(resolveCursorSdkConfig({ env: {}, user }).subagents).toMatchObject({ value: user.subagents, source: "user" });
+		expect(resolveCursorSdkConfig({ env: {}, user, project }).subagents).toMatchObject({
+			value: project.subagents,
+			source: "project",
+			trustLevel: "trusted-project",
+		});
+	});
+
+	it("passes custom subagents to cloud Agent options only when configured", () => {
+		const resolvedConfig = resolveCursorSdkConfig({ env: {}, cli: { runtime: "cloud", cloud: { acknowledged: true } } });
+		const customSubagents = buildCursorCustomSubagentDefinitions({ reviewer: REVIEWER });
+
+		expect(
+			buildCursorCloudAgentOptions({ apiKey: "test-key", modelSelection: { id: "gpt-5.5" }, agentMode: "agent", resolvedConfig, customSubagents }).agents,
+		).toEqual(customSubagents);
+		expect(
+			buildCursorCloudAgentOptions({ apiKey: "test-key", modelSelection: { id: "gpt-5.5" }, agentMode: "agent", resolvedConfig }),
+		).not.toHaveProperty("agents");
+	});
+});
+
+describe("Cursor custom subagents in local session agents", () => {
+	beforeEach(async () => {
+		installCursorSessionStoreMock();
+		cursorSessionScopeTestUtils.reset();
+		await sessionAgentTestUtils.disposeAllSessionCursorAgents();
+		vi.clearAllMocks();
+	});
+
+	it("passes custom subagents to Agent.create and repools when they change", async () => {
+		const createAgent = vi.fn().mockImplementation(async () => ({
+			agentId: `agent-${createAgent.mock.calls.length}`,
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		}));
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/subagents.jsonl");
+		const params = {
+			apiKey: "test-key",
+			agentMode: "agent" as const,
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		};
+		const reviewer = { reviewer: { description: "Reviews diffs.", prompt: "You review diffs.", model: { id: "grok-4.5" } } };
+
+		const first = await acquireSessionCursorAgent({ ...params, customSubagents: reviewer });
+		const reused = await acquireSessionCursorAgent({ ...params, customSubagents: reviewer });
+		const changed = await acquireSessionCursorAgent({
+			...params,
+			customSubagents: { reviewer: { ...reviewer.reviewer, model: { id: "composer-2.5" } } },
+		});
+
+		expect(createAgent.mock.calls[0][0].agents).toEqual(reviewer);
+		expect(reused.agent).toBe(first.agent);
+		expect(changed.agent).not.toBe(first.agent);
+		expect(createAgent).toHaveBeenCalledTimes(2);
+	});
+
+	it("omits agents from Agent.create when no subagents are configured", async () => {
+		const createAgent = vi.fn().mockResolvedValue({
+			agentId: "agent-plain",
+			[Symbol.asyncDispose]: vi.fn().mockResolvedValue(undefined),
+		});
+		cursorSessionScopeTestUtils.set("/tmp/project", "/tmp/sessions/no-subagents.jsonl");
+
+		await acquireSessionCursorAgent({
+			apiKey: "test-key",
+			agentMode: "agent",
+			cwd: "/tmp/project",
+			modelSelection: { id: "composer-2.5" },
+			createAgent,
+		});
+
+		expect(createAgent.mock.calls[0][0]).not.toHaveProperty("agents");
+	});
+});

--- a/test/cursor-provider-stream-config.test.ts
+++ b/test/cursor-provider-stream-config.test.ts
@@ -136,6 +136,72 @@ describe("streamCursor prompt and model config", () => {
 		expect(mockedCreate.mock.calls[0][0].local).toMatchObject({ cwd, autoReview: true, sandboxOptions: { enabled: true } });
 	});
 
+	it("passes trusted project custom subagents into Agent.create", async () => {
+		const root = mkdtempSync(join(tmpdir(), "pi-cursor-subagents-"));
+		const cwd = join(root, "repo");
+		mkdirSync(join(cwd, ".pi"), { recursive: true });
+		writeFileSync(join(cwd, ".pi", "settings.json"), "{}\n");
+		writeFileSync(
+			join(cwd, ".pi", "cursor-sdk.json"),
+			JSON.stringify({
+				subagents: {
+					reviewer: { description: "Reviews diffs.", prompt: "You review diffs.", model: "gpt-5.5@272k", thinking: "high" },
+					"bad name": { description: "Unusable.", prompt: "Unusable." },
+				},
+			}),
+		);
+		cursorSessionScopeTestUtils.set(cwd, "/tmp/session-subagents.jsonl", "test-session", true);
+		mockCreatedAgent({
+			send: vi.fn().mockResolvedValue({
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			}),
+		});
+
+		try {
+			await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+
+		expect(mockedCreate.mock.calls[0][0].agents).toEqual({
+			reviewer: {
+				description: "Reviews diffs.",
+				prompt: "You review diffs.",
+				model: {
+					id: "gpt-5.5",
+					params: expect.arrayContaining([
+						{ id: "context", value: "272k" },
+						{ id: "reasoning", value: "high" },
+					]),
+				},
+			},
+		});
+	});
+
+	it("omits agents from Agent.create when no subagents are configured", async () => {
+		mockCreatedAgent({
+			send: vi.fn().mockResolvedValue({
+				id: "run-1",
+				agentId: "agent-1",
+				status: "finished",
+				wait: vi.fn().mockResolvedValue({ id: "run-1", status: "finished" }),
+				cancel: vi.fn(),
+				supports: () => true,
+				unsupportedReason: () => undefined,
+			}),
+		});
+
+		await collectEvents(streamCursor(makeModel("gpt-5.5@1m"), makeContext(), { apiKey: "test-key" }));
+
+		expect(mockedCreate.mock.calls[0][0]).not.toHaveProperty("agents");
+	});
+
 	it("lets CLI local safety flags override disabled env/config", async () => {
 		process.env.PI_CURSOR_AUTO_REVIEW = "0";
 		process.env.PI_CURSOR_SANDBOX = "0";


### PR DESCRIPTION
## Summary

Cursor's built-in `task` subagent types resolve models through Cursor's own registry, so a delegated task cannot be pointed at an arbitrary Cursor model. `@cursor/sdk` already accepts named subagent definitions on `AgentOptions.agents` (each with its own `ModelSelection | "inherit"`), but the provider never passed them, so Cursor's agent loop always started with zero custom subagents.

This adds a `subagents` block to `cursor-sdk.json` (user or trusted project). Each entry becomes one named Cursor subagent type pinned to a pi Cursor model id, resolved through the same metadata as session model selection, so aliases (`composer-2-5`) and context variants (`claude-opus-5@300k`) work and an unregistered id is passed through for Cursor to reject rather than silently rewritten.

- `src/cursor-custom-subagents.ts` holds the config shape and parsing only. Unusable names and entries missing `description`/`prompt` are skipped rather than failing the file, and a block with no usable entry resolves to absent so it cannot shadow a lower-precedence layer.
- `src/cursor-custom-subagent-definitions.ts` maps parsed entries onto `AgentOptions.agents` via `buildCursorModelSelection`. `fast` is read only from a subagent's own config, since session fast state is scoped to the selected session model and the cloud parent path omits `fast`.
- Definitions join the local session-agent pool key (bounded fingerprint, order-independent) so changing one builds a new Cursor agent instead of reusing a stale set.
- Precedence is trusted project, then user; there is no CLI flag or env var, and the winning layer replaces the whole set.

Local runtime caveat is documented rather than worked around: the installed SDK narrows local runs to `RuntimeCustomSubagentDefinition` (`model: string`) and keeps only `model.id`, so `thinking`, `fast`, and the context part of `@300k` apply on cloud only. A contract test pins both SDK shapes so this is caught if a future SDK preserves local params.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — the two failures (`test/cloud-smoke-helpers.test.ts` signal timing, `test/cursor-cloud-local-state.test.ts` comparison) reproduce on a clean checkout and are unrelated to this change
- [x] New `test/cursor-custom-subagents.test.ts`: parsing/skip rules, model alias and unknown-id resolution, `inherit`, pool-key behavior, and the SDK local-downgrade contract pin
- [x] Wiring test through `streamCursor` asserting trusted-project subagents reach `Agent.create` with resolved model params
- [x] End-to-end through pi with three tiers on a `composer-2-5` parent: `explore => Composer`, `implement => Cursor Grok 4.5`, `architect => Claude Opus 5`

Made with [Cursor](https://cursor.com)