### PR TITLE
feat: mirror Cursor todos/tasks into Pi rpiv-todo

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Maintainers can run `/cursor-tools` in a Cursor model session to print the curre
 
 When a new local Cursor SDK agent is created, the extension seeds the mode through `Agent.create({ mode })`. The extension also sends the effective Cursor mode on every `agent.send(..., { mode })` call so `/cursor-mode` and `--cursor-mode` remain the source of truth even when a pooled SDK agent is reused.
 
-Cursor SDK `plan` mode can produce plan-oriented output and Cursor todo/plan activity, but those replay cards remain display-only. They do not drive pi's plan-mode extension, pi todos, or active tool state.
+Cursor SDK `plan` mode can produce plan-oriented output and Cursor todo/plan activity. Replay cards stay display-only for plan mode and createPlan. Live `updateTodos` / `task` completions can optionally mirror into `@juicesharp/rpiv-todo` when that package is installed (`PI_CURSOR_TODO_MIRROR`, default on): todos replace the Cursor-sourced list, and finished Cursor tasks append a completed note. This never re-spawns a Pi subagent.
 
 ## Cursor local agent config and safety controls
 

--- a/docs/cursor-native-tool-replay.md
+++ b/docs/cursor-native-tool-replay.md
@@ -19,7 +19,7 @@ This document is about replay. Replay is not execution and is not the local pi b
 
 Replay labels, replay cards, and transcript tool names are display-only/context-only. Bridge MCP names are also not pi tool names: Cursor must call the exposed `pi__*` MCP name, while pi history and cards use the real pi tool name.
 
-Cursor SDK `plan` mode (`--cursor-mode plan` or `/cursor-mode plan`) can make Cursor produce plan-oriented text and plan/todo activity. Replay still treats Cursor `createPlan`, `updateTodos`, task/mode, and related workflow activity as display-only Cursor activity. It does not switch pi into plan mode, mutate pi todos, or change pi active tools.
+Cursor SDK `plan` mode (`--cursor-mode plan` or `/cursor-mode plan`) can make Cursor produce plan-oriented text and plan/todo activity. Replay still treats Cursor `createPlan`, task/mode cards as display-only Cursor activity for plan-mode switching. Live `updateTodos` / `task` completions may mirror into `@juicesharp/rpiv-todo` when installed (`PI_CURSOR_TODO_MIRROR`, default on); that path never re-runs Cursor work or spawns Pi subagents.
 
 ## Local pi bridge summary
 
@@ -89,7 +89,7 @@ This matrix covers **Cursor native tool replay only**. It does not describe the 
 | `write` | native replay or neutral activity | `write` or `cursor` | Native `write` only when recorded content/path args satisfy pi's `write` schema; otherwise neutral **Cursor write** activity |
 | `delete` | neutral activity | `cursor` | Collapsed label **Cursor delete** |
 | `readLints` | neutral activity | `cursor` | Collapsed label **Cursor diagnostics** |
-| `updateTodos` | neutral activity | `cursor` | Collapsed label **Cursor todos**; display-only, does not drive pi todos, including in Cursor SDK `plan` mode |
+| `updateTodos` | neutral activity | `cursor` | Collapsed label **Cursor todos**; live completions may mirror into `@juicesharp/rpiv-todo` when installed (`PI_CURSOR_TODO_MIRROR`) |
 | `createPlan` | neutral activity | `cursor` | Collapsed label **Cursor plan**; display-only, does not drive pi plan mode, including in Cursor SDK `plan` mode |
 | `task` | neutral activity | `cursor` | Collapsed label **Cursor subagent** by default; summary includes description plus subagent kind/model/short ID when Cursor reports them; `PI_CURSOR_TASK_PRESENTATION=task` restores **Cursor task** wording |
 | `generateImage` | neutral activity | `cursor` | Collapsed label **Cursor image generation** |
@@ -132,7 +132,7 @@ These behaviors are by design. They are not pi replay execution bugs:
 - **`shell` → `bash`:** Cursor shell completions render as native pi `bash` cards, including aliases normalized to `shell`.
 - **`edit` / `StrReplace` / notebook edits:** native pi `edit` cards only when recorded replay args truthfully satisfy pi's `edit` schema; otherwise neutral **Cursor edit** activity so pi validation does not reject the replay before recorded-result handling.
 - **`write`:** native pi `write` cards only when recorded content/path args satisfy pi's schema; otherwise neutral **Cursor write** activity.
