### PR TITLE
Fix pruned precompiled host-peer loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-provider-run-finalizer.ts` owns live-run wait completion, outcome application, debug finalization, and SDK abort-suppression disposal.
 - `src/cursor-run-final-text.ts` owns final assistant text selection for run outcomes and live-run drain.
 - `src/cursor-provider-errors.ts` owns scrubbed Cursor SDK run failure detail, abort reason formatting, and provider error sanitization.
-- `src/cursor-provider-lazy.ts` owns the lazy `streamSimple` wrapper that defers Cursor provider runtime imports until the provider is invoked.
+- `src/cursor-provider-lazy.ts` owns the `streamSimple` wrapper that defers Cursor provider execution to invocation and converts provider runtime failures into stream errors; the provider module stays in Pi's static extension graph so host peers resolve through Pi's loader.
 - `src/cursor-session-scope.ts` owns pi session cwd, session file/id/name/generation scope keys, and `session_start` / `session_info_changed` registration for session-agent pooling, cloud agent names, and debug grouping.
 - `src/cursor-session-store.ts` owns per-session Cursor SDK SQLite store identity derivation, open/disposal, temporary fileless stores, and guarded removal.
 - `src/cursor-http1.ts` owns branch-scoped local HTTP/1.1 session state, global-preference override tracking, and extension-owned SDK configuration/null reset.
@@ -43,7 +43,7 @@ This repository is a pi provider extension that registers Cursor SDK-backed mode
 - `src/cursor-sdk-event-debug.ts` owns opt-in provider event artifact capture for Cursor SDK callbacks, stream events, replay/drain/bridge decisions, final partials, and summaries under `.debug/cursor-sdk-events/`, including discarded incomplete started tool calls when `PI_CURSOR_SDK_EVENT_DEBUG=1`.
 - `shared/cursor-sdk-event-debug-env.mjs` owns canonical Cursor SDK event-debug env names; `src/cursor-sdk-event-debug-constants.ts` re-exports them and owns debug artifact base-dir resolution.
 - `src/cursor-sdk-event-debug-session.ts` owns debug session grouping, turn artifact directory allocation, and session manifest updates.
-- `src/cursor-agents-context.ts` owns Cursor-model suppression of pi `<project_context>` / `AGENTS.md` duplication and `PI_CURSOR_PRESERVE_PI_AGENTS_MD`; `src/cursor-agents-context-registration.ts` owns the lazy lifecycle registration for that suppression.
+- `src/cursor-agents-context.ts` owns Cursor-model suppression of pi `<project_context>` / `AGENTS.md` duplication and `PI_CURSOR_PRESERVE_PI_AGENTS_MD`; `src/cursor-agents-context-registration.ts` owns the static lifecycle registration for that suppression.
 - `src/cursor-sdk-output-filter.ts` suppresses Cursor SDK integrator bootstrap noise from pi's TUI.
 - `src/cursor-edit-diff.ts` owns canonical edit diff fallback resolution for replay/display paths.
 - `src/cursor-record-utils.ts` owns shared record/string-key parsing and neutral unknown-value stringification helpers used across bridge and transcript layers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.2 - 2026-08-14
+
+### Fixed
+
+- Keep every Cursor runtime subtree that imports Pi host peers in Pi's static extension graph, preventing precompiled native `import()` from bypassing Pi's peer resolver after install-time dev-dependency pruning. This restores Cursor startup, native tool registration, provider turns, session-agent lifecycle, compaction, AGENTS.md deduplication, and stored Pi credential lookup from a pruned install.
+- Retain safe lazy boundaries for the installed Cursor SDK, SQLite store, MCP bridge implementation, and generated fallback catalog, with an import-graph regression test that rejects future native dynamic imports reaching Pi host peers.
+
 ## 0.3.1 - 2026-08-14
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-cursor-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-cursor-sdk",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "bundleDependencies": [
         "@hono/node-server",
         "@modelcontextprotocol/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-cursor-sdk",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "pi provider extension backed by @cursor/sdk local and cloud agents",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",
   "license": "MIT",

--- a/src/cursor-agents-context-registration.ts
+++ b/src/cursor-agents-context-registration.ts
@@ -1,14 +1,14 @@
 import { isCursorModel } from "./cursor-model.js";
 import { registerCursorModelLifecycle, type CursorModelLifecycleExtensionApi } from "./cursor-model-lifecycle.js";
 import { resolveEffectiveCursorConfigForContext } from "./cursor-runtime-state.js";
+import { resolveCursorFacingSystemPrompt } from "./cursor-agents-context.js";
 
 export type CursorAgentsContextExtensionApi = CursorModelLifecycleExtensionApi;
 
 export function registerCursorAgentsContextDedup(pi: CursorAgentsContextExtensionApi): void {
 	registerCursorModelLifecycle(pi, {
-		beforeAgentStart: async (event, ctx) => {
+		beforeAgentStart: (event, ctx) => {
 			if (!isCursorModel(ctx.model)) return undefined;
-			const { resolveCursorFacingSystemPrompt } = await import("./cursor-agents-context.js");
 			const runtime = resolveEffectiveCursorConfigForContext(ctx).runtime.value;
 			const resolved = resolveCursorFacingSystemPrompt(
 				event.systemPrompt,

--- a/src/cursor-agents-context.ts
+++ b/src/cursor-agents-context.ts
@@ -12,8 +12,6 @@ import {
 } from "./cursor-setting-sources.js";
 import type { SettingSource } from "@cursor/sdk";
 import type { CursorRuntime } from "./cursor-config.js";
-export { registerCursorAgentsContextDedup, type CursorAgentsContextExtensionApi } from "./cursor-agents-context-registration.js";
-
 export const CURSOR_PRESERVE_PI_AGENTS_MD_ENV = "PI_CURSOR_PRESERVE_PI_AGENTS_MD";
 
 /** Opening tag prefix pi `buildSystemPrompt()` uses for each context file (path attribute only). */

--- a/src/cursor-api-key.ts
+++ b/src/cursor-api-key.ts
@@ -1,3 +1,5 @@
+import { readStoredCredential } from "@earendil-works/pi-coding-agent";
+
 export const CURSOR_API_KEY_ENV_VAR = "CURSOR_API_KEY";
 const CURSOR_PROVIDER_ID = "cursor";
 
@@ -21,9 +23,8 @@ export function resolveCursorApiKey(apiKey?: string): string | undefined {
 	return trimmed;
 }
 
-async function getStoredCursorApiKey(): Promise<string | undefined> {
+function getStoredCursorApiKey(): string | undefined {
 	try {
-		const { readStoredCredential } = await import("@earendil-works/pi-coding-agent");
 		const credential = readStoredCredential(CURSOR_PROVIDER_ID);
 		return resolveCursorApiKey(credential?.type === "api_key" ? credential.key : undefined);
 	} catch {
@@ -31,6 +32,6 @@ async function getStoredCursorApiKey(): Promise<string | undefined> {
 	}
 }
 
-export async function resolveCursorRuntimeApiKey(): Promise<string | undefined> {
-	return (await getStoredCursorApiKey()) ?? resolveCursorApiKey(process.env.CURSOR_API_KEY);
+export function resolveCursorRuntimeApiKey(): Promise<string | undefined> {
+	return Promise.resolve(getStoredCursorApiKey() ?? resolveCursorApiKey(process.env.CURSOR_API_KEY));
 }

--- a/src/cursor-native-tool-display-registration.ts
+++ b/src/cursor-native-tool-display-registration.ts
@@ -18,6 +18,7 @@ import {
 	skippedNativeToolNames,
 } from "./cursor-native-tool-display-state.js";
 import { isCursorReplayToolName } from "./cursor-tool-presentation-registry.js";
+import { registerNativeCursorTool } from "./cursor-native-tool-display-tools.js";
 
 export const CURSOR_CORE_PI_REPLAY_TOOL_NAMES = ["read", "bash", "edit", "write"] as const;
 const CORE_PI_TOOL_NAMES = new Set<string>(CURSOR_CORE_PI_REPLAY_TOOL_NAMES);
@@ -40,12 +41,11 @@ type NativeRegistrationContext = Pick<ExtensionContext, "mode" | "model"> & {
 	ui: Pick<ExtensionContext["ui"], "notify">;
 };
 
-async function registerNativeCursorToolsFromSet(
+function registerNativeCursorToolsFromSet(
 	pi: CursorNativeToolRegistryApi,
 	toolNames: readonly NativeCursorToolName[],
-): Promise<NativeCursorToolName[]> {
+): NativeCursorToolName[] {
 	const newlySkippedToolNames: NativeCursorToolName[] = [];
-	let registerNativeCursorTool: ((pi: CursorNativeToolRegistryApi, toolName: NativeCursorToolName) => void) | undefined;
 	for (const toolName of toolNames) {
 		if (registeredNativeToolNames.has(toolName) || skippedNativeToolNames.has(toolName)) continue;
 		if (hasNonBuiltinTool(pi, toolName)) {
@@ -53,7 +53,6 @@ async function registerNativeCursorToolsFromSet(
 			newlySkippedToolNames.push(toolName);
 			continue;
 		}
-		registerNativeCursorTool ??= (await import("./cursor-native-tool-display-tools.js")).registerNativeCursorTool;
 		registerNativeCursorTool(pi, toolName);
 		registeredNativeToolNames.add(toolName);
 	}
@@ -105,31 +104,31 @@ export function syncRegisteredNativeCursorToolsForModel(
 	if (changed) pi.setActiveTools([...activeToolNames]);
 }
 
-async function ensureNativeCursorToolsRegisteredForModel(pi: CursorNativeToolRegistryApi, ctx: NativeRegistrationContext): Promise<void> {
+function ensureNativeCursorToolsRegisteredForModel(pi: CursorNativeToolRegistryApi, ctx: NativeRegistrationContext): void {
 	if (!isCursorModel(ctx.model) || hasAttemptedNativeCursorToolRegistration()) return;
 
 	const nonCoreToolNames = NATIVE_CURSOR_TOOL_NAMES.filter((toolName) => !isCursorCorePiReplayToolName(toolName));
 	const skippedToolNames = [
-		...(await registerNativeCursorToolsFromSet(pi, nonCoreToolNames)),
-		...(await registerNativeCursorToolsFromSet(pi, CURSOR_CORE_PI_REPLAY_TOOL_NAMES)),
+		...registerNativeCursorToolsFromSet(pi, nonCoreToolNames),
+		...registerNativeCursorToolsFromSet(pi, CURSOR_CORE_PI_REPLAY_TOOL_NAMES),
 	];
 	notifySkippedNativeCursorToolsIfNeeded(ctx, skippedToolNames);
 }
 
-async function ensureThenSyncNativeCursorToolsForModel(pi: CursorNativeToolRegistryApi, ctx: NativeRegistrationContext): Promise<void> {
+function ensureThenSyncNativeCursorToolsForModel(pi: CursorNativeToolRegistryApi, ctx: NativeRegistrationContext): void {
 	const requested = isCursorNativeToolRegistrationRequested(ctx.mode);
 	setCursorNativeToolDisplayRuntimeRequested(requested);
 	if (!requested) {
 		removeRegisteredNonCoreNativeCursorTools(pi);
 		return;
 	}
-	await ensureNativeCursorToolsRegisteredForModel(pi, ctx);
+	ensureNativeCursorToolsRegisteredForModel(pi, ctx);
 	syncRegisteredNativeCursorToolsForModel(pi, ctx.model);
 }
 
 export function registerCursorNativeToolDisplay(pi: CursorNativeToolDisplayExtensionApi): void {
-	registerCursorModelLifecycle(pi, async (ctx) => {
-		await ensureThenSyncNativeCursorToolsForModel(pi, ctx);
+	registerCursorModelLifecycle(pi, (ctx) => {
+		ensureThenSyncNativeCursorToolsForModel(pi, ctx);
 	});
 }
 

--- a/src/cursor-provider-lazy.ts
+++ b/src/cursor-provider-lazy.ts
@@ -7,8 +7,10 @@ import {
 	type Model,
 	type SimpleStreamOptions,
 } from "@earendil-works/pi-ai";
+import { streamCursor } from "./cursor-provider.js";
+import { sanitizeCursorProviderError } from "./cursor-provider-errors.js";
 
-function makeProviderLoadErrorMessage(model: Model<Api>, error: unknown): AssistantMessage {
+function makeProviderRuntimeErrorMessage(model: Model<Api>, error: unknown, apiKey?: string): AssistantMessage {
 	return {
 		role: "assistant",
 		content: [],
@@ -25,7 +27,7 @@ function makeProviderLoadErrorMessage(model: Model<Api>, error: unknown): Assist
 		},
 		stopReason: "error",
 		timestamp: Date.now(),
-		errorMessage: `Failed to load Cursor provider runtime: ${error instanceof Error ? error.message : String(error)}`,
+		errorMessage: `Cursor provider runtime failed: ${sanitizeCursorProviderError(error, apiKey)}`,
 	};
 }
 
@@ -37,12 +39,11 @@ export function streamCursorLazy(
 	const outer = createAssistantMessageEventStream();
 	queueMicrotask(async () => {
 		try {
-			const { streamCursor } = await import("./cursor-provider.js");
 			for await (const event of streamCursor(model, context, options)) {
 				outer.push(event);
 			}
 		} catch (error) {
-			const message = makeProviderLoadErrorMessage(model, error);
+			const message = makeProviderRuntimeErrorMessage(model, error, options?.apiKey);
 			outer.push({ type: "error", reason: "error", error: message });
 			outer.end(message);
 		}

--- a/src/cursor-session-agent-lifecycle.ts
+++ b/src/cursor-session-agent-lifecycle.ts
@@ -7,6 +7,11 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import { clearCursorSdkHttp1 } from "./cursor-http1.js";
 import { onCursorSessionScopeKeyChange } from "./cursor-session-scope.js";
+import {
+	disposeSessionCursorAgent,
+	invalidateSessionAgent,
+	resetSessionCursorAgent,
+} from "./cursor-session-agent.js";
 
 export interface CursorSessionAgentLifecycleExtensionApi {
 	on(event: "session_shutdown", handler: ExtensionHandler<SessionShutdownEvent>): void;
@@ -18,11 +23,9 @@ export interface CursorSessionAgentLifecycleExtensionApi {
 
 export function registerCursorSessionAgentLifecycle(pi: CursorSessionAgentLifecycleExtensionApi): void {
 	onCursorSessionScopeKeyChange(async (previousScopeKey) => {
-		const { disposeSessionCursorAgent } = await import("./cursor-session-agent.js");
 		await disposeSessionCursorAgent(previousScopeKey);
 	});
 	pi.on("session_shutdown", async (event) => {
-		const { disposeSessionCursorAgent, resetSessionCursorAgent } = await import("./cursor-session-agent.js");
 		try {
 			if (event.reason === "reload") {
 				await resetSessionCursorAgent();
@@ -33,20 +36,16 @@ export function registerCursorSessionAgentLifecycle(pi: CursorSessionAgentLifecy
 			clearCursorSdkHttp1();
 		}
 	});
-	pi.on("session_compact", async () => {
-		const { invalidateSessionAgent } = await import("./cursor-session-agent.js");
+	pi.on("session_compact", () => {
 		invalidateSessionAgent();
 	});
-	pi.on("session_before_tree", async () => {
-		const { invalidateSessionAgent } = await import("./cursor-session-agent.js");
+	pi.on("session_before_tree", () => {
 		invalidateSessionAgent();
 	});
 	pi.on("session_tree", async () => {
-		const { resetSessionCursorAgent } = await import("./cursor-session-agent.js");
 		await resetSessionCursorAgent();
 	});
-	pi.on("model_select", async () => {
-		const { invalidateSessionAgent } = await import("./cursor-session-agent.js");
+	pi.on("model_select", () => {
 		invalidateSessionAgent();
 	});
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { registerCursorFallbackIssueWarning } from "./cursor-fallback-warning.js
 import { registerCursorAgentsContextDedup } from "./cursor-agents-context-registration.js";
 import { registerCursorOverflowNormalization } from "./cursor-provider-overflow.js";
 import { registerCursorSdkSessionProcessErrorGuard } from "./cursor-sdk-process-error-guard.js";
+import { prepareCursorSessionForCompaction } from "./cursor-session-compaction-prep.js";
 
 type CursorExtensionApi =
 	& Pick<ExtensionAPI, "registerProvider" | "registerCommand" | "on">
@@ -54,7 +55,6 @@ export default async function (pi: CursorExtensionApi) {
 	registerCursorSessionAgentLifecycle(pi);
 	registerCursorSessionAgentResume(pi);
 	pi.on("session_before_compact", async () => {
-		const { prepareCursorSessionForCompaction } = await import("./cursor-session-compaction-prep.js");
 		await prepareCursorSessionForCompaction();
 	});
 	registerCursorRuntimeControls(pi);

--- a/test/cursor-sdk-lazy-import.test.ts
+++ b/test/cursor-sdk-lazy-import.test.ts
@@ -1,6 +1,6 @@
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, relative } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import ts from "typescript";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { fingerprintApiKey, saveModelListCache } from "../src/model-list-cache.js";
@@ -22,48 +22,203 @@ function isTypeOnlyExport(node: ts.ExportDeclaration): boolean {
 	return node.isTypeOnly || Boolean(node.exportClause && ts.isNamedExports(node.exportClause) && node.exportClause.elements.every((element) => element.isTypeOnly));
 }
 
-function collectRuntimeSdkEdges(): string[] {
+const PI_HOST_PEER_ROOTS = [
+	"@earendil-works/pi-agent-core",
+	"@earendil-works/pi-ai",
+	"@earendil-works/pi-coding-agent",
+	"@earendil-works/pi-tui",
+	"@sinclair/typebox",
+	"typebox",
+] as const;
+
+function isPiHostPeer(specifier: string): boolean {
+	return PI_HOST_PEER_ROOTS.some((root) => specifier === root || specifier.startsWith(`${root}/`));
+}
+
+function importHasRuntimeBindings(node: ts.ImportDeclaration): boolean {
+	const clause = node.importClause;
+	if (!clause) return true;
+	if (clause.isTypeOnly) return false;
+	if (clause.name || !clause.namedBindings || ts.isNamespaceImport(clause.namedBindings)) return true;
+	return clause.namedBindings.elements.some((element) => !element.isTypeOnly);
+}
+
+function isCursorSdkSpecifier(specifier: string): boolean {
+	return specifier === "@cursor/sdk" || specifier.startsWith("@cursor/sdk/");
+}
+
+function isAllowedCursorSdkDynamicImport(relativePath: string, specifier: string): boolean {
+	return (
+		(relativePath.endsWith("src/cursor-sdk-runtime.ts") && specifier === "@cursor/sdk")
+		|| (relativePath.endsWith("src/cursor-session-store.ts") && specifier === "@cursor/sdk/sqlite")
+	);
+}
+
+function collectRuntimeSdkEdges(paths: string[] = sourceFiles(join(process.cwd(), "src"))): string[] {
 	const offenders: string[] = [];
-	for (const path of sourceFiles(join(process.cwd(), "src"))) {
+	for (const path of paths) {
 		const relativePath = relative(process.cwd(), path).replace(/\\/g, "/");
 		const source = ts.createSourceFile(path, readFileSync(path, "utf-8"), ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
 		const visit = (node: ts.Node): void => {
-			if (ts.isImportDeclaration(node)) {
+			if (ts.isImportDeclaration(node) && importHasRuntimeBindings(node)) {
 				const specifier = moduleText(node);
-				if (specifier === "@cursor/sdk" && !node.importClause?.isTypeOnly && !relativePath.endsWith("src/cursor-sdk-runtime.ts")) {
-					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import @cursor/sdk`);
-				}
-				if (specifier?.startsWith("@modelcontextprotocol/sdk/") && !node.importClause?.isTypeOnly && !relativePath.endsWith("src/cursor-pi-tool-bridge-run.ts")) {
+				if (specifier && isCursorSdkSpecifier(specifier)) {
 					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import ${specifier}`);
 				}
-				if (specifier === "./cursor-pi-tool-bridge-run.js" && !node.importClause?.isTypeOnly) {
+				if (specifier?.startsWith("@modelcontextprotocol/sdk/") && !relativePath.endsWith("src/cursor-pi-tool-bridge-run.ts")) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import ${specifier}`);
+				}
+				if (specifier === "./cursor-pi-tool-bridge-run.js") {
 					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime import bridge run implementation`);
 				}
 			}
-			if (ts.isExportDeclaration(node)) {
+			if (ts.isExportDeclaration(node) && !isTypeOnlyExport(node)) {
 				const specifier = moduleText(node);
-				if (specifier === "@cursor/sdk" && !isTypeOnlyExport(node)) {
-					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime export @cursor/sdk`);
+				if (specifier && isCursorSdkSpecifier(specifier)) {
+					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime export ${specifier}`);
 				}
-				if (specifier?.startsWith("@modelcontextprotocol/sdk/") && !isTypeOnlyExport(node)) {
+				if (specifier?.startsWith("@modelcontextprotocol/sdk/")) {
 					offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: runtime export ${specifier}`);
 				}
 			}
