### PR TITLE
fix: isolate smoke:visual captures from host noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.3.6 - 2026-08-18
+
+### Fixed
+
+- Isolate `smoke:visual` captures from the host: pi runs with `PI_CODING_AGENT_DIR=<out-dir>/pi-agent` (seeded `auth.json`, `quietStartup`, telemetry off), `PI_OFFLINE=1`, and `PI_SKIP_VERSION_CHECK=1`, so host extensions, skills, MCP config, update banners, and package-update notices no longer pollute visual evidence.
+- Start the visual-smoke tmux session in `--cwd` with a non-login shell, eliminating `shell-init: getcwd` noise from a stale tmux-server working directory.
+- Forward `--session-id` to pi only when explicitly provided, so fresh captures no longer show the new-session warning line; the HTML render labels pi-assigned sessions instead of failing.
+
 ## 0.3.5 - 2026-08-18
 
 ### Fixed

--- a/docs/cursor-native-tool-visual-audit.md
+++ b/docs/cursor-native-tool-visual-audit.md
@@ -90,8 +90,11 @@ npx playwright install chromium
 - `PI_CURSOR_PI_TOOL_BRIDGE=0` by default
 - `PI_CURSOR_EXPOSE_BUILTIN_TOOLS=0` by default
 - Cursor SDK event-debug artifact env cleared before each run; `--event-debug` sets a deterministic debug directory under `--out-dir`
+- `PI_CODING_AGENT_DIR` isolated to `<out-dir>/pi-agent`, seeded with the host `auth.json` (0600) plus `quietStartup`/telemetry-off settings, so host extensions, skills, themes, and MCP config cannot leak into captures
+- `PI_OFFLINE=1` and `PI_SKIP_VERSION_CHECK=1`, so update banners and package-update notices cannot appear in captures
 - `TERM=xterm-256color`
