### PR TITLE
fix: resolve startup auth through model registry

### DIFF
--- a/_docs/ai/plans/20260813_112957_claude_issue-214-prime-agent-startup-auth.md
+++ b/_docs/ai/plans/20260813_112957_claude_issue-214-prime-agent-startup-auth.md
@@ -1,0 +1,66 @@
+# Prime Agent Startup Auth Implementation Plan
+
+> 作成日時: 2026-08-13 11:29
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use test-driven development and request code review before creating the pull request.
+
+**Goal:** Remove the extension's dependency on `readStoredCredential` and resolve startup-session Cursor credentials through the host-provided `ModelRegistry`.
+
+**Architecture:** Register the bundled/startup catalog immediately so the provider remains available before a session exists. During `session_start`, obtain the provider-scoped API key from `ctx.modelRegistry.getApiKeyForProvider("cursor")`, run cached/live discovery with that key, and replace the provider catalog before interactive selection. Runtime turns continue using the API key supplied by the host in stream options, while `CURSOR_API_KEY` remains the non-host fallback.
+
+**Tech Stack:** TypeScript, pi extension lifecycle API, Vitest
+
+## Issue
+
+- fitchmultz/pi-cursor-sdk#214
+
+## Global Constraints
+
+- Do not import or dynamically access `readStoredCredential`.
+- Do not persist or log Cursor API keys.
+- Preserve provider registration and `CURSOR_API_KEY` behavior for standalone pi.
+- Keep the change limited to authentication/catalog discovery and regression tests.
+
+---
+
+### Task 1: Host-scoped credential resolution
+
+**Files:**
+- Modify: `src/cursor-api-key.ts`
+- Modify: `src/model-discovery.ts`
+- Test: `test/cursor-api-key.test.ts`
+- Test: `test/model-discovery.test.ts`
+
+**Interfaces:**
+- `resolveCursorRuntimeApiKey(apiKey?: string): string | undefined` normalizes a host-provided key first, then falls back to `CURSOR_API_KEY`.
+- `discoverModels({ apiKey })` consumes the provider-scoped key supplied by the extension lifecycle.
+
+- [ ] Replace stored-file credential reads with host-key normalization plus environment fallback.
+- [ ] Add regression tests proving host keys take precedence, placeholders resolve through the environment, and missing values remain missing.
+- [ ] Run the focused API-key and discovery tests.
+
+### Task 2: Session-start catalog registration
+
+**Files:**
+- Modify: `src/index.ts`
+- Test: `test/index-registration.test.ts`
+
+**Interfaces:**
+- `session_start` receives `ctx.modelRegistry` and calls `getApiKeyForProvider("cursor")`.
+- Successful discovery replaces the initially registered Cursor provider catalog.
+
+- [ ] Write a failing registration test for a stored host key used during `session_start`.
+- [ ] Register a session-start catalog synchronization handler using `ModelRegistry`.
+- [ ] Ensure fallback warnings are emitted only when the host-scoped discovery still falls back.
+- [ ] Run the focused extension registration tests.
+
+### Task 3: Verification and delivery
+
+**Files:**
+- Modify only if verification identifies defects.
+
+- [ ] Run `npm run typecheck`.
+- [ ] Run `npm test`.
+- [ ] Run `npm run check:platform-smoke`.
+- [ ] Request an independent code review and resolve all critical/important findings.
+- [ ] Commit, push `fix/214-prime-agent-startup-auth`, and open an upstream PR containing `Closes #214`.

--- a/docs/cursor-model-ux-spec.md
+++ b/docs/cursor-model-ux-spec.md
@@ -1,5 +1,8 @@
 # Cursor Model UX Spec
 
+> 作成日時: 2026-08-13 11:43
+> 更新日時: 2026-08-13 11:43
+
 > Maintainer note: this is an internal design and behavior spec for pi-cursor-sdk. If you are trying to install or use the extension, start with the main [README](../README.md) instead.
 
 ## Status
@@ -16,7 +19,7 @@ Current implementation notes:
 - Installed `@cursor/sdk` user messages accept images, and Cursor models are treated as image-capable; registered input metadata is `text` plus `image`.
 - Image payload forwarding sends images only from the latest user message. If the latest user turn is plain text after an earlier image turn, the transcript keeps an `[image omitted from transcript]` placeholder but no image bytes are sent to Cursor. The prompt explicitly tells Cursor that prior image bytes are unavailable and to ask the user to reattach or describe a prior image when needed. Carrying images forward across turns remains a future product decision because it affects token cost, privacy, stale visual context, and expected multimodal follow-up behavior.
 - Exact `@cursor/sdk@1.0.23` is a package dependency of this extension; users should not need a global SDK install. Pi 0.84.0 is the minimum supported and current validation baseline, while optional published Pi core peer dependencies use `"*"` ranges per current Pi package guidance.
