### PR TITLE
Fix local usage fallback without billed rows

### DIFF
--- a/src/cursor-live-run-accounting.ts
+++ b/src/cursor-live-run-accounting.ts
@@ -7,6 +7,7 @@ export interface CursorLiveRunAccountingState {
 	promptInputTokensReported: boolean;
 	consumedToolResultIds: ReadonlySet<string>;
 	sdkTurnEnded: boolean;
+	sdkTurnUsageObserved: boolean;
 	sdkTurnUsage?: CursorSdkTurnUsage;
 }
 
@@ -23,6 +24,7 @@ export function createCursorLiveRunAccountingState(promptInputTokens: number): C
 		promptInputTokensReported: false,
 		consumedToolResultIds: new Set(),
 		sdkTurnEnded: false,
+		sdkTurnUsageObserved: false,
 	};
 }
 
@@ -30,7 +32,7 @@ export function recordCursorLiveSdkTurnEnded(
 	state: CursorLiveRunAccountingState,
 	sdkTurnUsage?: CursorSdkTurnUsage,
 ): CursorLiveRunAccountingState {
-	return { ...state, sdkTurnEnded: true, sdkTurnUsage };
+	return { ...state, sdkTurnEnded: true, sdkTurnUsageObserved: state.sdkTurnUsageObserved || sdkTurnUsage !== undefined, sdkTurnUsage };
 }
 
 export function takeCursorLiveSdkTurnUsage(state: CursorLiveRunAccountingState): {

--- a/src/cursor-live-run-coordinator.ts
+++ b/src/cursor-live-run-coordinator.ts
@@ -44,6 +44,7 @@ export interface CursorLiveRun {
 	ignoreFutureSdkTurnUsage?: boolean;
 	accounting: CursorLiveRunAccountingState;
 	billedTurnUsage?: CursorSdkTurnUsage;
+	completedRunUsage?: CursorSdkTurnUsage;
 	pendingEvents: CursorLiveQueuedEvent[];
 	textDeltas: string[];
 	emittedText: string;

--- a/src/cursor-provider-live-run-drain.ts
+++ b/src/cursor-provider-live-run-drain.ts
@@ -384,6 +384,7 @@ export async function drainCursorLiveRunTurn(
 					runtime: "local",
 					turn: cursorLiveRuns.takeSdkTurnUsage(run),
 					billed: run.billedTurnUsage,
+					completed: run.completedRunUsage,
 				});
 				if (run.resumeNotice) {
 					emitDisplayOnlyTraceBlock(stream, partial, run.resumeNotice);

--- a/src/cursor-provider-run-finalizer.ts
+++ b/src/cursor-provider-run-finalizer.ts
@@ -187,6 +187,7 @@ export class CursorRunFinalizer {
 					runtime: prepared.runtimeTarget,
 					turn: prepared.runtime.turnCoordinator.lastSdkTurnUsage,
 					billed: prepared.runtime.billedTurnUsage,
+					completed: prepared.runtime.completedRunUsage,
 				});
 				if (prepared.meta.resumeNotice) emitDisplayOnlyTraceBlock(stream, partial, prepared.meta.resumeNotice);
 				if (displayOnlyTraceBlock) emitDisplayOnlyTraceBlock(stream, partial, displayOnlyTraceBlock);

--- a/src/cursor-provider-turn-finalize.ts
+++ b/src/cursor-provider-turn-finalize.ts
@@ -17,7 +17,7 @@ import {
 } from "./cursor-provider-run-outcome.js";
 import type { CursorProviderTurnPrepareResult } from "./cursor-provider-turn-types.js";
 import { loadCursorSdk } from "./cursor-sdk-runtime.js";
-import { attachCursorSdkBilledTurnUsage } from "./cursor-sdk-billed-usage.js";
+import { attachCursorSdkBilledTurnUsage, resolveCursorSdkCompletedRunUsage } from "./cursor-sdk-billed-usage.js";
 
 export async function cacheSdkContextWindow(
 	agentId: string,
@@ -156,9 +156,20 @@ export async function awaitFinalizeCursorRunOutcome(params: AwaitFinalizeCursorR
 		runtime: params.prepared.runtimeTarget,
 		runId: params.run.id,
 	});
+	const completedRunUsage = resolveCursorSdkCompletedRunUsage({
+		runtime: params.prepared.runtimeTarget,
+		billedUsageAvailable: billed.turn !== undefined,
+		turnUsageObserved:
+			params.prepared.runtime.turnCoordinator.lastSdkTurnUsage !== undefined ||
+			params.prepared.runtime.liveRun?.accounting.sdkTurnUsageObserved,
+		waitResultUsage: waitResult.usage,
+		runUsage: params.run.usage,
+	});
 	params.prepared.runtime.billedTurnUsage = billed.turn;
+	params.prepared.runtime.completedRunUsage = completedRunUsage;
 	if (params.prepared.runtime.liveRun) {
 		params.prepared.runtime.liveRun.billedTurnUsage = billed.turn;
+		params.prepared.runtime.liveRun.completedRunUsage = completedRunUsage;
 	}
 	let displayOnlyTraceBlock: string | undefined;
 	if (params.prepared.runtimeTarget === "cloud" && isCursorRunFinishedSuccessfully(outcome)) {

--- a/src/cursor-provider-turn-types.ts
+++ b/src/cursor-provider-turn-types.ts
@@ -46,6 +46,7 @@ export interface CursorProviderTurnSendMeta {
 interface CursorProviderTurnRuntimeBase {
 	turnCoordinator: CursorSdkTurnCoordinator;
 	billedTurnUsage?: CursorSdkTurnUsage;
+	completedRunUsage?: CursorSdkTurnUsage;
 }
 
 /**

--- a/src/cursor-sdk-billed-usage.ts
+++ b/src/cursor-sdk-billed-usage.ts
@@ -68,6 +68,17 @@ export function selectCursorBilledTurnUsage(
 	return { turn: sumCursorSdkTurnUsage(unseen.map((run) => run.usage)), runIds: unseen.map((run) => run.runId) };
 }
 
+export function resolveCursorSdkCompletedRunUsage(options: {
+	runtime: CursorRuntime;
+	billedUsageAvailable?: boolean;
+	turnUsageObserved?: boolean;
+	waitResultUsage?: unknown;
+	runUsage?: unknown;
+}): CursorSdkTurnUsage | undefined {
+	if (options.runtime !== "local" || options.billedUsageAvailable || options.turnUsageObserved) return undefined;
+	return readCursorSdkTurnUsage(options.waitResultUsage) ?? readCursorSdkTurnUsage(options.runUsage);
+}
+
 export async function fetchCursorSdkAgentUsage(
 	agent: SDKAgent,
 	options: { runtime: CursorRuntime; runId?: string },

--- a/src/cursor-usage-accounting.ts
+++ b/src/cursor-usage-accounting.ts
@@ -113,6 +113,7 @@ export interface CursorSdkUsageApplyOptions {
 	runtime: CursorRuntime;
 	turn?: CursorSdkTurnUsage;
 	billed?: CursorSdkTurnUsage;
+	completed?: CursorSdkTurnUsage;
 }
 
 export function applyCursorSdkUsage(partial: AssistantMessage, turnUsage: CursorSdkTurnUsage): void {
@@ -208,10 +209,10 @@ export function applyCursorUsage(
 	sessionInputTokens: number,
 	sdkUsage?: CursorSdkUsageApplyOptions,
 ): void {
-	const billed = sdkUsage?.billed;
+	const spend = sdkUsage?.billed ?? sdkUsage?.completed;
 	const localTurn = sdkUsage?.runtime === "local" ? sdkUsage.turn : undefined;
-	if (billed && isCursorSdkUsagePartitionSafe(billed, model)) {
-		applyCursorSdkUsage(partial, billed);
+	if (spend && isCursorSdkUsagePartitionSafe(spend, model)) {
+		applyCursorSdkUsage(partial, spend);
 		applyResolvedCursorOccupancy(partial, model, context, localTurn);
 		return;
 	}

--- a/test/cursor-live-run-accounting.test.ts
+++ b/test/cursor-live-run-accounting.test.ts
@@ -75,6 +75,7 @@ describe("cursor live-run accounting", () => {
 
 		expect(first.sdkTurnUsage).toEqual({ inputTokens: 25_432, outputTokens: 612, cacheReadTokens: 24_000, cacheWriteTokens: 123 });
 		expect(second.sdkTurnUsage).toBeUndefined();
+		expect(second.state.sdkTurnUsageObserved).toBe(true);
 	});
 
 	it("ignores nonmatching tool results without consuming them", () => {

--- a/test/cursor-provider-replay-live-run.test.ts
+++ b/test/cursor-provider-replay-live-run.test.ts
@@ -46,7 +46,7 @@ import { join } from "node:path";
 describe("streamCursor native replay live run", () => {
 	beforeEach(resetCursorProviderTestState);
 
-	it("uses bounded approximate usage on the final native replay stop turn when no turn-ended usage arrives", async () => {
+	it("uses completed run spend with bounded occupancy when no turn-ended usage arrives", async () => {
 		process.env.PI_CURSOR_NATIVE_TOOL_DISPLAY = "1";
 		const registeredTools: RegisteredTool[] = [];
 		await registerNativeToolDisplayForTest(registeredTools);
@@ -132,9 +132,10 @@ describe("streamCursor native replay live run", () => {
 
 		expect(replayDone.reason).toBe("stop");
 		expect(collectTextDeltas(replayEvents)).toBe("Final answer only.");
-		expect(replayDone.message.usage.cacheRead).toBe(0);
-		expect(replayDone.message.usage.cacheWrite).toBe(0);
-		expect(replayDone.message.usage.input).toBeLessThan(500);
+		expect(replayDone.message.usage.cacheRead).toBe(400);
+		expect(replayDone.message.usage.cacheWrite).toBe(10);
+		expect(replayDone.message.usage.input).toBe(90);
+		expect(replayDone.message.usage.output).toBe(50);
 		expect(replayDone.message.usage.totalTokens).toBeLessThan(500);
 	});
 

--- a/test/cursor-provider-stream-usage.test.ts
+++ b/test/cursor-provider-stream-usage.test.ts
@@ -15,7 +15,7 @@ import { streamCursor } from "../src/cursor-provider.js";
 describe("streamCursor usage accounting", () => {
 	beforeEach(resetCursorProviderTestState);
 
-	it("ignores returned RunResult usage when no turn-ended usage was applied", async () => {
+	it("uses returned local RunResult usage for spend when no turn-ended usage was applied", async () => {
 		const mockSend = vi.fn().mockResolvedValue(asMockCursorRun({
 			id: "run-1",
 			agentId: "agent-1",
@@ -42,9 +42,10 @@ describe("streamCursor usage accounting", () => {
 		const events = await collectEvents(stream);
 		const done = getDoneEvent(events);
 
-		expect(done.message.usage.cacheRead).toBe(0);
+		expect(done.message.usage.cacheRead).toBe(1_015_493);
 		expect(done.message.usage.cacheWrite).toBe(0);
-		expect(done.message.usage.input).toBeLessThan(1_125_429);
+		expect(done.message.usage.input).toBe(1_125_429 - 1_015_493);
+		expect(done.message.usage.output).toBe(7_049);
 		expect(done.message.usage.totalTokens).toBeLessThan(1_125_429);
 	});
 

--- a/test/cursor-provider-turn-finalize.test.ts
+++ b/test/cursor-provider-turn-finalize.test.ts
@@ -50,6 +50,16 @@ function makeCloudPrepared(agent: SDKAgent): CursorProviderTurnPrepareResult {
 	} as unknown as CursorProviderTurnPrepareResult;
 }
 
+function makeLocalPrepared(agent: SDKAgent): CursorProviderTurnPrepareResult {
+	return {
+		...makeCloudPrepared(agent),
+		runtimeTarget: "local",
+		sessionAgentScopeKey: "test-session",
+		sessionAgentLease: { store: {} },
+		localForce: { value: false, source: "default" },
+	} as unknown as CursorProviderTurnPrepareResult;
+}
+
 describe("awaitFinalizeCursorRunOutcome", () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
@@ -187,6 +197,44 @@ describe("awaitFinalizeCursorRunOutcome", () => {
 
 		expect(finalized.outcome.kind).toBe("finished");
 		expect(pi.appendEntry).toHaveBeenCalledTimes(1);
+	});
+
+	it("uses completed local run usage when getUsage has no billed run row", async () => {
+		const usage = {
+			inputTokens: 25_432,
+			outputTokens: 612,
+			cacheReadTokens: 24_000,
+			cacheWriteTokens: 123,
+			totalTokens: 50_167,
+		};
+		const agent = {
+			agentId: "agent-local",
+			getUsage: vi.fn().mockResolvedValue({ usage, runs: [] }),
+		} as unknown as SDKAgent;
+		const prepared = makeLocalPrepared(agent);
+
+		const finalized = await awaitFinalizeCursorRunOutcome({
+			run: {
+				id: "run-local",
+				agentId: "agent-local",
+				usage,
+				wait: vi.fn(),
+			} as unknown as Awaited<ReturnType<SDKAgent["send"]>>,
+			prepared,
+			cursorAgentMessageOffset: undefined,
+			modelId: "composer-2.5",
+			waitResult: { id: "run-local", status: "finished", result: "done", usage },
+			cacheContextWindow: false,
+		});
+
+		expect(finalized.outcome.kind).toBe("finished");
+		expect(prepared.runtime.billedTurnUsage).toBeUndefined();
+		expect(prepared.runtime.completedRunUsage).toEqual({
+			inputTokens: 25_432,
+			outputTokens: 612,
+			cacheReadTokens: 24_000,
+			cacheWriteTokens: 123,
+		});
 	});
 });
 

--- a/test/cursor-sdk-billed-usage.test.ts
+++ b/test/cursor-sdk-billed-usage.test.ts
@@ -5,6 +5,7 @@ import {
 	attachCursorSdkBilledTurnUsage,
 	fetchCursorSdkAgentUsage,
 	isCursorSdkClientMintedRunId,
+	resolveCursorSdkCompletedRunUsage,
 	selectCursorBilledTurnUsage,
 	sumCursorSdkTurnUsage,
 } from "../src/cursor-sdk-billed-usage.js";
@@ -42,6 +43,40 @@ describe("cursor billed usage selection", () => {
 			turn: turnB,
 			runIds: ["usage-b"],
 		});
+	});
+
+	it("falls back to completed local run usage when no billed row is available", () => {
+		expect(resolveCursorSdkCompletedRunUsage({
+			runtime: "local",
+			waitResultUsage: turnA,
+			runUsage: turnB,
+		})).toEqual(turnA);
+		expect(resolveCursorSdkCompletedRunUsage({
+			runtime: "local",
+			runUsage: turnB,
+		})).toEqual(turnB);
+	});
+
+	it("does not fall back when billed usage is available or for cloud runs", () => {
+		expect(resolveCursorSdkCompletedRunUsage({
+			runtime: "local",
+			billedUsageAvailable: true,
+			waitResultUsage: turnB,
+		})).toBeUndefined();
+		expect(resolveCursorSdkCompletedRunUsage({
+			runtime: "cloud",
+			waitResultUsage: turnA,
+			runUsage: turnB,
+		})).toBeUndefined();
+	});
+
+	it("does not duplicate completed run usage when turn-ended usage was already observed", () => {
+		expect(resolveCursorSdkCompletedRunUsage({
+			runtime: "local",
+			turnUsageObserved: true,
+			waitResultUsage: turnA,
+			runUsage: turnB,
+		})).toBeUndefined();
 	});
 
 	it("does not pass a local client-minted runId into getUsage", async () => {


### PR DESCRIPTION
## Summary

- preserve completed local run token usage when `Agent.getUsage()` has no billed UUID row
- keep billed usage authoritative and keep completed-run spend separate from context occupancy
- avoid double-counting completed run usage after split turns already received `turn-ended` usage

Closes #245

## Test plan

- [x] `npm run typecheck`
- [x] focused usage suite: 51 tests passed
- [x] full suite: 1453 passed, 2 skipped; two unrelated test files failed (`cloud-smoke-helpers` signal exit-code expectation and default 5s timeouts in `cursor-cloud-local-state`)
- [x] `cursor-cloud-local-state` passes independently with `--testTimeout=15000`

Made with [Cursor](https://cursor.com)