-- cwd set to the target audit repo
+- cwd set to the target audit repo; the tmux session starts in `--cwd` with a non-login shell so a stale tmux-server cwd cannot print `getcwd` errors
+- `--session-id` forwarded to pi only when explicitly provided, so fresh captures avoid the new-session warning line
 - prompt paste plus carriage return into the interactive TUI
 - bounded post-prompt wait via `--wait-ms`
 - artifacts outside the repo by default

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-cursor-sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-cursor-sdk",
-      "version": "0.3.5",
+      "version": "0.3.6",
       "bundleDependencies": [
         "@hono/node-server",
         "@modelcontextprotocol/sdk"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-cursor-sdk",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "pi provider extension backed by @cursor/sdk local and cloud agents",
   "author": "Mitch Fultz (https://github.com/fitchmultz)",
   "license": "MIT",

--- a/scripts/lib/cursor-visual-render.mjs
+++ b/scripts/lib/cursor-visual-render.mjs
@@ -66,7 +66,7 @@ header code { color: #d8dee9; }
 <header>
 	<div><strong>pi-cursor-sdk visual smoke</strong> <code>${escapeHtml(options.label)}</code></div>
 	<div>model <code>${escapeHtml(options.model)}</code> · mode <code>${escapeHtml(options.mode)}</code> · cwd <code>${escapeHtml(options.cwd)}</code></div>
-	<div>session <code>${escapeHtml(options.sessionId)}</code> · captured ${new Date().toISOString()}</div>
+	<div>session <code>${escapeHtml(options.sessionId ?? "pi-assigned")}</code> · captured ${new Date().toISOString()}</div>
 </header>
 <div id="terminal"></div>
 <noscript><pre class="fallback">${escapeHtml(plain)}</pre></noscript>

--- a/scripts/visual-tui-smoke-self-test.mjs
+++ b/scripts/visual-tui-smoke-self-test.mjs
@@ -89,6 +89,9 @@ export function runVisualSmokeSelfTest(deps) {
 		assertSelfTest(defaults.get("PI_CURSOR_SETTING_SOURCES") === "none", "setting sources must default to none");
 		assertSelfTest(defaults.get("PI_CURSOR_PI_TOOL_BRIDGE") === "0", "bridge must default off");
 		assertSelfTest(defaults.get("PI_CURSOR_EXPOSE_BUILTIN_TOOLS") === "0", "built-in exposure must default off");
+		assertSelfTest(defaults.get("PI_CODING_AGENT_DIR") === join(tempDir, "pi-agent"), "agent dir must be isolated under out-dir");
+		assertSelfTest(defaults.get("PI_OFFLINE") === "1", "startup network operations must be off");
+		assertSelfTest(defaults.get("PI_SKIP_VERSION_CHECK") === "1", "pi.dev version check must be off");
 		for (const name of DEBUG_ENV_NAMES) {
 			assertSelfTest(plan.clearEnvNames.includes(name), `${name} must be cleared by default`);
 		}

--- a/scripts/visual-tui-smoke.mjs
+++ b/scripts/visual-tui-smoke.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { accessSync, constants, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { accessSync, chmodSync, constants, copyFileSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { commonBooleanFlag, commonRepeatStringFlag, parseArgv } from "./lib/cursor-cli-args.mjs";
@@ -44,7 +45,7 @@ Common options:
   --model MODEL                 Cursor model. Default: ${DEFAULT_MODEL}.
   --mode agent|plan             Cursor SDK mode. Default: ${DEFAULT_MODE}.
   --session-dir PATH            pi session directory. Default: <out-dir>/<label>.session.
-  --session-id ID               pi session id. Default: visual-<label>-<timestamp>.
+  --session-id ID               pi session id; pass to resume a prior capture session. Default: pi-assigned, so fresh captures avoid the new-session warning line.
   --width N                     PTY columns. Default: ${DEFAULT_WIDTH}.
   --height N                    PTY rows. Default: ${DEFAULT_HEIGHT}.
   --history-lines N             tmux capture history lines. Default: ${DEFAULT_HISTORY_LINES}.
@@ -63,7 +64,11 @@ Native replay isolation defaults:
   PI_CURSOR_SETTING_SOURCES=none
   PI_CURSOR_PI_TOOL_BRIDGE=0
   PI_CURSOR_EXPOSE_BUILTIN_TOOLS=0
+  PI_CODING_AGENT_DIR=<out-dir>/pi-agent  (seeded auth.json + quietStartup; host extensions stay out)
+  PI_OFFLINE=1
+  PI_SKIP_VERSION_CHECK=1
   TERM=xterm-256color
+  tmux starts in --cwd with a non-login shell so a stale tmux-server cwd cannot print getcwd errors
   Debug artifact env is cleared before each run; --event-debug sets a deterministic debug dir.
 
 Artifacts written:
@@ -194,8 +199,24 @@ function parseArgs(argv) {
 	options.safeLabel = sanitizeLabel(options.label);
 	options.outDir ??= resolve(`/tmp/pi-cursor-sdk-visual-smoke-${timestamp()}`);
 	options.sessionDir ??= resolve(options.outDir, `${options.safeLabel}.session`);
-	options.sessionId ??= `visual-${options.safeLabel}-${Date.now()}`;
+	options.agentDir ??= resolve(options.outDir, "pi-agent");
 	return options;
+}
+
+function seedVisualAgentDir(agentDir) {
+	mkdirSync(agentDir, { recursive: true });
+	const srcAuth = join(homedir(), ".pi", "agent", "auth.json");
+	const destAuth = join(agentDir, "auth.json");
+	try {
+		copyFileSync(srcAuth, destAuth);
+		chmodSync(destAuth, 0o600);
+	} catch {
+		// CURSOR_API_KEY remains the fallback when host auth.json is absent.
+	}
+	writeFileSync(
+		join(agentDir, "settings.json"),
+		`${JSON.stringify({ quietStartup: true, enableInstallTelemetry: false })}\n`,
+	);
 }
 
 function sanitizeLabel(label) {
@@ -359,7 +380,13 @@ function buildLaunchPlan(options, commands, shell) {
 		eventDebugDir: options.eventDebug ? resolve(options.outDir, `${options.safeLabel ?? "visual-smoke"}.cursor-sdk-events`) : undefined,
 	});
 	const sealedPath = commands.sealedPath ?? smokeEnvPlan.sealedPath;
-	const envAssignments = smokeEnvPlan.envEntries;
+	const agentDir = options.agentDir ?? resolve(options.outDir, "pi-agent");
+	const envAssignments = [
+		...smokeEnvPlan.envEntries,
+		["PI_CODING_AGENT_DIR", agentDir],
+		["PI_OFFLINE", "1"],
+		["PI_SKIP_VERSION_CHECK", "1"],
+	];
 	const clearEnvNames = smokeEnvPlan.clearEnvNames;
 	const command = [
 		...envAssignments.map(([name, value]) => `${name}=${shellQuote(value)}`),
@@ -370,7 +397,7 @@ function buildLaunchPlan(options, commands, shell) {
 		"--cursor-no-fast",
 		"--cursor-mode", shellQuote(options.mode),
 		"--session-dir", shellQuote(options.sessionDir),
-		"--session-id", shellQuote(options.sessionId),
+		...(options.sessionId ? ["--session-id", shellQuote(options.sessionId)] : []),
 		"--model", shellQuote(options.model),
 	].join(" ");
 	const clearLines = clearEnvNames.map((name) => `unset ${name}`).join("\n");
@@ -397,6 +424,8 @@ function runVisualSmoke(options) {
 
 	mkdirSync(options.outDir, { recursive: true });
 	mkdirSync(options.sessionDir, { recursive: true });
+	options.agentDir ??= resolve(options.outDir, "pi-agent");
+	seedVisualAgentDir(options.agentDir);
 
 	const sessionName = `pi-visual-${options.safeLabel}-${process.pid}`;
 	const bufferName = `pi-visual-prompt-${process.pid}`;
@@ -418,7 +447,22 @@ function runVisualSmoke(options) {
 	const jsonlMtimesBeforeRun = snapshotJsonlMtimes(options.sessionDir);
 	const runStartedAtMs = Date.now();
 	try {
-		const start = run(commands.tmux, ["new-session", "-d", "-s", sessionName, "-x", String(options.width), "-y", String(options.height), "--", shell, "-lc", script]);
+		const start = run(commands.tmux, [
+			"new-session",
+			"-d",
+			"-s",
+			sessionName,
+			"-c",
+			options.cwd,
+			"-x",
+			String(options.width),
+			"-y",
+			String(options.height),
+			"--",
+			shell,
+			"-c",
+			script,
+		]);
 		if (start.status !== 0) throw new Error(`tmux new-session failed: ${start.stderr?.toString().trim() || start.status}`);
 		sessionStarted = true;
 


### PR DESCRIPTION
## Summary
- Isolate `smoke:visual` pi runs: `PI_CODING_AGENT_DIR=<out-dir>/pi-agent` (seeded `auth.json` 0600, `quietStartup`, telemetry off), `PI_OFFLINE=1`, `PI_SKIP_VERSION_CHECK=1` — host extensions/skills/MCP config, update banners, and package-update notices no longer pollute captures.
- Start the tmux session in `--cwd` with a non-login shell (fixes `shell-init: getcwd` noise from a stale tmux-server cwd).
- Forward `--session-id` only when explicitly provided (kills the "No project session found" warning on fresh captures); HTML render labels pi-assigned sessions.
- Self-test pins the new isolation env; runner-contract doc updated; release 0.3.6.

## Evidence
Recaptured 3-stage grok-4.6:slow TUI evidence under `/tmp/pi-cursor-sdk-036-visual-iso/` — occupancy (3.3%/256k), `/compact` (from 8,557 tokens), post-compact (8.8%/256k matching JSONL totalTokens 22555). All screens free of host noise, warnings, and banners.

## Verification
- `npm test`: 129 files / 1452 passed / 2 skipped
- `npm run typecheck` + `typecheck:tests`: pass
- `node scripts/visual-tui-smoke.mjs --self-test`: PASS