-- Startup discovery does not duplicate Pi CLI parsing: it uses stored `~/.pi/agent/auth.json` API-key auth from `/login`, then `CURSOR_API_KEY`, otherwise it registers the bundled fallback catalog. Provider turns keep Pi's resolved `options.apiKey`. `/cursor-refresh-models` and `/cursor-cloud` mutations resolve provider `cursor` through the command context's Pi ModelRegistry, then normalize placeholders through `CURSOR_API_KEY`. The extension config file stores only non-secret Cursor-only state such as fast defaults and the user-level local HTTP transport preference.
+- Startup discovery does not duplicate Pi CLI parsing or read auth storage directly: it first registers the bundled fallback catalog, then at `session_start` asks the host ModelRegistry for provider `cursor` and re-registers the discovered catalog. The explicit host key takes precedence over `CURSOR_API_KEY`. Provider turns keep Pi's resolved `options.apiKey`. `/cursor-refresh-models` and `/cursor-cloud` mutations also resolve provider `cursor` through the command context's Pi ModelRegistry, then normalize placeholders through `CURSOR_API_KEY`. The extension config file stores only non-secret Cursor-only state such as fast defaults and the user-level local HTTP transport preference.
 - Cursor Cloud repository overrides accept only HTTPS repository URLs without userinfo, query parameters, or fragments. Invalid values fail during preflight before `Agent.create()`, messages never echo the supplied URL, and shared provider/maintainer scrubbing removes URL/SCP-style userinfo defensively.
 - Cursor Cloud requires a persisted pi session. Immediately after remote `Agent.create()` returns, before debug work or abort checks, the provider appends a branch-local pi lifecycle entry, fsyncs the existing Pi session JSONL anchor through a read-write descriptor, and then fsyncs a newline-framed sidecar keyed by the stable pi session ID (POSIX mode `0600`; Windows inherits the user session directory ACL) in the session directory. Journal creation is exclusive, and existing append/read opens reject symlinks and require matching regular-file descriptor/path identity before using the descriptor. Existing session files use the exact lifecycle entry ID as anchor; fileless first turns use an orphan marker that a same-session-ID restart durably claims onto exactly one matching or replacement branch, surviving the timestamped path change and later JSONL creation without granting sibling access; returned run IDs are fsynced before abort/wait handling, readers skip malformed/truncated lines independently, and branch-only history events are reduced after deduplicated sidecar history, and tombstones are tracked before records exist. A durable sidecar result remains authoritative if its optional Pi mirror append fails; if the sidecar result itself fails, the prior durable intent remains pending and blocks retry rather than claiming success. `--no-session` and durable-ledger failures fail closed before send, while post-send ledger failure requests bounded cancellation. `/cursor-cloud` always validates the embedded session ID, accepts only null anchors while truly fileless, and reconciles each orphan to one branch before listing or mutation. Successive record events merge run/branch metadata monotonically even when mirrored sources arrive out of order. Archive/delete require resolved Cursor auth, fsync a durable intent before the SDK call, and fsync a durable success result afterward; unresolved intent blocks repeat mutation and requires dashboard inspection.
 - Local agents pass `settingSources: ["all"]` by default so Cursor MCP servers, plugin tools, project/user settings, and related Cursor-native capabilities are available. Users can narrow loading with a comma-separated list such as `PI_CURSOR_SETTING_SOURCES=project,user,plugins`, or disable ambient setting sources with `PI_CURSOR_SETTING_SOURCES=none`. `/cursor-refresh-config` calls the current pooled SDK agent's `agent.reload()` to refresh filesystem Cursor config without recreating the agent. The provider suppresses direct Cursor SDK bootstrap stdout/stderr/console noise (including late first-send workspace loading such as hook compatibility warnings) so it does not pollute pi's TUI.
@@ -77,18 +80,18 @@ Not building now:
 
 Cursor SDK is the source of truth for Cursor model IDs and Cursor-supported parameters.
 
-At startup, the extension calls:
+During extension loading, the extension registers a bundled fallback catalog without reading host auth storage directly. At `session_start`, it asks the host ModelRegistry for the `cursor` provider key, then discovers and re-registers the catalog by calling:
 
 ```ts
 Cursor.models.list({ apiKey });
 ```
 