-- **Plan/todo tools:** `createPlan` and `updateTodos` replay is display-only and does not drive pi plan mode or pi todo state, even when Cursor SDK mode is `plan` (see [What replay does not do](#what-replay-does-not-do)).
+- **Plan/todo tools:** `createPlan` replay is display-only and does not drive pi plan mode. Live `updateTodos` / `task` may mirror into `@juicesharp/rpiv-todo` when installed (`PI_CURSOR_TODO_MIRROR`); see [What replay does not do](#what-replay-does-not-do).
 - **`semSearch`:** semantic codebase search activity, not web search.
 - **Web search/fetch:** visible **Cursor web search** / **Cursor web fetch** activity when the SDK reports completed replayable tool data (SDK `mcp` with web `toolName`, host aliases above, or local transcript `webSearchToolCall` / `webFetchToolCall` records). These cards are display-only; pi does not expose executable web search/fetch tools through replay.
 - **Unknown/future SDK tools:** neutral Cursor activity cards titled with the SDK tool name (for example **Cursor futureSemSearchWidget**) and bounded scrubbed args/result/error text until an explicit spec is added.

--- a/src/cursor-bridge-contract.ts
+++ b/src/cursor-bridge-contract.ts
@@ -1,6 +1,6 @@
 export const CURSOR_PI_BRIDGE_MCP_TOOL_PREFIX = "pi__";
 export const CURSOR_PI_BRIDGE_PREFERENCE_TEXT =
-	"When exposed, prefer pi__mcp for MCP work and pi__subagent for delegation; use Cursor-configured MCP or Cursor-native subagents only when the matching pi__ tool is not exposed or unavailable.";
+	"When exposed, prefer pi__todo for todos and pi__subagent_spawn for delegation; use Cursor-native TodoWrite/Task only when the matching pi__ tool is not exposed or unavailable.";
 
 const CURSOR_PI_BRIDGE_CONTRACT_LINES = [
 	"Pi bridge contract:",

--- a/src/cursor-provider-turn-coordinator.ts
+++ b/src/cursor-provider-turn-coordinator.ts
@@ -16,6 +16,9 @@ import { getToolName } from "./cursor-transcript-utils.js";
 import { getNormalizedCursorToolName } from "./cursor-tool-visibility.js";
 import { buildCursorPiToolDisplay } from "./cursor-tool-transcript.js";
 import { getField } from "./cursor-record-utils.js";
+import { readCursorTaskMetadata } from "./cursor-task-presentation.js";
+import { mirrorCursorActivityTool } from "./cursor-todo-mirror.js";
+import { getToolArgs, getToolResult, normalizeResult } from "./cursor-transcript-utils.js";
 import { CursorTurnDisplayRouter } from "./cursor-provider-turn-display-router.js";
 import {
 	createTurnCoordinatorContentEmitter,
@@ -313,6 +316,21 @@ export class CursorSdkTurnCoordinator {
 			source: options.source,
 			fingerprint,
 		});
+
+		// Live Cursor activity only. Transcript/history completions stay display-only.
+		if (options.source !== "transcript") {
+			const normalized = getNormalizedCursorToolName(toolCall);
+			if (normalized === "updateTodos" || normalized === "task") {
+				const args = getToolArgs(toolCall);
+				const result = normalizeResult(getToolResult(toolCall));
+				void mirrorCursorActivityTool({
+					toolName: normalized,
+					args,
+					result,
+					taskMetadata: normalized === "task" ? readCursorTaskMetadata(args, result.value) : undefined,
+				});
+			}
+		}
 
 		const action = this.displayRouter.routeCompletedToolCall(toolCall, options);
 		if (action) this.displayRouter.emitDisplayAction(action);

--- a/src/cursor-session-scope.ts
+++ b/src/cursor-session-scope.ts
@@ -37,6 +37,13 @@ export function getCursorSessionFile(): string | undefined {
 }
 
 /**
+ * Pi session id when known; used by Cursor→Pi todo mirroring.
+ */
+export function getCursorSessionId(): string | undefined {
+	return state.sessionId;
+}
+
+/**
  * Stable scope key for session-agent pooling. Falls back to a process-local anonymous key
  * before the first session_start (tests and early startup).
  */

--- a/src/cursor-todo-mirror.ts
+++ b/src/cursor-todo-mirror.ts
@@ -1,0 +1,235 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { parseEnvBoolean } from "./cursor-env-boolean.js";
+import { getCursorSessionId } from "./cursor-session-scope.js";
+import type { CursorTaskMetadata } from "./cursor-task-presentation.js";
+import {
+	getTodoItems,
+	type CursorTodoItem,
+	type CursorToolResultLike,
+} from "./cursor-tool-result-display-readers.js";
+
+export const CURSOR_TODO_MIRROR_ENV = "PI_CURSOR_TODO_MIRROR";
+export const CURSOR_TODO_MIRROR_EVENT = "pi-cursor-sdk/todo-mirror";
+export const RPIV_TODO_UPDATED_EVENT = "rpiv-todo/updated";
+
+export const CURSOR_TODO_SOURCE = "cursor-updateTodos";
+export const CURSOR_TASK_NOTE_SOURCE = "cursor-task";
+
+type PiTaskStatus = "pending" | "in_progress" | "completed" | "deleted";
+
+export interface MirroredPiTask {
+	id: number;
+	subject: string;
+	description?: string;
+	activeForm?: string;
+	status: PiTaskStatus;
+	metadata?: Record<string, unknown>;
+}
+
+export interface MirroredPiTaskState {
+	tasks: MirroredPiTask[];
+	nextId: number;
+}
+
+export type CursorTodoMirrorKind = "updateTodos" | "task";
+
+export interface CursorTodoMirrorPayload {
+	kind: CursorTodoMirrorKind;
+	sessionId: string;
+	state: MirroredPiTaskState;
+}
+
+type CursorTodoMirrorEvents = Pick<ExtensionAPI, "events">;
+
+type RpivTodoStoreModule = {
+	replaceState(sessionId: string, next: MirroredPiTaskState): void;
+	getState(sessionId: string): MirroredPiTaskState;
+};
+
+let mirrorEvents: CursorTodoMirrorEvents | undefined;
+let storeImporter: (() => Promise<RpivTodoStoreModule | undefined>) | undefined;
+
+export function resolveCursorTodoMirrorEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	return parseEnvBoolean(env[CURSOR_TODO_MIRROR_ENV], true);
+}
+
+export function mapCursorTodoStatus(status: string | undefined): PiTaskStatus {
+	const normalized = status?.trim().toLowerCase();
+	if (!normalized) return "pending";
+	if (normalized === "completed" || normalized === "complete" || normalized === "done") return "completed";
+	// Cursor cancelled is not a pi status; keep visible as pending.
+	if (normalized === "cancelled" || normalized === "canceled") return "pending";
+	if (normalized === "in_progress" || normalized === "inprogress" || normalized === "in-progress") {
+		return "in_progress";
+	}
+	if (normalized === "deleted") return "deleted";
+	return "pending";
+}
+
+function cursorTodoKey(item: CursorTodoItem): string {
+	return item.content.trim();
+}
+
+function isPreservedTaskNote(task: MirroredPiTask): boolean {
+	return task.metadata?.source === CURSOR_TASK_NOTE_SOURCE && task.status !== "deleted";
+}
+
+export function mapCursorTodosToTasks(items: readonly CursorTodoItem[]): MirroredPiTask[] {
+	let nextId = 1;
+	const tasks: MirroredPiTask[] = [];
+	let sawInProgress = false;
+	for (const item of items) {
+		const subject = item.content.trim();
+		if (!subject) continue;
+		let status = mapCursorTodoStatus(item.status);
+		if (status === "in_progress") {
+			if (sawInProgress) status = "pending";
+			else sawInProgress = true;
+		}
+		tasks.push({
+			id: nextId,
+			subject,
+			status,
+			activeForm: status === "in_progress" ? subject : undefined,
+			metadata: {
+				source: CURSOR_TODO_SOURCE,
+				cursorKey: cursorTodoKey(item),
+				cursorStatus: item.status ?? null,
+			},
+		});
+		nextId += 1;
+	}
+	return tasks;
+}
+
+export function mapCursorTaskToNote(metadata: CursorTaskMetadata): MirroredPiTask {
+	const description = metadata.description?.trim() || "Cursor task";
+	const agentId = metadata.agentId?.trim();
+	const subject = agentId ? `Cursor task: ${description}` : `Cursor task: ${description}`;
+	return {
+		id: 1,
+		subject: subject.slice(0, 200),
+		description: [
+			metadata.subagentName ? `subagent=${metadata.subagentName}` : undefined,
+			metadata.subagentKind ? `kind=${metadata.subagentKind}` : undefined,
+			metadata.model ? `model=${metadata.model}` : undefined,
+			agentId ? `agentId=${agentId}` : undefined,
+			metadata.isBackground === true ? "background=true" : undefined,
+		]
+			.filter((line): line is string => Boolean(line))
+			.join("\n") || undefined,
+		status: "completed",
+		metadata: {
+			source: CURSOR_TASK_NOTE_SOURCE,
+			cursorAgentId: agentId ?? null,
+			cursorSubagentName: metadata.subagentName ?? null,
+			cursorSubagentKind: metadata.subagentKind ?? null,
+			cursorModel: metadata.model ?? null,
+			cursorIsBackground: metadata.isBackground ?? null,
+		},
+	};
+}
+
+export function mergeMirroredTodoState(
+	existing: MirroredPiTaskState | undefined,
+	incoming: { kind: "updateTodos"; items: readonly CursorTodoItem[] } | { kind: "task"; note: MirroredPiTask },
+): MirroredPiTaskState {
+	const preservedNotes = (existing?.tasks ?? []).filter(isPreservedTaskNote);
+	if (incoming.kind === "updateTodos") {
+		const mapped = mapCursorTodosToTasks(incoming.items);
+		const tasks = [...mapped];
+		let nextId = mapped.reduce((max, task) => Math.max(max, task.id), 0) + 1;
+		for (const note of preservedNotes) {
+			tasks.push({ ...note, id: nextId });
+			nextId += 1;
+		}
+		return { tasks, nextId };
+	}
+
+	const noteKey = incoming.note.metadata?.cursorAgentId;
+	const withoutMatching = preservedNotes.filter((task) => {
+		if (noteKey == null || noteKey === "") return true;
+		return task.metadata?.cursorAgentId !== noteKey;
+	});
+	const cursorTodos = (existing?.tasks ?? []).filter(
+		(task) => task.metadata?.source === CURSOR_TODO_SOURCE && task.status !== "deleted",
+	);
+	const tasks = [...cursorTodos];
+	let nextId = tasks.reduce((max, task) => Math.max(max, task.id), 0) + 1;
+	for (const note of withoutMatching) {
+		tasks.push({ ...note, id: nextId });
+		nextId += 1;
+	}
+	tasks.push({ ...incoming.note, id: nextId });
+	nextId += 1;
+	return { tasks, nextId };
+}
+
+export function registerCursorTodoMirror(pi: CursorTodoMirrorEvents): void {
+	mirrorEvents = pi;
+}
+
+export function __setCursorTodoMirrorStoreImporterForTests(
+	importer: (() => Promise<RpivTodoStoreModule | undefined>) | undefined,
+): void {
+	storeImporter = importer;
+}
+
+export function __resetCursorTodoMirrorForTests(): void {
+	mirrorEvents = undefined;
+	storeImporter = undefined;
+}
+
+async function loadRpivTodoStore(): Promise<RpivTodoStoreModule | undefined> {
+	if (storeImporter) return storeImporter();
+	try {
+		return (await import("@juicesharp/rpiv-todo/state/store.js")) as RpivTodoStoreModule;
+	} catch {
+		return undefined;
+	}
+}
+
+export async function mirrorCursorActivityTool(options: {
+	toolName: string;
+	args: Record<string, unknown>;
+	result: CursorToolResultLike;
+	taskMetadata?: CursorTaskMetadata;
+	env?: NodeJS.ProcessEnv;
+	sessionId?: string;
+}): Promise<CursorTodoMirrorPayload | undefined> {
+	if (!resolveCursorTodoMirrorEnabled(options.env)) return undefined;
+	if (options.toolName !== "updateTodos" && options.toolName !== "task") return undefined;
+
+	const sessionId = options.sessionId ?? getCursorSessionId() ?? "";
+	if (!sessionId) return undefined;
+
+	const store = await loadRpivTodoStore();
+	const existing = store?.getState(sessionId);
+
+	const state =
+		options.toolName === "updateTodos"
+			? mergeMirroredTodoState(existing, {
+					kind: "updateTodos",
+					items: getTodoItems(options.args, options.result),
+				})
+			: mergeMirroredTodoState(existing, {
+					kind: "task",
+					note: mapCursorTaskToNote(options.taskMetadata ?? {}),
+				});
+
+	const payload: CursorTodoMirrorPayload = {
+		kind: options.toolName,
+		sessionId,
+		state,
+	};
+
+	try {
+		store?.replaceState(sessionId, state);
+	} catch {
+		// Soft dependency: keep emitting so a local bridge can still apply.
+	}
+
+	mirrorEvents?.events.emit(CURSOR_TODO_MIRROR_EVENT, payload);
+	mirrorEvents?.events.emit(RPIV_TODO_UPDATED_EVENT, { sessionId });
+	return payload;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { registerCursorPiToolBridge } from "./cursor-pi-tool-bridge.js";
 import { registerCursorQuestionTool } from "./cursor-question-tool.js";
 import { registerCursorSkillTool } from "./cursor-skill-tool.js";
 import { registerCursorSessionScope } from "./cursor-session-scope.js";
+import { registerCursorTodoMirror } from "./cursor-todo-mirror.js";
 import { registerCursorSessionAgentLifecycle } from "./cursor-session-agent-lifecycle.js";
 import { registerCursorSessionAgentLineage } from "./cursor-session-agent-lineage.js";
 import { registerCursorSessionAgentResume } from "./cursor-session-agent-resume.js";
@@ -27,6 +28,7 @@ type CursorExtensionApi =
 	& Parameters<typeof registerCursorQuestionTool>[0]
 	& Parameters<typeof registerCursorSkillTool>[0]
 	& Parameters<typeof registerCursorPiToolBridge>[0]
+	& Parameters<typeof registerCursorTodoMirror>[0]
 	& Parameters<typeof registerCursorFallbackIssueWarning>[0]
 	& Parameters<typeof registerCursorAgentsContextDedup>[0]
 	& Parameters<typeof registerCursorOverflowNormalization>[0]
@@ -61,6 +63,7 @@ export default async function (pi: CursorExtensionApi) {
 	registerCursorNativeToolDisplay(pi);
 	registerCursorQuestionTool(pi);
 	registerCursorSkillTool(pi);
+	registerCursorTodoMirror(pi);
 	registerCursorPiToolBridge(pi);
 	registerCursorAgentsContextDedup(pi);
 	registerCursorOverflowNormalization(pi);

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -571,7 +571,7 @@ describe("buildCursorPrompt", () => {
 		expect(result.text).toContain("not pi card/history names");
 		expect(result.text).toContain("Do not claim pi-side or WebSearch/WebFetch tools");
 		expect(result.text).toContain("Use pi__cursor_ask_question for material choices if exposed");
-		expect(result.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(result.text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 		expect(result.text).not.toContain("Pi bridge contract:");
 		expect(result.text).not.toContain("do not use SwitchMode");
 	});
@@ -600,7 +600,7 @@ describe("buildCursorPrompt", () => {
 		const incremental = buildCursorIncrementalPrompt({ messages: [{ role: "user", content: "test", timestamp: 1 }] });
 		expect(bootstrap.text).toContain("explicit `cd`");
 		expect(incremental.text).toContain("explicit `cd`");
-		expect(incremental.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(incremental.text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 	});
 
 	it("adds plan-mode guidance without disabling inspection tools", () => {

--- a/test/cursor-bridge-contract.test.ts
+++ b/test/cursor-bridge-contract.test.ts
@@ -9,7 +9,7 @@ describe("cursor bridge contract", () => {
 		const text = getCursorPiBridgeContractText();
 		expect(text).toContain("Pi bridge contract:");
 		expect(text).toContain("pi__* names are live Cursor MCP bridge tool names");
-		expect(text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 		expect(text).toContain("only when the matching pi__ tool is not exposed or unavailable");
 	});
 

--- a/test/cursor-provider-bridge-session.test.ts
+++ b/test/cursor-provider-bridge-session.test.ts
@@ -158,10 +158,10 @@ describe("streamCursor session agent", () => {
 		const secondPrompt = mockSend.mock.calls[1]?.[0] as { text?: string };
 		expect(firstPrompt.text).toContain("Cursor SDK tool boundary:");
 		expect(firstPrompt.text).toContain("User: Hello");
-		expect(firstPrompt.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(firstPrompt.text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 		expect(secondPrompt.text).toContain("User: Follow up");
 		expect(secondPrompt.text).not.toContain("User: Hello");
-		expect(secondPrompt.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(secondPrompt.text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 	});
 
 	it("recreates the session agent after session-tree invalidation", async () => {

--- a/test/cursor-provider-local-resume.test.ts
+++ b/test/cursor-provider-local-resume.test.ts
@@ -103,7 +103,7 @@ describe("streamCursor local resume", () => {
 		const prompt = mockSend.mock.calls[0]?.[0] as { text?: string };
 		expect(prompt.text).toContain("User: Follow up");
 		expect(prompt.text).toContain("User: Hello");
-		expect(prompt.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(prompt.text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 	});
 
 	it.each([

--- a/test/cursor-provider-stream-config.test.ts
+++ b/test/cursor-provider-stream-config.test.ts
@@ -540,7 +540,7 @@ describe("streamCursor prompt and model config", () => {
 		expect(sentMessage.text).toContain("For exposed pi bridge tools");
 		expect(sentMessage.text).not.toContain("Use pi__cursor_ask_question");
 		expect(sentMessage.text).toContain("Pi bridge: call exposed pi__* MCP names");
-		expect(sentMessage.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
+		expect(sentMessage.text).toContain("prefer pi__todo for todos and pi__subagent_spawn for delegation");
 		expect(sentMessage.text).toContain("pi__sem_reindex");
 	});
 

--- a/test/cursor-todo-mirror.test.ts
+++ b/test/cursor-todo-mirror.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	__resetCursorTodoMirrorForTests,
+	__setCursorTodoMirrorStoreImporterForTests,
+	CURSOR_TASK_NOTE_SOURCE,
+	CURSOR_TODO_MIRROR_EVENT,
+	CURSOR_TODO_SOURCE,
+	RPIV_TODO_UPDATED_EVENT,
+	mapCursorTaskToNote,
+	mapCursorTodoStatus,
+	mapCursorTodosToTasks,
+	mergeMirroredTodoState,
+	mirrorCursorActivityTool,
+	registerCursorTodoMirror,
+	resolveCursorTodoMirrorEnabled,
+} from "../src/cursor-todo-mirror.js";
+
+describe("cursor todo mirror", () => {
+	afterEach(() => {
+		__resetCursorTodoMirrorForTests();
+	});
+
+	it("defaults mirror on and honors opt-out", () => {
+		expect(resolveCursorTodoMirrorEnabled({})).toBe(true);
+		expect(resolveCursorTodoMirrorEnabled({ PI_CURSOR_TODO_MIRROR: "0" })).toBe(false);
+	});
+
+	it("maps Cursor todo statuses onto pi statuses", () => {
+		expect(mapCursorTodoStatus("pending")).toBe("pending");
+		expect(mapCursorTodoStatus("inProgress")).toBe("in_progress");
+		expect(mapCursorTodoStatus("completed")).toBe("completed");
+		expect(mapCursorTodoStatus("cancelled")).toBe("pending");
+	});
+
+	it("keeps at most one in_progress Cursor todo", () => {
+		const tasks = mapCursorTodosToTasks([
+			{ content: "A", status: "inProgress" },
+			{ content: "B", status: "inProgress" },
+			{ content: "C", status: "completed" },
+		]);
+		expect(tasks.map((task) => task.status)).toEqual(["in_progress", "pending", "completed"]);
+		expect(tasks.every((task) => task.metadata?.source === CURSOR_TODO_SOURCE)).toBe(true);
+	});
+
+	it("preserves Cursor task notes across updateTodos snapshots", () => {
+		const withNote = mergeMirroredTodoState(undefined, {
+			kind: "task",
+			note: mapCursorTaskToNote({
+				description: "Map APIs",
+				agentId: "abc123",
+				subagentName: "composer-worker",
+			}),
+		});
+		expect(withNote.tasks).toHaveLength(1);
+		expect(withNote.tasks[0]?.metadata?.source).toBe(CURSOR_TASK_NOTE_SOURCE);
+
+		const merged = mergeMirroredTodoState(withNote, {
+			kind: "updateTodos",
+			items: [{ content: "Ship mirror", status: "pending" }],
+		});
+		expect(merged.tasks.map((task) => task.subject)).toEqual([
+			"Ship mirror",
+			"Cursor task: Map APIs",
+		]);
+	});
+
+	it("upserts task notes by agent id", () => {
+		const first = mergeMirroredTodoState(undefined, {
+			kind: "task",
+			note: mapCursorTaskToNote({ description: "old", agentId: "a1" }),
+		});
+		const second = mergeMirroredTodoState(first, {
+			kind: "task",
+			note: mapCursorTaskToNote({ description: "new", agentId: "a1" }),
+		});
+		expect(second.tasks.filter((task) => task.metadata?.source === CURSOR_TASK_NOTE_SOURCE)).toHaveLength(1);
+		expect(second.tasks[0]?.subject).toContain("new");
+	});
+
+	it("writes rpiv-todo store and emits mirror events", async () => {
+		const replaced: Array<{ sessionId: string; state: unknown }> = [];
+		const emitted: Array<{ channel: string; data: unknown }> = [];
+		__setCursorTodoMirrorStoreImporterForTests(async () => ({
+			getState: () => ({ tasks: [], nextId: 1 }),
+			replaceState: (sessionId, state) => {
+				replaced.push({ sessionId, state });
+			},
+		}));
+		registerCursorTodoMirror({
+			events: {
+				emit: (channel, data) => {
+					emitted.push({ channel, data });
+				},
+			},
+		} as never);
+
+		const payload = await mirrorCursorActivityTool({
+			toolName: "updateTodos",
+			args: {
+				todos: [{ content: "Wire mirror", status: "inProgress" }],
+			},
+			result: { status: "ok", value: {} },
+			sessionId: "sess-1",
+			env: { PI_CURSOR_TODO_MIRROR: "1" },
+		});
+
+		expect(payload?.state.tasks).toHaveLength(1);
+		expect(replaced).toHaveLength(1);
+		expect(emitted.map((entry) => entry.channel)).toEqual([
+			CURSOR_TODO_MIRROR_EVENT,
+			RPIV_TODO_UPDATED_EVENT,
+		]);
+	});
+
+	it("skips when disabled", async () => {
+		const payload = await mirrorCursorActivityTool({
+			toolName: "updateTodos",
+			args: { todos: [{ content: "Nope", status: "pending" }] },
+			result: { status: "ok", value: {} },
+			sessionId: "sess-1",
+			env: { PI_CURSOR_TODO_MIRROR: "0" },
+		});
+		expect(payload).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary
- Live Cursor `updateTodos` completions mirror into `@juicesharp/rpiv-todo` when installed (`PI_CURSOR_TODO_MIRROR`, default on).
- Finished Cursor `task` activity appends a completed Pi todo note; never re-spawns a Pi subagent.
- Emits `pi-cursor-sdk/todo-mirror` and `rpiv-todo/updated` for overlay consumers.
- Bridge preference text now prefers `pi__todo` / `pi__subagent_spawn`.

## Test plan
- [x] `pnpm exec vitest run test/cursor-todo-mirror.test.ts test/cursor-bridge-contract.test.ts test/context.test.ts test/cursor-provider-bridge-session.test.ts test/cursor-provider-local-resume.test.ts test/cursor-provider-stream-config.test.ts` (99 passed)
- [ ] Manual: Cursor parent with rpiv-todo loaded; TodoWrite updates Pi overlay; Task completion adds a note; `PI_CURSOR_TODO_MIRROR=0` disables.

Made with [Cursor](https://cursor.com)