-			if (
-				ts.isCallExpression(node) &&
-				node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-				node.arguments.length === 1 &&
-				ts.isStringLiteral(node.arguments[0]) &&
-				node.arguments[0].text === "@cursor/sdk" &&
-				!relativePath.endsWith("src/cursor-sdk-runtime.ts")
-			) {
-				offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: dynamic import @cursor/sdk outside runtime loader`);
+			if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+				const argument = node.arguments[0];
+				if (argument && ts.isStringLiteralLike(argument)) {
+					const specifier = argument.text;
+					if (isCursorSdkSpecifier(specifier) && !isAllowedCursorSdkDynamicImport(relativePath, specifier)) {
+						offenders.push(`${relativePath}:${source.getLineAndCharacterOfPosition(node.getStart()).line + 1}: dynamic import ${specifier} outside runtime loader`);
+					}
+				}
 			}
 			ts.forEachChild(node, visit);
 		};
 		visit(source);
 	}
 	return offenders;
+}
+
+type RuntimeModuleInfo = {
+	path: string;
+	relativePath: string;
+	runtimeHostPeers: string[];
+	staticRelativeSpecifiers: string[];
+	dynamicImports: Array<{ line: number; specifier?: string }>;
+};
+
+function sharedRuntimeFiles(dir: string): string[] {
+	return readdirSync(dir).flatMap((entry) => {
+		const path = join(dir, entry);
+		if (statSync(path).isDirectory()) return sharedRuntimeFiles(path);
+		return path.endsWith(".mjs") ? [path] : [];
+	});
+}
+
+function runtimeModuleFiles(
+	srcDir: string = join(process.cwd(), "src"),
+	sharedDir: string = join(process.cwd(), "shared"),
+): string[] {
+	return [...sourceFiles(srcDir), ...sharedRuntimeFiles(sharedDir)];
+}
+
+function resolveSourceSpecifier(importerPath: string, specifier: string, sourcePaths: ReadonlySet<string>): string | undefined {
+	if (!specifier.startsWith(".")) return undefined;
+	const resolved = resolve(dirname(importerPath), specifier);
+	const candidates = [
+		resolved.replace(/\.(?:c|m)?js$/, ".ts"),
+		resolved,
+		`${resolved}.ts`,
+		join(resolved, "index.ts"),
+	];
+	return candidates.find((candidate) => sourcePaths.has(candidate));
+}
+
+function collectUnsafeHostPeerDynamicImports(paths: string[] = runtimeModuleFiles()): string[] {
+	const sourcePaths = new Set(paths);
+	const modules = new Map<string, RuntimeModuleInfo>();
+
+	for (const path of paths) {
+		const source = ts.createSourceFile(
+			path,
+			readFileSync(path, "utf-8"),
+			ts.ScriptTarget.Latest,
+			true,
+			path.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS,
+		);
+		const info: RuntimeModuleInfo = {
+			path,
+			relativePath: relative(process.cwd(), path).replace(/\\/g, "/"),
+			runtimeHostPeers: [],
+			staticRelativeSpecifiers: [],
+			dynamicImports: [],
+		};
+		const visit = (node: ts.Node): void => {
+			if (ts.isImportDeclaration(node) && importHasRuntimeBindings(node)) {
+				const specifier = moduleText(node);
+				if (specifier && isPiHostPeer(specifier)) info.runtimeHostPeers.push(specifier);
+				if (specifier?.startsWith(".")) info.staticRelativeSpecifiers.push(specifier);
+			}
+			if (ts.isExportDeclaration(node) && !isTypeOnlyExport(node)) {
+				const specifier = moduleText(node);
+				if (specifier && isPiHostPeer(specifier)) info.runtimeHostPeers.push(specifier);
+				if (specifier?.startsWith(".")) info.staticRelativeSpecifiers.push(specifier);
+			}
+			if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+				const argument = node.arguments[0];
+				info.dynamicImports.push({
+					line: source.getLineAndCharacterOfPosition(node.getStart()).line + 1,
+					specifier: argument && ts.isStringLiteralLike(argument) ? argument.text : undefined,
+				});
+			}
+			ts.forEachChild(node, visit);
+		};
+		visit(source);
+		modules.set(path, info);
+	}
+
+	const findHostPeer = (startPath: string): string | undefined => {
+		const pending = [startPath];
+		const visited = new Set<string>();
+		while (pending.length > 0) {
+			const path = pending.pop()!;
+			if (visited.has(path)) continue;
+			visited.add(path);
+			const info = modules.get(path);
+			if (!info) continue;
+			if (info.runtimeHostPeers.length > 0) return `${info.relativePath} -> ${info.runtimeHostPeers[0]}`;
+			for (const specifier of info.staticRelativeSpecifiers) {
+				const target = resolveSourceSpecifier(path, specifier, sourcePaths);
+				if (!target) return `${info.relativePath} -> unresolved static import ${specifier}`;
+				pending.push(target);
+			}
+		}
+		return undefined;
+	};
+
+	const offenders: string[] = [];
+	for (const info of modules.values()) {
+		for (const dynamicImport of info.dynamicImports) {
+			if (!dynamicImport.specifier) {
+				offenders.push(`${info.relativePath}:${dynamicImport.line}: non-literal dynamic import`);
+				continue;
+			}
+			if (isPiHostPeer(dynamicImport.specifier)) {
+				offenders.push(`${info.relativePath}:${dynamicImport.line}: dynamic import of host peer ${dynamicImport.specifier}`);
+				continue;
+			}
+			const target = resolveSourceSpecifier(info.path, dynamicImport.specifier, sourcePaths);
+			if (!target) {
+				if (dynamicImport.specifier.startsWith(".")) {
+					offenders.push(`${info.relativePath}:${dynamicImport.line}: unresolved relative dynamic import ${dynamicImport.specifier}`);
+				}
+				continue;
+			}
+			const hostPeer = findHostPeer(target);
+			if (hostPeer) {
+				offenders.push(`${info.relativePath}:${dynamicImport.line}: ${dynamicImport.specifier} reaches ${hostPeer}`);
+			}
+		}
+	}
+	return offenders.sort();
 }
 
 describe("Cursor SDK lazy runtime imports", () => {
@@ -80,6 +235,53 @@ describe("Cursor SDK lazy runtime imports", () => {
 
 	it("keeps heavy SDK value imports behind lazy runtime boundaries", () => {
 		expect(collectRuntimeSdkEdges()).toEqual([]);
+	});
+
+	it("rejects static SDK subpaths and template SDK imports outside the runtime loaders", () => {
+		tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-sdk-edge-"));
+		const fixturePath = join(tmpAgentDir, "sdk-edge.ts");
+		writeFileSync(fixturePath, [
+			'import { open } from "@cursor/sdk/sqlite";',
+			"void import(`@cursor/sdk/experimental`);",
+		].join("\n"));
+
+		const findings = collectRuntimeSdkEdges([fixturePath]).join("\n");
+		expect(findings).toContain("runtime import @cursor/sdk/sqlite");
+		expect(findings).toContain("dynamic import @cursor/sdk/experimental outside runtime loader");
+	});
+
+	it("keeps native dynamic imports away from Pi host-peer subtrees", () => {
+		expect(collectUnsafeHostPeerDynamicImports()).toEqual([]);
+	});
+
+	it("fails closed for host subpaths, template specifiers, nested shared modules, and unresolved edges", () => {
+		tmpAgentDir = mkdtempSync(join(tmpdir(), "pi-cursor-sdk-import-graph-"));
+		const srcDir = join(tmpAgentDir, "src");
+		const sharedDir = join(tmpAgentDir, "shared");
+		const nestedSharedDir = join(sharedDir, "nested");
+		mkdirSync(srcDir);
+		mkdirSync(nestedSharedDir, { recursive: true });
+		const entryPath = join(srcDir, "entry.ts");
+		writeFileSync(entryPath, [
+			'void import("@earendil-works/pi-ai/compat");',
+			"void import(`../shared/peer.mjs`);",
+			'void import("../shared/broken.mjs");',
+			'const computed = "./safe.js";',
+			"void import(computed);",
+			'void import("./missing.js");',
+		].join("\n"));
+		writeFileSync(join(sharedDir, "peer.mjs"), 'export { Text } from "./nested/host.mjs";\n');
+		writeFileSync(join(nestedSharedDir, "host.mjs"), 'import { Text } from "@earendil-works/pi-tui/components";\nexport { Text };\n');
+		writeFileSync(join(sharedDir, "broken.mjs"), 'export { missing } from "./missing.mjs";\n');
+
+		const findings = collectUnsafeHostPeerDynamicImports(runtimeModuleFiles(srcDir, sharedDir)).join("\n");
+		expect(findings).toContain("dynamic import of host peer @earendil-works/pi-ai/compat");
+		expect(findings).toContain("../shared/peer.mjs reaches");
+		expect(findings).toContain("@earendil-works/pi-tui/components");
+		expect(findings).toContain("../shared/broken.mjs reaches");
+		expect(findings).toContain("unresolved static import ./missing.mjs");
+		expect(findings).toContain("non-literal dynamic import");
+		expect(findings).toContain("unresolved relative dynamic import ./missing.js");
 	});
 
 	it("serves a warm model catalog without evaluating @cursor/sdk", async () => {

--- a/test/index-registration.test.ts
+++ b/test/index-registration.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { createAssistantMessageEventStream } from "@earendil-works/pi-ai";
+import { createAssistantMessageEventStream, type AssistantMessageEvent } from "@earendil-works/pi-ai";
 import {
 	createExtensionCommandContext,
 	createExtensionRegistrationPi,
@@ -251,6 +251,31 @@ describe("extension registration and discovery", () => {
 
 		await expect(resultPromise).resolves.toBe(message);
 		expect(mockedStreamCursor).toHaveBeenCalledOnce();
+	});
+
+	it("reports and scrubs synchronous Cursor provider runtime failures through the stream", async () => {
+		const apiKey = "cursor-dogfood-secret-key";
+		mockedStreamCursor.mockImplementationOnce(() => {
+			throw new Error(`synchronous provider failure: Bearer ${apiKey}`);
+		});
+		const stream = streamCursorLazy(makeModel("composer-2"), makeContext(), { apiKey });
+		const events: AssistantMessageEvent[] = [];
+		const consumeEvents = (async () => {
+			for await (const event of stream) events.push(event);
+		})();
+
+		const result = await stream.result();
+		await consumeEvents;
+
+		expect(events).toHaveLength(1);
+		const [errorEvent] = events;
+		expect(errorEvent).toMatchObject({ type: "error", reason: "error" });
+		if (errorEvent?.type !== "error") throw new Error("Expected a provider error event");
+		expect(errorEvent.error).toBe(result);
+		expect(result.stopReason).toBe("error");
+		expect(result.errorMessage).toMatch(/^Cursor provider runtime failed: /);
+		expect(result.errorMessage).toContain("[redacted]");
+		expect(result.errorMessage).not.toContain(apiKey);
 	});
 
 	it("keeps only canonical Cursor replay tools active for Cursor models", async () => {


### PR DESCRIPTION
## Summary

- move every dynamic subtree that reaches Pi host peers into the static extension graph so precompiled pruned installs use Pi's aliases
- preserve the four intentional lazy boundaries for `@cursor/sdk`, SQLite, the bridge runtime, and the generated fallback catalog
- add fail-closed AST graph regression coverage for peer subpaths, templates, computed imports, nested shared modules, and unresolved edges
- sanitize synchronous provider runtime failures before persisting them
- bump the GitHub-only patch release to 0.3.2

## Validation

- `npm run typecheck`
- focused regression suites: 122/122, plus registration suite 28/28
- default full suite: 1,421 passed; four known 5-second filesystem/git flakes passed individually
- package dry run and clean diff
- genuinely pruned worktree with no Pi host peers or dev tools: global Pi loaded `dist/index.js` and `cursor/composer-2-5:slow` returned `CURSOR_EXACT_HEAD_OK`
- Ubuntu `platform-build`: PASS (`run-1786740251442-dv6bh8`)
- Ubuntu `cursor-native-visual-matrix`: PASS (`run-1786740405311-lltm1i`)
- exact-SHA reviewer-gpt, reviewer-ponytail, reviewer-claude, and reviewer-security panel clear

Windows and macOS SSH lanes remain explicitly waived. Direct pruned macOS Pi execution passed.