-Startup discovery resolves `apiKey` in this order:
+Discovery resolves `apiKey` in this order:
 
-1. Stored pi auth for provider `cursor` from `readStoredCredential("cursor")`, accepting only an `api_key` credential.
+1. The key supplied by the host ModelRegistry, including stored `/login` auth.
 2. `CURSOR_API_KEY`.
 
-Startup never parses `process.argv`; Pi remains the sole owner of CLI model/provider/key parsing. Provider turns keep Pi's resolved `options.apiKey`. Users can persist the stored key through `/login` -> `Use an API key` -> `Cursor`. If auth is added after startup, fallback models can run once Pi resolves the saved key for provider requests, and `/cursor-refresh-models` asks the command context's ModelRegistry for provider `cursor` and passes that normalized key explicitly to a forced live refresh.
+Startup never parses `process.argv`; Pi remains the sole owner of CLI model/provider/key parsing. Provider turns keep Pi's resolved `options.apiKey`. Users can persist the stored key through `/login` -> `Use an API key` -> `Cursor`. If auth is added after `session_start`, fallback models can run once Pi resolves the saved key for provider requests, and `/cursor-refresh-models` asks the command context's ModelRegistry for provider `cursor` and passes that normalized key explicitly to a forced live refresh.
 
 For each model, use:
 

--- a/src/cursor-api-key.ts
+++ b/src/cursor-api-key.ts
@@ -1,10 +1,9 @@
 export const CURSOR_API_KEY_ENV_VAR = "CURSOR_API_KEY";
-const CURSOR_PROVIDER_ID = "cursor";
 
 // Non-secret literal sentinel for pi's provider registry. Pi 0.77 treats `$ENV_VAR`
 // values as unconfigured when the env var is absent, which hides fallback models
 // before `/login`. Keep the provider available and resolve the real key in the
