### PR TITLE
fix: tell Cursor not to comment on GitHub issues or PRs unless asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Tell Cursor not to comment on GitHub issues or pull requests unless the user asked. Cursor otherwise treats an issue mentioned in conversation as an invitation to post a status comment on it.
+
 ## 0.3.6 - 2026-08-18
 
 ### Fixed

--- a/src/context.ts
+++ b/src/context.ts
@@ -65,6 +65,7 @@ function getCursorToolBoundaryText(
 			? "For exposed pi bridge tools, call pi__* MCP names, not pi card/history names."
 			: undefined,
 		"Do not claim pi-side or WebSearch/WebFetch tools unless Cursor ran an equivalent tool.",
+		"Do not comment on GitHub issues or PRs unless the user asked.",
 		includePiAskQuestionGuidance ? "Use pi__cursor_ask_question for material choices if exposed." : undefined,
 		getCursorPlanModeToolGuidanceText(options.agentMode, { includePiBridgeGuidance }),
 		"Images: only latest user images are sent; ask to reattach prior images.",

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -570,6 +570,7 @@ describe("buildCursorPrompt", () => {
 		expect(result.text).toContain("call pi__* MCP names");
 		expect(result.text).toContain("not pi card/history names");
 		expect(result.text).toContain("Do not claim pi-side or WebSearch/WebFetch tools");
+		expect(result.text).toContain("Do not comment on GitHub issues or PRs unless the user asked");
 		expect(result.text).toContain("Use pi__cursor_ask_question for material choices if exposed");
 		expect(result.text).toContain("prefer pi__mcp for MCP work and pi__subagent for delegation");
 		expect(result.text).not.toContain("Pi bridge contract:");


### PR DESCRIPTION
Fixes #239.

## Problem

Cursor posts status comments on GitHub issues and PRs nobody asked it to touch. Mentioning an issue number is enough to trigger it, and because `gh` runs through the normal shell tool there is no confirmation step. These are writes on repositories that are often not the user's.

## Fix

One unconditional line in the bootstrap boundary block:

```
Do not comment on GitHub issues or PRs unless the user asked.
```

Reading GitHub is untouched. Only unrequested writes are discouraged.

## Tests

`test/context.test.ts` asserts the line is present in the boundary block. `npm test`: 1452 passed, 2 skipped.

## Notes

Prompt text is not a guarantee, but it is the same lever the boundary block already uses for every other prohibition, at a cost of one line.

Touches `src/context.ts` near #241 and #242. Trivial rebase if more than one lands.

`npm run smoke:platform:all` not run; it needs the packed-install matrix across three platforms.