-// Cursor provider turn path from pi auth or CURSOR_API_KEY.
+// Cursor provider turn path from the host ModelRegistry or CURSOR_API_KEY.
 export const CURSOR_API_KEY_CONFIG_VALUE = "pi-cursor-sdk-cursor-api-key-placeholder";
 
 const CURSOR_API_KEY_PLACEHOLDERS = new Set([
@@ -21,16 +20,6 @@ export function resolveCursorApiKey(apiKey?: string): string | undefined {
 	return trimmed;
 }
 
-async function getStoredCursorApiKey(): Promise<string | undefined> {
-	try {
-		const { readStoredCredential } = await import("@earendil-works/pi-coding-agent");
-		const credential = readStoredCredential(CURSOR_PROVIDER_ID);
-		return resolveCursorApiKey(credential?.type === "api_key" ? credential.key : undefined);
-	} catch {
-		return undefined;
-	}
-}
-
-export async function resolveCursorRuntimeApiKey(): Promise<string | undefined> {
-	return (await getStoredCursorApiKey()) ?? resolveCursorApiKey(process.env.CURSOR_API_KEY);
+export function resolveCursorRuntimeApiKey(apiKey?: string): string | undefined {
+	return resolveCursorApiKey(apiKey) ?? resolveCursorApiKey(process.env.CURSOR_API_KEY);
 }

--- a/src/cursor-fallback-warning.ts
+++ b/src/cursor-fallback-warning.ts
@@ -8,12 +8,17 @@ export type CursorFallbackWarningExtensionApi = CursorModelLifecycleExtensionApi
 
 export function registerCursorFallbackIssueWarning(
 	pi: CursorFallbackWarningExtensionApi,
-	issue: CursorModelFallbackIssue,
+	issueOrGetter: CursorModelFallbackIssue | (() => CursorModelFallbackIssue | undefined),
 ): void {
+	const getIssue =
+		typeof issueOrGetter === "function"
+			? issueOrGetter
+			: () => issueOrGetter;
 	const warnedSessionScopeKeys = new Set<string>();
 
 	registerCursorModelLifecycle(pi, (ctx: ExtensionContext) => {
-		if (!isCursorModel(ctx.model) || !ctx.hasUI) return;
+		const issue = getIssue();
+		if (!issue || !isCursorModel(ctx.model) || !ctx.hasUI) return;
 		const scopeKey = getCursorSessionScopeKey();
 		if (warnedSessionScopeKeys.has(scopeKey)) return;
 		warnedSessionScopeKeys.add(scopeKey);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ProviderConfig, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext, ProviderConfig, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
 import { discoverModels, type CursorModelFallbackIssue } from "./model-discovery.js";
 import { registerCursorRuntimeControls } from "./cursor-state.js";
 import { registerCursorNativeToolDisplay } from "./cursor-native-tool-display-registration.js";
@@ -64,16 +64,29 @@ export default async function (pi: CursorExtensionApi) {
 	registerCursorPiToolBridge(pi);
 	registerCursorAgentsContextDedup(pi);
 	registerCursorOverflowNormalization(pi);
-	let fallbackIssue: CursorModelFallbackIssue | undefined;
-	const models = await discoverModels({
-		onFallback: (issue) => {
-			fallbackIssue = issue;
-		},
+
+	const sessionFallbackIssueRef: { current: CursorModelFallbackIssue | undefined } = { current: undefined };
+
+	const syncSessionCatalog = async (ctx: ExtensionContext): Promise<void> => {
+		sessionFallbackIssueRef.current = undefined;
+		const apiKey = resolveCursorApiKey(await ctx.modelRegistry.getApiKeyForProvider("cursor"));
+		const sessionModels = await discoverModels({
+			apiKey,
+			onFallback: (issue) => {
+				sessionFallbackIssueRef.current = issue;
+			},
+		});
+		registerCursorProvider(pi, sessionModels);
+	};
+
+	pi.on("session_start", async (_event, ctx) => {
+		await syncSessionCatalog(ctx);
 	});
 
-	if (fallbackIssue) {
-		registerCursorFallbackIssueWarning(pi, fallbackIssue);
-	}
+	registerCursorFallbackIssueWarning(pi, () => sessionFallbackIssueRef.current);
+
+	const startupModels = await discoverModels();
+	registerCursorProvider(pi, startupModels);
 
 	pi.registerCommand("cursor-refresh-models", {
 		description: "Refresh the live Cursor model catalog without restarting pi",
@@ -87,6 +100,7 @@ export default async function (pi: CursorExtensionApi) {
 					refreshFallbackIssue = issue;
 				},
 			});
+			sessionFallbackIssueRef.current = refreshFallbackIssue;
 			registerCursorProvider(pi, refreshedModels);
 			if (!ctx.hasUI) return;
 			if (refreshFallbackIssue) {
@@ -97,7 +111,6 @@ export default async function (pi: CursorExtensionApi) {
 		},
 	});
 
-	registerCursorProvider(pi, models);
 	// Register last so session_shutdown cleanup remains protected until other Cursor handlers finish.
 	registerCursorSdkSessionProcessErrorGuard(pi);
 }

--- a/src/model-discovery.ts
+++ b/src/model-discovery.ts
@@ -44,7 +44,7 @@ export interface DiscoverModelsOptions {
 }
 
 async function getDiscoveryApiKey(apiKey?: string): Promise<string | undefined> {
-	return resolveCursorApiKey(apiKey) ?? resolveCursorRuntimeApiKey();
+	return resolveCursorRuntimeApiKey(apiKey);
 }
 
 export interface CursorModelMetadata {

--- a/test/cursor-api-key.test.ts
+++ b/test/cursor-api-key.test.ts
@@ -1,6 +1,3 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	CURSOR_API_KEY_CONFIG_VALUE,
@@ -8,28 +5,17 @@ import {
 	resolveCursorRuntimeApiKey,
 } from "../src/cursor-api-key.js";
 
-function writeStoredCursorApiKey(apiKey: string): void {
-	writeFileSync(
-		join(process.env.PI_CODING_AGENT_DIR!, "auth.json"),
-		JSON.stringify({ cursor: { type: "api_key", key: apiKey } }, null, 2),
-	);
-}
-
 describe("cursor-api-key helpers", () => {
 	const originalEnv = process.env;
 	const originalArgv = process.argv;
-	let tmpAgentDir: string;
 
 	beforeEach(() => {
 		process.env = { ...originalEnv };
 		delete process.env.CURSOR_API_KEY;
-		tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-api-key-"));
-		process.env.PI_CODING_AGENT_DIR = tmpAgentDir;
 		process.argv = ["node", "vitest"];
 	});
 
 	afterEach(() => {
-		rmSync(tmpAgentDir, { recursive: true, force: true });
 		process.env = originalEnv;
 		process.argv = originalArgv;
 	});
@@ -43,7 +29,12 @@ describe("cursor-api-key helpers", () => {
 		},
 	);
 
-	it("ignores every process argv form and resolves stored auth before env", async () => {
+	it("prefers a host-provided key over CURSOR_API_KEY", () => {
+		process.env.CURSOR_API_KEY = "env-key-123";
+		expect(resolveCursorRuntimeApiKey("host-key-123")).toBe("host-key-123");
+	});
+
+	it("ignores every process argv form and falls back to env when host key is absent", () => {
 		process.argv = [
 			"node", "pi", "--model", "anthropic/first", "--api-key", "first-key",
 			"--MODEL", "cursor/case", "--API-KEY", "case-key",
@@ -51,19 +42,19 @@ describe("cursor-api-key helpers", () => {
 			"--models", "cursor/list-like", "--provider", "cursor",
 			"--model", "cursor/final", "--api-key", "last-key",
 		];
-		expect(await resolveCursorRuntimeApiKey()).toBeUndefined();
+		expect(resolveCursorRuntimeApiKey()).toBeUndefined();
 
 		process.env.CURSOR_API_KEY = "env-key-123";
-		expect(await resolveCursorRuntimeApiKey()).toBe("env-key-123");
-
-		writeStoredCursorApiKey("stored-key-123");
-		expect(await resolveCursorRuntimeApiKey()).toBe("stored-key-123");
+		expect(resolveCursorRuntimeApiKey()).toBe("env-key-123");
 	});
 
-	it("resolves stored placeholders through env", async () => {
-		writeStoredCursorApiKey(CURSOR_API_KEY_CONFIG_VALUE);
+	it("resolves host placeholders through env", () => {
 		process.env.CURSOR_API_KEY = "env-key-123";
+		expect(resolveCursorRuntimeApiKey(CURSOR_API_KEY_CONFIG_VALUE)).toBe("env-key-123");
+	});
 
-		expect(await resolveCursorRuntimeApiKey()).toBe("env-key-123");
+	it("returns undefined when host and env keys are missing", () => {
+		expect(resolveCursorRuntimeApiKey()).toBeUndefined();
+		expect(resolveCursorRuntimeApiKey("   ")).toBeUndefined();
 	});
 });

--- a/test/index-registration.test.ts
+++ b/test/index-registration.test.ts
@@ -70,7 +70,7 @@ describe("extension registration and discovery", () => {
 
 	it("registers Cursor runtime controls and one provider with correct fields", async () => {
 		const mockModels = [makeProviderModelConfig("composer-2", { name: "Cursor Composer 2" })];
-		mockedDiscover.mockResolvedValueOnce(mockModels);
+		mockedDiscover.mockResolvedValueOnce(mockModels).mockResolvedValue(mockModels);
 
 		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
 		const pi = createExtensionPi();
@@ -222,8 +222,8 @@ describe("extension registration and discovery", () => {
 		expect(pi.on).toHaveBeenCalledWith("before_agent_start", expect.any(Function));
 		expect(pi.on).toHaveBeenCalledWith("turn_start", expect.any(Function));
 		expect(pi.on).toHaveBeenCalledWith("model_select", expect.any(Function));
-		expect(mockedDiscover).toHaveBeenCalledOnce();
-		expect(pi.registerProvider).toHaveBeenCalledOnce();
+		expect(mockedDiscover).toHaveBeenCalledTimes(2);
+		expect(pi.registerProvider).toHaveBeenCalledTimes(2);
 
 		const [call] = pi._registered;
 		expect(call.name).toBe("cursor");
@@ -569,6 +569,32 @@ describe("extension registration and discovery", () => {
 		expect(call.config.models).toHaveLength(2);
 	});
 
+	it("refreshes Cursor models from the host registry on session_start", async () => {
+		const startupModels = [makeProviderModelConfig("composer-2", { name: "Cursor Composer 2" })];
+		const sessionModels = [
+			makeProviderModelConfig("gpt-5.5@1m", {
+				name: "GPT-5.5 @ 1m",
+				reasoning: true,
+				contextWindow: 1_000_000,
+			}),
+		];
+		mockedDiscover.mockResolvedValueOnce(startupModels).mockResolvedValueOnce(sessionModels);
+		const pi = createExtensionPi();
+		await extensionFactory(pi);
+		const getApiKeyForProvider = vi.fn().mockResolvedValue(" host-registry-key ");
+
+		await pi.runSessionStart({
+			modelRegistry: { getApiKeyForProvider } as never,
+		});
+
+		expect(getApiKeyForProvider).toHaveBeenCalledWith("cursor");
+		expect(mockedDiscover).toHaveBeenNthCalledWith(2, expect.objectContaining({ apiKey: "host-registry-key" }));
+		expect(mockedDiscover).toHaveBeenCalledTimes(2);
+		expect(pi.registerProvider).toHaveBeenCalledTimes(2);
+		expect(pi._registered[0].config.models).toBe(startupModels);
+		expect(pi._registered[1].config.models).toBe(sessionModels);
+	});
+
 	it("refreshes Cursor models through a live command without reload", async () => {
 		const startupModels = [makeProviderModelConfig("composer-2", { name: "Cursor Composer 2" })];
 		const refreshedModels = [
@@ -687,7 +713,7 @@ describe("extension registration and discovery", () => {
 	});
 
 	it("notifies interactive users when fallback models are registered", async () => {
-		mockedDiscover.mockImplementationOnce(async (options: DiscoverOptions) => {
+		mockedDiscover.mockImplementation(async (options: DiscoverOptions) => {
 			options?.onFallback?.({
 				reason: "missing-api-key",
 				message:
@@ -714,7 +740,7 @@ describe("extension registration and discovery", () => {
 	});
 
 	it("does not notify fallback discovery issues for non-Cursor sessions", async () => {
-		mockedDiscover.mockImplementationOnce(async (options: DiscoverOptions) => {
+		mockedDiscover.mockImplementation(async (options: DiscoverOptions) => {
 			options?.onFallback?.({
 				reason: "empty-model-list",
 				message: "Cursor model discovery returned no models; using fallback Cursor model list.",
@@ -737,7 +763,7 @@ describe("extension registration and discovery", () => {
 	});
 
 	it("notifies fallback discovery issues after delayed Cursor model selection", async () => {
-		mockedDiscover.mockImplementationOnce(async (options: DiscoverOptions) => {
+		mockedDiscover.mockImplementation(async (options: DiscoverOptions) => {
 			options?.onFallback?.({
 				reason: "missing-api-key",
 				message: "missing key; using fallback models",
@@ -765,8 +791,53 @@ describe("extension registration and discovery", () => {
 		expect(notify).toHaveBeenCalledWith("missing key; using fallback models", "warning");
 	});
 
+	it("clears a pending session fallback warning after a successful live refresh", async () => {
+		const fallbackModels = [makeProviderModelConfig("composer-2", { name: "Cursor Composer 2" })];
+		const fallbackDiscovery = async (options: DiscoverOptions) => {
+			options?.onFallback?.({
+				reason: "missing-api-key",
+				message: "missing key; using fallback models",
+			});
+			return fallbackModels;
+		};
+		mockedDiscover
+			.mockImplementationOnce(fallbackDiscovery)
+			.mockImplementationOnce(fallbackDiscovery)
+			.mockResolvedValueOnce([makeProviderModelConfig("gpt-5.5@1m", { name: "GPT-5.5 @ 1m" })]);
+
+		const pi = createExtensionPi();
+		await extensionFactory(pi);
+
+		const notify = vi.fn();
+		await pi.runSessionStart({
+			hasUI: true,
+			model: makeHarnessModel("anthropic", "anthropic-messages", "claude-sonnet-4-5"),
+			ui: { notify, setStatus: vi.fn() },
+			sessionManager: { getBranch: vi.fn(() => []) },
+		});
+		expect(notify).not.toHaveBeenCalled();
+
+		await pi.runCommand(
+			"cursor-refresh-models",
+			"",
+			createExtensionCommandContext({
+				hasUI: true,
+				model: undefined,
+				ui: { notify },
+			}),
+		);
+		notify.mockClear();
+
+		await pi.runModelSelect(makeHarnessModel("cursor", "cursor-sdk", "gpt-5.5@1m"), {
+			hasUI: true,
+			ui: { notify, setStatus: vi.fn() },
+		});
+
+		expect(notify).not.toHaveBeenCalled();
+	});
+
 	it("notifies fallback discovery issues once per Cursor session scope", async () => {
-		mockedDiscover.mockImplementationOnce(async (options: DiscoverOptions) => {
+		mockedDiscover.mockImplementation(async (options: DiscoverOptions) => {
 			options?.onFallback?.({
 				reason: "missing-api-key",
 				message: "missing key; using fallback models",
@@ -804,7 +875,7 @@ describe("extension registration and discovery", () => {
 	});
 
 	it("does not notify fallback discovery issues without UI", async () => {
-		mockedDiscover.mockImplementationOnce(async (options: DiscoverOptions) => {
+		mockedDiscover.mockImplementation(async (options: DiscoverOptions) => {
 			options?.onFallback?.({
 				reason: "empty-model-list",
 				message: "Cursor model discovery returned no models; using fallback Cursor model list.",

--- a/test/index-session-cwd-integration.test.ts
+++ b/test/index-session-cwd-integration.test.ts
@@ -100,8 +100,8 @@ describe("extension session cwd integration", () => {
 			await extensionFactory(pi);
 			await pi.runSessionStart({ cwd: sessionDir, hasUI: false });
 
-			expect(pi.registerProvider).toHaveBeenCalledOnce();
-			const streamSimple = pi._registered[0]?.config.streamSimple;
+			expect(pi.registerProvider).toHaveBeenCalledTimes(2);
+			const streamSimple = pi._registered.at(-1)?.config.streamSimple;
 			expect(streamSimple).toBe(streamCursorLazy);
 
 			await collectEvents(streamSimple!(makeModel("composer-2.5"), makeContext(), { apiKey: "test-key" }));

--- a/test/model-discovery-cache.test.ts
+++ b/test/model-discovery-cache.test.ts
@@ -18,13 +18,6 @@ import { Cursor } from "@cursor/sdk";
 
 const mockedList = vi.mocked(Cursor.models.list);
 
-function writeStoredCursorApiKey(apiKey: string): void {
-	writeFileSync(
-		join(process.env.PI_CODING_AGENT_DIR!, "auth.json"),
-		JSON.stringify({ cursor: { type: "api_key", key: apiKey } }, null, 2),
-	);
-}
-
 describe("discoverModels model-list cache", () => {
 	const originalEnv = process.env;
 	const originalArgv = process.argv;
@@ -95,33 +88,30 @@ describe("discoverModels model-list cache", () => {
 	});
 
 	it("serves a warm catalog from cache without a second network call", async () => {
-		writeStoredCursorApiKey("cache-key");
 		mockedList.mockResolvedValueOnce([MODEL]);
 
-		const first = await discoverModels();
-		const second = await discoverModels();
+		const first = await discoverModels({ apiKey: "cache-key" });
+		const second = await discoverModels({ apiKey: "cache-key" });
 
 		expect(mockedList).toHaveBeenCalledTimes(1);
 		expect(second.map((model) => model.id)).toEqual(first.map((model) => model.id));
 	});
 
 	it("bypasses the cache when forceRefresh is set", async () => {
-		writeStoredCursorApiKey("cache-key");
 		mockedList.mockResolvedValue([MODEL]);
 
-		await discoverModels();
-		await discoverModels({ forceRefresh: true });
+		await discoverModels({ apiKey: "cache-key" });
+		await discoverModels({ apiKey: "cache-key", forceRefresh: true });
 
 		expect(mockedList).toHaveBeenCalledTimes(2);
 	});
 
 	it("does not read the cache when disabled via env", async () => {
 		process.env.PI_CURSOR_SDK_DISABLE_MODEL_CACHE = "1";
-		writeStoredCursorApiKey("cache-key");
 		mockedList.mockResolvedValue([MODEL]);
 
-		await discoverModels();
-		await discoverModels();
+		await discoverModels({ apiKey: "cache-key" });
+		await discoverModels({ apiKey: "cache-key" });
 
 		expect(mockedList).toHaveBeenCalledTimes(2);
 	});
@@ -141,13 +131,12 @@ describe("discoverModels model-list cache", () => {
 	});
 
 	it("falls back to the cached catalog with a warning when a forced refresh fails", async () => {
-		writeStoredCursorApiKey("cache-key");
 		mockedList.mockResolvedValueOnce([MODEL]);
-		await discoverModels();
+		await discoverModels({ apiKey: "cache-key" });
 
 		mockedList.mockRejectedValueOnce(new Error("network down"));
 		const issues: CursorModelFallbackIssue[] = [];
-		const refreshed = await discoverModels({ forceRefresh: true, onFallback: (issue) => issues.push(issue) });
+		const refreshed = await discoverModels({ apiKey: "cache-key", forceRefresh: true, onFallback: (issue) => issues.push(issue) });
 
 		expect(refreshed.map((model) => model.id)).toEqual(["composer-2"]);
 		expect(issues).toHaveLength(1);
@@ -157,13 +146,12 @@ describe("discoverModels model-list cache", () => {
 	});
 
 	it("omits an empty cached-catalog error detail", async () => {
-		writeStoredCursorApiKey("cache-key");
 		mockedList.mockResolvedValueOnce([MODEL]);
-		await discoverModels();
+		await discoverModels({ apiKey: "cache-key" });
 
 		mockedList.mockRejectedValueOnce({});
 		const issues: CursorModelFallbackIssue[] = [];
-		await discoverModels({ forceRefresh: true, onFallback: (issue) => issues.push(issue) });
+		await discoverModels({ apiKey: "cache-key", forceRefresh: true, onFallback: (issue) => issues.push(issue) });
 
 		expect(issues).toHaveLength(1);
 		expect(issues[0].reason).toBe("cached-after-error");

--- a/test/model-discovery.test.ts
+++ b/test/model-discovery.test.ts
@@ -30,13 +30,6 @@ function register(items: ModelListItem[]) {
 	return __testUtils.registerModelItems(items);
 }
 
-function writeStoredCursorApiKey(apiKey: string): void {
-	writeFileSync(
-		join(process.env.PI_CODING_AGENT_DIR!, "auth.json"),
-		JSON.stringify({ cursor: { type: "api_key", key: apiKey } }, null, 2),
-	);
-}
-
 describe("discoverModels", () => {
 	const originalEnv = process.env;
 	const originalArgv = process.argv;
@@ -127,24 +120,7 @@ describe("discoverModels", () => {
 		expect(models.map((model) => model.id)).toEqual(["composer-2"]);
 	});
 
-	it("uses stored pi auth for model discovery when env and CLI are absent", async () => {
-		writeStoredCursorApiKey("stored-key-123");
-		mockedList.mockResolvedValueOnce([
-			{
-				id: "composer-2",
-				displayName: "Composer 2",
-				variants: [{ params: [], displayName: "Composer 2", isDefault: true }],
-			},
-		]);
-
-		const models = await discoverModels();
-
-		expect(mockedList).toHaveBeenCalledWith({ apiKey: "stored-key-123" });
-		expect(models.map((model) => model.id)).toEqual(["composer-2"]);
-	});
-
-	it("prefers stored pi auth over CURSOR_API_KEY for model discovery", async () => {
-		writeStoredCursorApiKey("stored-key-123");
+	it("prefers an explicitly supplied host key over CURSOR_API_KEY for model discovery", async () => {
 		process.env.CURSOR_API_KEY = "env-key-123";
 		mockedList.mockResolvedValueOnce([
 			{
@@ -154,18 +130,17 @@ describe("discoverModels", () => {
 			},
 		]);
 
-		await discoverModels();
+		await discoverModels({ apiKey: "host-key-123" });
 
-		expect(mockedList).toHaveBeenCalledWith({ apiKey: "stored-key-123" });
+		expect(mockedList).toHaveBeenCalledWith({ apiKey: "host-key-123" });
 	});
 
 	it.each(["CURSOR_API_KEY", "$CURSOR_API_KEY", "${CURSOR_API_KEY}", "pi-cursor-sdk-cursor-api-key-placeholder"])(
-		"treats unresolved stored %s auth as missing when env is absent",
+		"treats unresolved host %s key as missing when env is absent",
 		async (placeholder) => {
-			writeStoredCursorApiKey(placeholder);
 			const issues: CursorModelFallbackIssue[] = [];
 
-			const models = await discoverModels({ onFallback: (issue) => issues.push(issue) });
+			const models = await discoverModels({ apiKey: placeholder, onFallback: (issue) => issues.push(issue) });
 
 			expect(models.some((model) => model.id === "composer-2.5")).toBe(true);
 			expect(issues).toEqual([expect.objectContaining({ reason: "missing-api-key" })]);
@@ -175,9 +150,8 @@ describe("discoverModels", () => {
 	);
 
 	it.each(["CURSOR_API_KEY", "$CURSOR_API_KEY", "${CURSOR_API_KEY}", "pi-cursor-sdk-cursor-api-key-placeholder"])(
-		"resolves stored %s auth through the env var when present",
+		"resolves host %s key through the env var when present",
 		async (placeholder) => {
-			writeStoredCursorApiKey(placeholder);
 			process.env.CURSOR_API_KEY = "env-key-123";
 			mockedList.mockResolvedValueOnce([
 				{
@@ -187,7 +161,7 @@ describe("discoverModels", () => {
 				},
 			]);
 
-			await discoverModels();
+			await discoverModels({ apiKey: placeholder });
 
 			expect(mockedList).toHaveBeenCalledWith({ apiKey: "env-key-123" });
 		},


### PR DESCRIPTION
## Summary
- remove startup discovery's dependency on `readStoredCredential`
- resolve the Cursor provider key from the host `ModelRegistry` during `session_start`, with `CURSOR_API_KEY` retained as fallback
- re-register the discovered catalog before interactive model selection and keep fallback warnings synchronized after live refreshes
- update authentication/catalog tests and the model UX spec

## Testing
- `npm test` (126 files passed, 1412 tests passed, 2 skipped)
- `npm run typecheck`
- `npm run check:platform-smoke` (6 files passed, 81 tests passed, 1 skipped)
- `git diff --check`

Closes #214
